### PR TITLE
Remove .merlin file.

### DIFF
--- a/bootstrap/.merlin
+++ b/bootstrap/.merlin
@@ -1,4 +1,0 @@
-S bin/**
-S src/**
-
-B _build/**


### PR DESCRIPTION
Merlin configuration has been auto-generated by dune for several releases, and
the presence of a .merlin file prevents proper function of ocaml-lsp.