### PR TITLE
Fix missing '\0' termination in deflate_bytes().

### DIFF
--- a/bootstrap/src/basis/file.c
+++ b/bootstrap/src/basis/file.c
@@ -28,6 +28,9 @@ deflate_bytes(size_t n, size_t * inflated_bytes) {
     for (size_t i = 0; i < n; i++) {
         deflated_bytes[i] = Int_val(inflated_bytes[i]);
     }
+    if (n > 0) {
+        deflated_bytes[n] = '\0';
+    }
     return deflated_bytes;
 }
 


### PR DESCRIPTION
Fixes #129

Manual test with the following at the command line.
```
dune exec hmc /home/hemlock/Hemlock/src/Basis/Array.hm
```
Before the change, this results in the output
```
Halt: File.of_path error: No such file or directory
```
Array.hm clearly exists at this location in the Hemlock image, so this was a bug.

After the changes in this PR, the result is that the test print the expected `hmc` output.

`deflate_bytes()` is only used to prepare a `Bytes.t` to be used with a system call. A `Bytes.t` in
memory actually uses 32 bits per byte, so a `Bytes.t` with the value `"path"` might look like
```
? ? ? p ? ? ? a ? ? ? t ? ? ? h
```
After `deflate_bytes()`, it looks like
```
p a t h ? ? ? a ? ? ? t ? ? ? h
```
To be safe with a system call, it needs to be null-terminated.
```
p a t h\0 ? ? a ? ? ? t ? ? ? h
```

The `deflate_bytes()` conterpart, `inflate_bytes()` does not have a similar bug.