### PR TITLE
Reduce size of Text.Cursor.t .

### DIFF
--- a/bootstrap/src/basis/bytes.ml
+++ b/bootstrap/src/basis/bytes.ml
@@ -187,6 +187,9 @@ module Slice = struct
   let length t =
     (Cursor.index (past t)) - (Cursor.index (base t))
 
+  let get i t =
+    Array.get (Cursor.index (base t) + i) (container t)
+
   let pp ppf t =
     let open Format in
     fprintf ppf "@[<h>[|";
@@ -252,6 +255,9 @@ let hash_fold t state =
 
 let length t =
   Slice.(length (of_container t))
+
+let get i t =
+  Slice.(get i (of_container t))
 
 let of_codepoint cp =
   Slice.(to_container (of_codepoint cp))

--- a/bootstrap/src/basis/bytes.mli
+++ b/bootstrap/src/basis/bytes.mli
@@ -23,7 +23,10 @@ module Slice : sig
       the resulting state. *)
 
   val length: t -> uns
-  (* [length t] returns the length of [t] in bytes. *)
+  (** [length t] returns the length of [t] in bytes. *)
+
+  val get: uns -> t -> byte
+  (** [get i t] returns the byte at index [i] within [t]. *)
 
   val of_codepoint: codepoint -> t
   (** [of_codepoint codepoint] creates a slice of bytes corresponding to the
@@ -55,6 +58,9 @@ val hash_fold: t -> Hash.State.t -> Hash.State.t
 
 val length: t -> uns
 (* [length t] returns the length of [t] in bytes. *)
+
+val get: uns -> t -> byte
+(** [get i t] returns the byte at index [i] within [t]. *)
 
 val of_codepoint: codepoint -> t
 (** [of_codepoint codepoint] creates an array of bytes corresponding to the


### PR DESCRIPTION
Add Excerpt.Cursor.t which is a flat wrapper around Bytes.Cursor.t to remove
duplicate references to the containing excerpt in Text.Cursor.t .