### PR TITLE
Rename 'master' branch to 'main'.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{matrix.platform}}
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@main
     - uses: actions/cache@v2
       id: cache-opam
       with:
@@ -36,6 +36,6 @@ jobs:
       with:
         python-version: '3.8'
     - name: check-ocp-indent deps
-      run: opam install ocp-indent && git fetch origin master
+      run: opam install ocp-indent && git fetch origin main
     - name: check-ocp-indent
       run: python ./.github/scripts/check_ocp_indent.py

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ setup script like so.
 ```sh
 pushd $YOUR_DOTFILES_PATH > /dev/null
 export DOTFILES_URL=$(git remote get-url origin 2> /dev/null || :)
-export DOTFILES_HASH=$(git rev-parse origin/master 2> /dev/null || :)
+export DOTFILES_HASH=$(git rev-parse origin/main 2> /dev/null || :)
 popd > /dev/null
 ```
 


### PR DESCRIPTION
Default branch naming inconsistency among repos is starting to chafe.

CI is going to fail for this commit, since the branch rename cannot be done as part of the commit itself.