### PR TITLE
Implement {Ordmap,Map,Ordset,Set}.{subset,disjoint} .

### DIFF
--- a/bootstrap/src/basis/map_intf.ml
+++ b/bootstrap/src/basis/map_intf.ml
@@ -133,9 +133,19 @@ module type S = sig
 
   val equal: ('v -> 'v -> bool) -> ('k, 'v, 'cmp) t -> ('k, 'v, 'cmp) t -> bool
   (** [equal veq t0 t1] returns [true] if [t0] and [t1] contain identical key
-      sets and identical key-value mappings as determined by [t]'s key
-      comparator and the [veq] value comparison function, [false] otherwise.
-      O(n) time complexity. *)
+      sets and identical key-value mappings as determined by the key comparator
+      and the [veq] value comparison function, [false] otherwise.  O(n) time
+      complexity. *)
+
+  val subset: ('v -> 'v -> bool) -> ('k, 'v, 'cmp) t -> ('k, 'v, 'cmp) t -> bool
+  (** [subset veq t0 t1] returns [true] if all key-value mappings in [t1] are
+      also in [t0], as determined by the key comparator and the [veq] value
+      comparison function, [false] otherwise.  O(n) time complexity. *)
+
+  val disjoint: ('k, 'v, 'cmp) t -> ('k, 'v, 'cmp) t -> bool
+  (** [disjoint t0 t1] returns [true] if [t0] and [t1] contain disjoint key sets
+      as determined by the key comparator, [false] otherwise.  O(n) time
+      complexity. *)
 
   val union: f:('k -> 'v -> 'v -> 'v) -> ('k, 'v, 'cmp) t -> ('k, 'v, 'cmp) t
     -> ('k, 'v, 'cmp) t

--- a/bootstrap/src/basis/set_intf.ml
+++ b/bootstrap/src/basis/set_intf.ml
@@ -74,6 +74,14 @@ module type S = sig
   (** [equal t0 t1] returns [true] if [t0] and [t1] contain identical sets of
       elements, [false] otherwise.  O(n) time complexity. *)
 
+  val subset: ('a, 'cmp) t -> ('a, 'cmp) t -> bool
+  (** [subset t0 t1] returns [true] if all elements in [t1] are also in [t0],
+      [false] otherwise.  O(n) time complexity. *)
+
+  val disjoint: ('a, 'cmp) t -> ('a, 'cmp) t -> bool
+  (** [disjoint t0 t1] returns [true] if [t0] and [t1] contain disjoint sets of
+      elements, [false] otherwise.  O(n) time complexity. *)
+
   val union: ('a, 'cmp) t -> ('a, 'cmp) t -> ('a, 'cmp) t
   (** [union t0 t1] creates a set that is the union of [t0] and [t1]; that is,
       a set that contains all elements in [t0] or [t1].  O(m lg (n/m + 1)) time


### PR DESCRIPTION
These functions aren't overly important for maps, but they should definitely be provided for sets.