### PR TITLE
Enable multi-platform Docker build.

### DIFF
--- a/.docker-compose.yml
+++ b/.docker-compose.yml
@@ -4,6 +4,7 @@ services:
     build:
       args:
         - HEMLOCK_BOOTSTRAP_OCAML_VERSION
+        - HEMLOCK_PLATFORM
       context: .
       dockerfile: .dockerfile
       target: prod

--- a/.dockerfile
+++ b/.dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu AS base
+ARG HEMLOCK_PLATFORM=$BUILDPLATFORM
+FROM --platform=${HEMLOCK_PLATFORM} ubuntu AS base
 RUN --mount=type=cache,target=/var/cache/apt \
     --mount=type=cache,target=/var/lib/apt \
     rm /etc/apt/apt.conf.d/docker-clean \
@@ -15,7 +16,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     && echo "hemlock ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 CMD [ "/bin/bash" ]
 
-FROM base AS prod
+FROM --platform=${HEMLOCK_PLATFORM} base AS prod
 ARG HEMLOCK_BOOTSTRAP_OCAML_VERSION
 USER hemlock
 WORKDIR /home/hemlock
@@ -38,7 +39,7 @@ RUN --mount=type=cache,target=/home/hemlock/.opam/download-cache,uid=1000,gid=10
     && opam install -y --deps-only . \
     && rm Hemlock.opam
 
-FROM base AS dev
+FROM --platform=${HEMLOCK_PLATFORM} base AS dev
 USER root
 RUN --mount=type=cache,target=/var/cache/apt \
     --mount=type=cache,target=/var/lib/apt \

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ Run a Hemlock `prod` docker container.
 docker compose run prod
 ```
 
+(Optional) Install
+[binfmt_misc](https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images). This
+enables building and running cross-platform images.
+```sh
+docker run --privileged --rm tonistiigi/binfmt --install all
+HEMLOCK_PLATFORM=linux/arm64 docker compose build prod
+HEMLOCK_PLATFORM=linux/arm64 docker compose run prod
+```
+
 ##### (Optional) Building Dotfiles Into `dev` Image
 
 Set a `DOTFILES_URL` environment variable to include your dotfiles in the Hemlock `dev` image.


### PR DESCRIPTION
This enables us to manually set the target platform for our image using the HEMLOCK_PLATFORM
environment variable. There are less-verbose ways of plumbing the target platform through, such as
using the `platform: ` key in docker-compose.yml. However, by doing it in here, the default value
for HEMLOCK_PLATFORM is set equal to the docker buildx BUILDPLATFORM environment variable, which
matches the builder's host platform. That means that in the cases where we connect a remote builder
(AWS Graviton, for instance), the default target platform will match that of the builder and not of
the local host where the CLI commands are invoked.