### PR TITLE
Fix bug in check_ocp_indent.py

### DIFF
--- a/.github/scripts/check_ocp_indent.py
+++ b/.github/scripts/check_ocp_indent.py
@@ -56,7 +56,7 @@ class Hunk:
 
     # "git diff -U0" has the following predictable pattern for hunk headers. It shows exactly where
     # a change starts and if any additional lines were changed after that, how many.
-    _header_pattern: Pattern = re.compile(r'^@@.*\+(?P<start>\d+)(,(?P<delta>\d+))? @@.*$')
+    _header_pattern: Pattern = re.compile(r'^@@.*\+(?P<start>\d+)(,(?P<delta>[1-9]\d*))? @@.*$')
 
     @staticmethod
     async def from_path(path: Path, /) -> Tuple[Hunk]:

--- a/.ocp-indent
+++ b/.ocp-indent
@@ -1,0 +1,3 @@
+align_ops=false
+align_params=never
+max_indent=2


### PR DESCRIPTION
Fixes these two bad behaviors discovered in check_ocp_indent.py.

1. Hunks that were entirely deleted were incorrectly detected as a
single line addition by the script's hunk header pattern match. This
caused weird indentation in places where blocks of code were deleted.

2. The script did not have an ocp-indend config that matched developer
configurations. The addition of the .ocp-indent file will cause
ocp-indent to use the correct configuration if it is run anywhere within
this repo. It is not in REPO_ROOT/boostrap since it is also relevant for
scripts in REPO_ROOT/.github/scripts.