### PR TITLE
Add choose[_hlt] to maps and sets.

### DIFF
--- a/bootstrap/src/basis/map_intf.ml
+++ b/bootstrap/src/basis/map_intf.ml
@@ -84,6 +84,14 @@ module type S = sig
       key in [t], halts otherwise.  O(lg n) time complexity if ordered, O(1)
       time complexity if unordered. *)
 
+  val choose: ('k, 'v, 'cmp) t -> ('k * 'v) option
+  (** [choose t] returns an arbitrary key-value mapping in [t] if the map is
+      non-empty, [None] otherwise. *)
+
+  val choose_hlt: ('k, 'v, 'cmp) t -> ('k * 'v)
+  (** [choose_hlt t] returns an arbitrary key-value mapping in [t] if the map is
+      non-empty, halts otherwise. *)
+
   val insert: k:'k -> v:'v -> ('k, 'v, 'cmp) t -> ('k, 'v, 'cmp) t
   (** [insert ~k ~v t] returns an incremental derivative of [t] with [k] bound
       to [v] if [k] is not a key in [t], [t] otherwise.  O(lg n) time complexity

--- a/bootstrap/src/basis/set.ml
+++ b/bootstrap/src/basis/set.ml
@@ -19,6 +19,15 @@ let is_empty = Map.is_empty
 
 let mem = Map.mem
 
+let choose t =
+  match Map.choose t with
+  | Some (k, _) -> Some k
+  | None -> None
+
+let choose_hlt t =
+  let k, _ = Map.choose_hlt t in
+  k
+
 let insert a t =
   Map.insert ~k:a ~v:() t
 
@@ -326,6 +335,28 @@ let%expect_test "of_list,to_list,to_array" =
     of_list [0; 1; 2]; to_list -> [0; 1; 2]; to_array -> [|0; 1; 2|]
     of_list [0; 1; 66]; to_list -> [0; 1; 66]; to_array -> [|0; 1; 66|]
     of_list [0; 1; 66; 91]; to_list -> [0; 1; 66; 91]; to_array -> [|0; 1; 66; 91|]
+    |}]
+
+let%expect_test "choose_hlt" =
+  let open Format in
+  printf "@[";
+  (* test is n^2 time complexity, so keep n small. *)
+  let rec test n i set = begin
+    match i < n with
+    | false -> set
+    | true -> begin
+        let set' = test n (succ i) (insert i set) in
+        let m = choose_hlt set' in
+        let set'' = remove m set' in
+        assert ((length set') = (length set'') + 1);
+        set''
+      end
+  end in
+  let e = empty (module Usize) in
+  let _ = test 100 0 e in
+  printf "@]";
+
+  [%expect{|
     |}]
 
 let%expect_test "fold_until" =

--- a/bootstrap/src/basis/set_intf.ml
+++ b/bootstrap/src/basis/set_intf.ml
@@ -58,6 +58,14 @@ module type S = sig
   (** [mem a t] returns [true] if [a] is a member of [t]; [false] otherwise.
       O(lg n) time complexity if ordered, O(1) time complexity if unordered. *)
 
+  val choose: ('a, 'cmp) t -> 'a option
+  (** [choose t] returns an arbitrary member of [t] if the set is non-empty,
+      [None] otherwise. *)
+
+  val choose_hlt: ('a, 'cmp) t -> 'a
+  (** [choose_hlt t] returns an arbitrary member of [t] if the set is non-empty,
+      halts otherwise. *)
+
   val insert: 'a -> ('a, 'cmp) t -> ('a, 'cmp) t
   (** [insert elm t] returns a set that is equivalent to the union of a
       singleton set containing [elm] with [t].  O(lg n) time complexity if


### PR DESCRIPTION
I didn't plan on adding these, but discovered while writing 'remove' benchmarks that there was no straightforward way to choose an arbitrary element of an unordered  map/set.  For ordered maps/sets we have `nth`, but the best we can do for unordered maps/sets absent `choose` is to `fold_until` and terminate after the first iteration.