### PR TITLE
Create github action to run tests on pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on: pull_request
+
+jobs:
+  run:
+    name: Test
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{matrix.platform}}
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/cache@v1
+      id: cache-opam
+      with:
+        path: ~/.opam
+        key: ${{ runner.os }}-opam-${{ hashFiles('**/*.opam') }}
+    - name: opam
+      uses: avsm/setup-ocaml@master
+      with:
+        ocaml-version: '4.09.0'
+    - name: deps
+      if: steps.cache-opam.outputs.cache-hit != 'true'
+      working-directory: ./bootstrap
+      run: opam install -t . --deps-only
+    - name: build
+      working-directory: ./bootstrap
+      run: opam exec -- dune build
+    - name: test
+      working-directory: ./bootstrap
+      run: opam exec -- dune runtest


### PR DESCRIPTION
resolve #35 

The initial version includes a caching mechanism. It caches everything in the ~/.opam directory after the first successful run. The key is hashed based on the OS name and the contents of any *.opam file in our repo. If a new PR is opened and no *.opam file changes were made in the PR, the CI reloads the cached data in ~/.opam and avoids building it from scratch.

Note that there are two sections of the CI that benefit from the caching.
- 'opam' - This section always runs, but if we successfully reloaded from cache, the underlying action's download manager is smart enough to skip downloading cached dependencies. This action does some other useful things for us, like setting up our opam environment.
- 'init' - Here we would call opam init on a cache miss, but on a hit, all the dependencies exist in the ~/.opam directory. It's okay to completely skip this on a hit.

Time w/o cache: ~15min
Time with cache: ~1.5min