### PR TITLE
Fix hlc compilation.

### DIFF
--- a/bootstrap/bin/hlc.ml
+++ b/bootstrap/bin/hlc.ml
@@ -1,9 +1,11 @@
 open Hemlock
 include Hemlock.Rudiments
 
-type 'a v = 'a array
-
 let _ =
-  let x:(int v) = Array.of_list [1; 2; 3] in
-  Printf.printf "Array.length x -> %d\n" (Usize.to_int (Array.length x));
-  1
+  let open Format in
+  let x = Array.of_list [1; 2; 3] in
+  printf "@[<h>";
+  printf "Array.length %a -> %a\n"
+    (Array.pp Usize.pp) x
+    Usize.pp (Array.length x);
+  printf "@]"


### PR DESCRIPTION
Fix hlc.ml to fully adopt uint-to-usize renaming and related API changes.  Also
clean up the code to match its current minimal intent of verifying that an
executable can compile and execute using the bootstrap library code.

This regression was introduced by dfdaa2384213394ea3818e717c0f9e5d3eacd85d
(Rename uint/int to usize/isize, and make usize the default integer type.).