### PR TITLE
Fix Array.iter[i]2 signatures to allow environment mutation.

### DIFF
--- a/src/stdlib/array.hli
+++ b/src/stdlib/array.hli
@@ -245,11 +245,11 @@ val foldi2: ''a $t -> ''b $t -> init:''accum
 (** Create an accumulated result for the paired elements of two arrays, calling
     the indexed element folding function in increasing index order. *)
 
-val iter2: ''a $t -> ''b $t -> f:(''a -> ''b -> unit) -> unit
+val iter2: ''a $t -> ''b $t -> f:(''a -> ''b !-> unit) !-> unit
 (** Iterate over the paired elements of two arrays, calling the element visiting
     function in increasing index order. *)
 
-val iteri2: ''a $t -> ''b $t -> f:(usize -> ''a -> ''b -> unit) -> unit
+val iteri2: ''a $t -> ''b $t -> f:(usize -> ''a -> ''b !-> unit) !-> unit
 (** Iterate over the paired elements of two arrays, calling the indexed element
     visiting function in increasing index order. *)
 


### PR DESCRIPTION
For most Array functions, environment mutation is both unnecessary and
undesirable.  The plain iteration functions are an exception, since they have
no way of getting work done besides mutating the environment.