### PR TITLE
Consolidate radix/base types into `Radix` module

### DIFF
--- a/bootstrap/src/basis/bytes.ml
+++ b/bootstrap/src/basis/bytes.ml
@@ -190,7 +190,7 @@ module Slice = struct
 
   let pp t formatter =
     let slice = Array.Slice.init ~range:(range t) (container t) in
-    Array.Slice.fmt (Byte.fmt ~alt:true ~base:Fmt.Hex ~pretty:true) slice formatter
+    Array.Slice.fmt (Byte.fmt ~alt:true ~radix:Radix.Hex ~pretty:true) slice formatter
 
   let hash_fold t state =
     Hash.State.Gen.init state

--- a/bootstrap/src/basis/fmt.ml
+++ b/bootstrap/src/basis/fmt.ml
@@ -22,12 +22,6 @@ type sign =
   | Explicit
   | Space
 
-type base =
-  | Bin
-  | Oct
-  | Dec
-  | Hex
-
 type pmode =
   | Limited
   | Fixed
@@ -52,7 +46,7 @@ let precision_dec_m_default = 15L
 let precision_dec_a_default = 3L
 let precision_hex_m_default = 13L
 let precision_hex_a_default = 14L
-let base_default = Dec
+let radix_default = Radix0.Dec
 let notation_default = Compact
 let pretty_default = false
 
@@ -109,15 +103,6 @@ let pp_sign sign formatter =
     | Implicit -> "Implicit"
     | Explicit -> "Explicit"
     | Space -> "Space"
-  )
-
-let pp_base base formatter =
-  formatter |> fmt (
-    match base with
-    | Bin -> "Bin"
-    | Oct -> "Oct"
-    | Dec -> "Dec"
-    | Hex -> "Hex"
   )
 
 let pp_pmode pmode formatter =

--- a/bootstrap/src/basis/fmt.mli
+++ b/bootstrap/src/basis/fmt.mli
@@ -42,15 +42,6 @@ type sign =
 val pp_sign: sign -> (module Formatter) -> (module Formatter)
 (** [pp_sign sign] formats a syntactically valid representation of [sign]. *)
 
-type base =
-  | Bin (** Binary base (2). *)
-  | Oct (** Octal base (8). *)
-  | Dec (** Decimal base (10). *)
-  | Hex (** Hexadecimal base (16). *)
-
-val pp_base: base -> (module Formatter) -> (module Formatter)
-(** [pp_base base] formats a syntactically valid representation of [base]. *)
-
 type pmode =
   | Limited (** Limited precision, i.e. trailing zeros omitted. *)
   | Fixed   (** Fixed precision, i.e. trailing zeros as needed. *)
@@ -113,8 +104,8 @@ val precision_hex_m_default: int64
 val precision_hex_a_default: int64
 (** Default digits of [RadixPoint] precision to right of hexadecimal radix point ([14]). *)
 
-val base_default: base
-(** Default numerical base ([Dec]). *)
+val radix_default: Radix0.t
+(** Default numerical radix ([Dec]). *)
 
 val notation_default: notation
 (** Default notation ([Compact]). *)

--- a/bootstrap/src/basis/intnb.ml
+++ b/bootstrap/src/basis/intnb.ml
@@ -176,7 +176,7 @@ module MakeCommon (T : ICommon) : SCommon with type t := uns = struct
       narrow (Int64.of_string s)
 
     let to_string ?(sign=Fmt.sign_default) ?(alt=Fmt.alt_default) ?(zpad=Fmt.zpad_default)
-      ?(width=Fmt.width_default) ?(base=Fmt.base_default) ?(pretty=Fmt.pretty_default) t =
+      ?(width=Fmt.width_default) ?(radix=Fmt.radix_default) ?(pretty=Fmt.pretty_default) t =
       assert Stdlib.(Int64.(compare (narrow t) t) = 0);
       let rec fn accum ndigits is_neg t = begin
         match Stdlib.(Int64.(unsigned_compare t 0L) = 0)
@@ -190,7 +190,7 @@ module MakeCommon (T : ICommon) : SCommon with type t := uns = struct
             )
             ^ (match alt with
               | true -> begin
-                  match base with
+                  match radix with
                   | Bin -> "0b"
                   | Oct -> "0o"
                   | Dec -> ""
@@ -206,7 +206,7 @@ module MakeCommon (T : ICommon) : SCommon with type t := uns = struct
             )
           end
         | _ -> begin
-            let divisor, group = match base with
+            let divisor, group = match radix with
               | Bin -> 2L, 8
               | Oct -> 8L, 3
               | Dec -> 10L, 3
@@ -226,8 +226,8 @@ module MakeCommon (T : ICommon) : SCommon with type t := uns = struct
       | false -> fn [] 0 false t
       | true -> fn [] 0 true (Stdlib.Int64.neg t)
 
-    let fmt ?pad ?just ?sign ?alt ?zpad ?width ?base ?pretty t formatter =
-      Fmt.fmt ?pad ?just ?width (to_string ?sign ?alt ?zpad ?width ?base ?pretty t) formatter
+    let fmt ?pad ?just ?sign ?alt ?zpad ?width ?radix ?pretty t formatter =
+      Fmt.fmt ?pad ?just ?width (to_string ?sign ?alt ?zpad ?width ?radix ?pretty t) formatter
 
     let pp t formatter =
       fmt ~alt:true ~pretty:true t formatter
@@ -389,11 +389,11 @@ module MakeI (T : I) : SI with type t := sint = struct
     let of_string s =
       sint_of_uns (V.of_string s)
 
-    let to_string ?sign ?alt ?zpad ?width ?base ?pretty t =
-      V.to_string ?sign ?alt ?zpad ?width ?base ?pretty (uns_of_sint t)
+    let to_string ?sign ?alt ?zpad ?width ?radix ?pretty t =
+      V.to_string ?sign ?alt ?zpad ?width ?radix ?pretty (uns_of_sint t)
 
-    let fmt ?pad ?just ?sign ?alt ?zpad ?width ?base ?pretty t formatter =
-      V.fmt ?pad ?just ?sign ?alt ?zpad ?width ?base ?pretty (uns_of_sint t) formatter
+    let fmt ?pad ?just ?sign ?alt ?zpad ?width ?radix ?pretty t formatter =
+      V.fmt ?pad ?just ?sign ?alt ?zpad ?width ?radix ?pretty (uns_of_sint t) formatter
 
     let pp t formatter =
       fmt ~alt:true ~pretty:true t formatter

--- a/bootstrap/src/basis/intnbIntf.ml
+++ b/bootstrap/src/basis/intnbIntf.ml
@@ -80,17 +80,17 @@ module type SLimitless = sig
   include CmpableIntf.SMonoZero with type t := t
   include RealableIntf.S with type t := t
 
-  val to_string: ?sign:Fmt.sign -> ?alt:bool -> ?zpad:bool -> ?width:uns -> ?base:Fmt.base
+  val to_string: ?sign:Fmt.sign -> ?alt:bool -> ?zpad:bool -> ?width:uns -> ?radix:Radix.t
     -> ?pretty:bool -> t -> string
-  (** [to_string ~sign ~alt ~zpad ~width ~base ~pretty t] creates a base-[~base] representation of
+  (** [to_string ~sign ~alt ~zpad ~width ~radix ~pretty t] creates a base-[~radix] representation of
       [t] with [~sign]-controlled sign representation, [~zpad]-controlled zero padding to [~width]
-      digits, [~alt]-controlled alternate formatting (base prefix and digits grouped via '_'), and
+      digits, [~alt]-controlled alternate formatting (radix prefix and digits grouped via '_'), and
       [~pretty]-controlled type suffix. *)
 
   val fmt: ?pad:string -> ?just:Fmt.just -> ?sign:Fmt.sign -> ?alt:bool -> ?zpad:bool -> ?width:uns
-    -> ?base:Fmt.base -> ?pretty:bool -> t -> (module Fmt.Formatter) -> (module Fmt.Formatter)
-  (** [fmt ~pad ~just ~sign ~alt ~zpad ~width ~base ~pretty t formatter] calls [formatter.fmt ~pad
-      ~just ~width] on the result of [to_string ~sign ~alt ~zpad ~width ~base ~pretty t]. *)
+    -> ?radix:Radix.t -> ?pretty:bool -> t -> (module Fmt.Formatter) -> (module Fmt.Formatter)
+  (** [fmt ~pad ~just ~sign ~alt ~zpad ~width ~radix ~pretty t formatter] calls [formatter.fmt ~pad
+      ~just ~width] on the result of [to_string ~sign ~alt ~zpad ~width ~radix ~pretty t]. *)
 
   val one: t
   (** Constant value 1. *)

--- a/bootstrap/src/basis/intw.ml
+++ b/bootstrap/src/basis/intw.ml
@@ -588,7 +588,7 @@ module MakeVCommon (T : IVCommon) : SVCommon with type t := T.t = struct
       prefix0 s 0L (Int64.of_int (Stdlib.String.length s))
 
     let to_string ?(sign=Fmt.sign_default) ?(alt=Fmt.alt_default) ?(zpad=Fmt.zpad_default)
-      ?(width=Fmt.width_default) ?(base=Fmt.base_default) ?(pretty=Fmt.pretty_default) t =
+      ?(width=Fmt.width_default) ?(radix=Fmt.radix_default) ?(pretty=Fmt.pretty_default) t =
       let rec fn accum ndigits is_neg t = begin
         match t = zero && (not zpad || (ndigits >= (Int64.to_int width))) with
         | true -> begin
@@ -600,7 +600,7 @@ module MakeVCommon (T : IVCommon) : SVCommon with type t := T.t = struct
             )
             ^ (match alt with
               | true -> begin
-                  match base with
+                  match radix with
                   | Bin -> "0b"
                   | Oct -> "0o"
                   | Dec -> ""
@@ -622,7 +622,7 @@ module MakeVCommon (T : IVCommon) : SVCommon with type t := T.t = struct
             )
           end
         | _ -> begin
-            let divisor, group = match base with
+            let divisor, group = match radix with
               | Bin -> of_uns 2L, 8
               | Oct -> of_uns 8L, 3
               | Dec -> of_uns 10L, 3
@@ -645,8 +645,8 @@ module MakeVCommon (T : IVCommon) : SVCommon with type t := T.t = struct
       | false -> fn [] 0 false t
       | true -> fn [] 0 true (neg t)
 
-    let fmt ?pad ?just ?sign ?alt ?zpad ?width ?base ?pretty t formatter =
-      Fmt.fmt ?pad ?just ?width (to_string ?sign ?alt ?zpad ?width ?base ?pretty t) formatter
+    let fmt ?pad ?just ?sign ?alt ?zpad ?width ?radix ?pretty t formatter =
+      Fmt.fmt ?pad ?just ?width (to_string ?sign ?alt ?zpad ?width ?radix ?pretty t) formatter
 
     let pp t formatter =
       fmt ~alt:true ~pretty:true t formatter

--- a/bootstrap/src/basis/map.ml
+++ b/bootstrap/src/basis/map.ml
@@ -967,10 +967,10 @@ let fmt ?(alt=Fmt.alt_default) ?(width=Fmt.width_default) fmt_v t formatter =
     let width' = width + indent in
     formatter
     |> Fmt.fmt "present_kv="
-    |> Bitset.fmt ~alt:true ~base:Fmt.Hex node.present_kv
+    |> Bitset.fmt ~alt:true ~radix:Radix.Hex node.present_kv
     |> fmt_sep ~alt ~width
     |> Fmt.fmt "present_child="
-    |> Bitset.fmt ~alt:true ~base:Fmt.Hex node.present_child
+    |> Bitset.fmt ~alt:true ~radix:Radix.Hex node.present_child
     |> fmt_sep ~alt ~width
     |> Fmt.fmt "elms_kv="
     |> (Array.fmt ~alt ~width fmt_kv) node.elms_kv

--- a/bootstrap/src/basis/radix.ml
+++ b/bootstrap/src/basis/radix.ml
@@ -1,0 +1,16 @@
+include Radix0
+
+let pp t formatter =
+  formatter |> Fmt.fmt (
+    match t with
+    | Bin -> "Bin"
+    | Oct -> "Oct"
+    | Dec -> "Dec"
+    | Hex -> "Hex"
+  )
+
+let to_uns = function
+  | Bin -> 2L
+  | Oct -> 8L
+  | Dec -> 10L
+  | Hex -> 16L

--- a/bootstrap/src/basis/radix.mli
+++ b/bootstrap/src/basis/radix.mli
@@ -1,0 +1,10 @@
+(** Radix (base) type. *)
+
+open RudimentsInt0
+
+include (module type of Radix0)
+
+include FormattableIntf.SMono with type t := t
+
+val to_uns: t -> uns
+(** [to_uns t] returns [2], [8], [10], or [16]. *)

--- a/bootstrap/src/basis/radix0.ml
+++ b/bootstrap/src/basis/radix0.ml
@@ -1,0 +1,5 @@
+type t =
+  | Bin (** Binary (base 2). *)
+  | Oct (** Octal (base 8). *)
+  | Dec (** Decimal (base 10). *)
+  | Hex (** Hexadecimal (base 16). *)

--- a/bootstrap/src/basis/real.mli
+++ b/bootstrap/src/basis/real.mli
@@ -8,19 +8,19 @@ include IdentifiableIntf.S with type t := t
 include StringableIntf.S with type t := t
 
 val to_string: ?sign:Fmt.sign -> ?alt:bool -> ?zpad:bool -> ?width:uns -> ?pmode:Fmt.pmode
-  -> ?precision:uns -> ?notation:Fmt.notation -> ?base:Fmt.base -> t -> string
-(** [to_string ~sign ~alt ~zpad ~width ~pmode ~precision ~notation ~base t] creates a base-[~base]
+  -> ?precision:uns -> ?notation:Fmt.notation -> ?radix:Radix.t -> t -> string
+(** [to_string ~sign ~alt ~zpad ~width ~pmode ~precision ~notation ~radix t] creates a base-[~radix]
     representation of [t] with [~sign]-controlled sign representation, [~zpad]-controlled zero
     padding to [~width] digits and [~pmode]-controlled [~precision] digits past the radix point in
-    the specified [~notation], and [~alt]-controlled alternate formatting (base prefix and digits
+    the specified [~notation], and [~alt]-controlled alternate formatting (radix prefix and digits
     grouped via '_'). *)
 
 val fmt: ?pad:string -> ?just:Fmt.just -> ?sign:Fmt.sign -> ?alt:bool -> ?zpad:bool -> ?width:uns
-  -> ?pmode:Fmt.pmode -> ?precision:uns -> ?notation:Fmt.notation -> ?base:Fmt.base -> t
+  -> ?pmode:Fmt.pmode -> ?precision:uns -> ?notation:Fmt.notation -> ?radix:Radix.t -> t
   -> (module Fmt.Formatter) -> (module Fmt.Formatter)
-(** [fmt ~pad ~just ~sign ~alt ~zpad ~width ~pmode ~precision ~notation ~base t formatter] calls
+(** [fmt ~pad ~just ~sign ~alt ~zpad ~width ~pmode ~precision ~notation ~radix t formatter] calls
     [formatter.fmt ~pad ~just ~width] on the result of [to_string ~sign ~alt ~zpad ~width ~pmode
-    ~precision ~notation ~base t]. *)
+    ~precision ~notation ~radix t]. *)
 
 (** Rounding direction. *)
 module Dir : sig

--- a/bootstrap/src/basis/sint.ml
+++ b/bootstrap/src/basis/sint.ml
@@ -22,7 +22,7 @@ module T = struct
     let one = Int64.one
 
     let to_string ?(sign=Fmt.sign_default) ?(alt=Fmt.alt_default) ?(zpad=Fmt.zpad_default)
-      ?(width=Fmt.width_default) ?(base=Fmt.base_default) ?(pretty=Fmt.pretty_default) t =
+      ?(width=Fmt.width_default) ?(radix=Fmt.radix_default) ?(pretty=Fmt.pretty_default) t =
       let rec fn accum ndigits is_neg t = begin
         match Stdlib.(Int64.(unsigned_compare t 0L) = 0)
               && Stdlib.(not zpad || (ndigits >= (Int64.to_int width))) with
@@ -35,7 +35,7 @@ module T = struct
             )
             ^ (match alt with
               | true -> begin
-                  match base with
+                  match radix with
                   | Bin -> "0b"
                   | Oct -> "0o"
                   | Dec -> ""
@@ -47,7 +47,7 @@ module T = struct
             ^ (match pretty with false -> "" | true -> "i")
           end
         | _ -> begin
-            let divisor, group = match base with
+            let divisor, group = match radix with
               | Bin -> 2L, 8
               | Oct -> 8L, 3
               | Dec -> 10L, 3
@@ -67,8 +67,8 @@ module T = struct
       | false -> fn [] 0 false t
       | true -> fn [] 0 true (Int64.neg t)
 
-    let fmt ?pad ?just ?sign ?alt ?zpad ?width ?base ?pretty t formatter =
-      Fmt.fmt ?pad ?just ?width (to_string ?sign ?alt ?zpad ?width ?base ?pretty t) formatter
+    let fmt ?pad ?just ?sign ?alt ?zpad ?width ?radix ?pretty t formatter =
+      Fmt.fmt ?pad ?just ?width (to_string ?sign ?alt ?zpad ?width ?radix ?pretty t) formatter
 
     let pp t formatter =
       fmt ~alt:true ~pretty:true t formatter

--- a/bootstrap/src/basis/string.ml
+++ b/bootstrap/src/basis/string.ml
@@ -1872,7 +1872,7 @@ let to_string ?(alt=Fmt.alt_default) ?(pretty=Fmt.pretty_default) s =
             | Some _ -> fn h_hd (C.Cursor.succ h_right) s
           end in
           let h =
-            Hash.State.empty |> hash_fold s |> Hash.t_of_state |> U128.to_string ~base:Fmt.Hex in
+            Hash.State.empty |> hash_fold s |> Hash.t_of_state |> U128.to_string ~radix:Radix.Hex in
           let h_hd = C.Cursor.hd h in
           fn h_hd h_hd s
         end

--- a/bootstrap/src/basis/uns.ml
+++ b/bootstrap/src/basis/uns.ml
@@ -22,7 +22,7 @@ module T = struct
     let one = Int64.one
 
     let to_string ?(sign=Fmt.sign_default) ?(alt=Fmt.alt_default) ?(zpad=Fmt.zpad_default)
-      ?(width=Fmt.width_default) ?(base=Fmt.base_default) ?(pretty=Fmt.pretty_default) t =
+      ?(width=Fmt.width_default) ?(radix=Fmt.radix_default) ?(pretty=Fmt.pretty_default) t =
       let rec fn accum ndigits t = begin
         match Stdlib.(Int64.(unsigned_compare t 0L) = 0)
               && Stdlib.(not zpad || (ndigits >= (Int64.to_int width))) with
@@ -30,7 +30,7 @@ module T = struct
             (match sign with Implicit -> "" | Explicit -> "+" | Space -> " ")
             ^ (match alt with
               | true -> begin
-                  match base with
+                  match radix with
                   | Bin -> "0b"
                   | Oct -> "0o"
                   | Dec -> ""
@@ -42,7 +42,7 @@ module T = struct
             ^ (match pretty with false -> "" | true -> "u")
           end
         | _ -> begin
-            let divisor, group = match base with
+            let divisor, group = match radix with
               | Bin -> 2L, 8
               | Oct -> 8L, 3
               | Dec -> 10L, 3
@@ -60,8 +60,8 @@ module T = struct
       end in
       fn [] 0 t
 
-    let fmt ?pad ?just ?sign ?alt ?zpad ?width ?base ?pretty t formatter =
-      Fmt.fmt ?pad ?just ?width (to_string ?sign ?alt ?zpad ?width ?base ?pretty t) formatter
+    let fmt ?pad ?just ?sign ?alt ?zpad ?width ?radix ?pretty t formatter =
+      Fmt.fmt ?pad ?just ?width (to_string ?sign ?alt ?zpad ?width ?radix ?pretty t) formatter
 
     let pp t formatter =
       fmt ~alt:true t formatter

--- a/bootstrap/src/hmc/realer.ml
+++ b/bootstrap/src/hmc/realer.ml
@@ -190,7 +190,7 @@ module T = struct
           let frac' = Nat.bit_sr ~shift:4L frac in
           formatter
           |> pp_frac (pred hex_digits) frac';
-          |> Uns.fmt ~base:Fmt.Hex int64_digit
+          |> Uns.fmt ~radix:Radix.Hex int64_digit
         end
     end in
     match t with

--- a/bootstrap/test/basis/codepoint/test_conversion.ml
+++ b/bootstrap/test/basis/codepoint/test_conversion.ml
@@ -3,7 +3,7 @@ open! Basis
 open Codepoint
 
 let pp_uns_x u formatter =
-  formatter |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex u
+  formatter |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex u
 
 let pp_x cp formatter =
   formatter |> pp_uns_x (extend_to_uns cp)

--- a/bootstrap/test/basis/codepoint/test_fmt.ml
+++ b/bootstrap/test/basis/codepoint/test_fmt.ml
@@ -9,7 +9,7 @@ let test () =
     | _ -> begin
         let cp = trunc_of_uns i in
         File.Fmt.stdout
-        |> Uns.fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex i
+        |> Uns.fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex i
         |> Fmt.fmt " -> "
         |> pp cp
         |> Fmt.fmt " "

--- a/bootstrap/test/basis/codepoint/test_hash_fold.ml
+++ b/bootstrap/test/basis/codepoint/test_hash_fold.ml
@@ -9,7 +9,7 @@ let test () =
     | cp :: cps' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> (Uns.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex) (extend_to_uns cp)
+        |> (Uns.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex) (extend_to_uns cp)
         |> Fmt.fmt " -> "
         |> Hash.pp (Hash.t_of_state (hash_fold cp Hash.State.empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/codepoint/test_rel.ml
+++ b/bootstrap/test/basis/codepoint/test_rel.ml
@@ -3,7 +3,7 @@ open! Basis
 open Codepoint
 
 let pp_uns_x u formatter =
-  formatter |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex u
+  formatter |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex u
 
 let pp_x cp formatter =
   formatter |> pp_uns_x (extend_to_uns cp)

--- a/bootstrap/test/basis/codepoint/test_to_string_escape.ml
+++ b/bootstrap/test/basis/codepoint/test_to_string_escape.ml
@@ -3,7 +3,7 @@ open! Basis
 open Codepoint
 
 let pp_uns_x u formatter =
-  formatter |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex u
+  formatter |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex u
 
 let pp_x cp formatter =
   formatter |> pp_uns_x (extend_to_uns cp)

--- a/bootstrap/test/basis/codepoint/test_utf8.ml
+++ b/bootstrap/test/basis/codepoint/test_utf8.ml
@@ -3,7 +3,7 @@ open! Basis
 open Codepoint
 
 let pp_uns_x u formatter =
-  formatter |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex u
+  formatter |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex u
 
 let pp_x cp formatter =
   formatter |> pp_uns_x (extend_to_uns cp)
@@ -23,7 +23,7 @@ let test () =
         |> Fmt.fmt ", codepoint'="
         |> pp_x codepoint'
         |> Fmt.fmt ", bytes="
-        |> List.pp (Byte.fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true) bytes
+        |> List.pp (Byte.fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true) bytes
         |> Fmt.fmt ", length="
         |> Uns.pp length
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/convert/test_nbI.ml
+++ b/bootstrap/test/basis/convert/test_nbI.ml
@@ -10,7 +10,7 @@ let test () =
         |> Fmt.fmt "extend_to_uns "
         |> I16.pp i
         |> Fmt.fmt " -> "
-        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex (I16.extend_to_uns i)
+        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex (I16.extend_to_uns i)
         |> Fmt.fmt "\n"
       )
   )

--- a/bootstrap/test/basis/convert/test_nbI_nbU.ml
+++ b/bootstrap/test/basis/convert/test_nbI_nbU.ml
@@ -20,9 +20,9 @@ let test () =
       kv 65535L; kv 65536L; kv 131071L]) ~init:formatter ~f:(fun formatter u ->
       formatter
       |> Fmt.fmt "trunc_of_u32/narrow_of_u32_opt "
-      |> U32.fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true u
+      |> U32.fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true u
       |> Fmt.fmt " -> "
-      |> I16.fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (I16.trunc_of_u32 u)
+      |> I16.fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (I16.trunc_of_u32 u)
       |> Fmt.fmt "/"
       |> (Option.fmt I16.pp) (I16.narrow_of_u32_opt u)
       |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/convert/test_nbI_wN.ml
+++ b/bootstrap/test/basis/convert/test_nbI_wN.ml
@@ -22,7 +22,7 @@ let test () =
       |> Fmt.fmt "trunc_of_nat/narrow_of_nat_opt "
       |> Nat.pp u
       |> Fmt.fmt " -> "
-      |> I16.fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (I16.trunc_of_nat u)
+      |> I16.fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (I16.trunc_of_nat u)
       |> Fmt.fmt "/"
       |> (Option.fmt I16.pp) (I16.narrow_of_nat_opt u)
       |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/convert/test_nbI_wU.ml
+++ b/bootstrap/test/basis/convert/test_nbI_wU.ml
@@ -22,7 +22,7 @@ let test () =
       |> Fmt.fmt "trunc_of_u512/narrow_of_u512_opt "
       |> U512.pp u
       |> Fmt.fmt " -> "
-      |> I16.fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (I16.trunc_of_u512 u)
+      |> I16.fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (I16.trunc_of_u512 u)
       |> Fmt.fmt "/"
       |> (Option.fmt I16.pp) (I16.narrow_of_u512_opt u)
       |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/convert/test_wI_wN.ml
+++ b/bootstrap/test/basis/convert/test_wI_wN.ml
@@ -10,9 +10,9 @@ let test () =
       ~f:(fun formatter i ->
         formatter
         |> Fmt.fmt "widen_to_nat_opt "
-        |> I128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true i
+        |> I128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> "
-        |> (Option.fmt (Nat.fmt ~alt:true ~base:Fmt.Hex ~pretty:true)) (I128.widen_to_nat_opt i)
+        |> (Option.fmt (Nat.fmt ~alt:true ~radix:Radix.Hex ~pretty:true)) (I128.widen_to_nat_opt i)
         |> Fmt.fmt "\n"
       )
   )
@@ -27,11 +27,11 @@ let test () =
       ~f:(fun formatter u ->
         formatter
         |> Fmt.fmt "trunc_of_nat/narrow_of_nat_opt "
-        |> Nat.fmt ~alt:true ~base:Fmt.Hex ~pretty:true u
+        |> Nat.fmt ~alt:true ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
-        |> I128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (I128.trunc_of_nat u)
+        |> I128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (I128.trunc_of_nat u)
         |> Fmt.fmt "/"
-        |> (Option.fmt (I128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true)) (I128.narrow_of_nat_opt u)
+        |> (Option.fmt (I128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true)) (I128.narrow_of_nat_opt u)
         |> Fmt.fmt "\n"
       )
   )

--- a/bootstrap/test/basis/convert/test_wI_wU.ml
+++ b/bootstrap/test/basis/convert/test_wI_wU.ml
@@ -10,9 +10,9 @@ let test () =
       ~f:(fun formatter i ->
         formatter
         |> Fmt.fmt "widen_to_u512_opt "
-        |> I128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true i
+        |> I128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> "
-        |> (Option.fmt (U512.fmt ~alt:true ~base:Fmt.Hex ~pretty:true)) (I128.widen_to_u512_opt i)
+        |> (Option.fmt (U512.fmt ~alt:true ~radix:Radix.Hex ~pretty:true)) (I128.widen_to_u512_opt i)
         |> Fmt.fmt "\n"
       )
   )
@@ -27,11 +27,11 @@ let test () =
       ~f:(fun formatter u ->
         formatter
         |> Fmt.fmt "trunc_of_u512/narrow_of_u512_opt "
-        |> U512.fmt ~alt:true ~base:Fmt.Hex ~pretty:true u
+        |> U512.fmt ~alt:true ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
-        |> I128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (I128.trunc_of_u512 u)
+        |> I128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (I128.trunc_of_u512 u)
         |> Fmt.fmt "/"
-        |> (Option.fmt (I128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true)) (I128.narrow_of_u512_opt u)
+        |> (Option.fmt (I128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true)) (I128.narrow_of_u512_opt u)
         |> Fmt.fmt "\n"
       )
   )

--- a/bootstrap/test/basis/convert/test_wI_wX.ml
+++ b/bootstrap/test/basis/convert/test_wI_wX.ml
@@ -9,9 +9,9 @@ let test () =
       ~init:formatter ~f:(fun formatter i ->
       formatter
       |> Fmt.fmt "extend_to_i512 "
-      |> I128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true i
+      |> I128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true i
       |> Fmt.fmt " -> "
-      |> I512.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (I128.extend_to_i512 i)
+      |> I512.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (I128.extend_to_i512 i)
       |> Fmt.fmt "\n"
     )
   )
@@ -26,9 +26,9 @@ let test () =
       ~f:(fun formatter i ->
         formatter
         |> Fmt.fmt "trunc_of_i512/narrow_of_i512_opt "
-        |> I512.fmt ~alt:true ~base:Fmt.Hex ~pretty:true i
+        |> I512.fmt ~alt:true ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> "
-        |> I128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (I128.trunc_of_i512 i)
+        |> I128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (I128.trunc_of_i512 i)
         |> Fmt.fmt "/"
         |> (Option.fmt I128.pp) (I128.narrow_of_i512_opt i)
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/convert/test_wI_wZ.ml
+++ b/bootstrap/test/basis/convert/test_wI_wZ.ml
@@ -9,9 +9,9 @@ let test () =
       ~init:formatter ~f:(fun formatter i ->
       formatter
       |> Fmt.fmt "extend_to_zint "
-      |> I128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true i
+      |> I128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true i
       |> Fmt.fmt " -> "
-      |> Zint.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (I128.extend_to_zint i)
+      |> Zint.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (I128.extend_to_zint i)
       |> Fmt.fmt "\n"
     )
   )
@@ -26,9 +26,9 @@ let test () =
       ~f:(fun formatter i ->
         formatter
         |> Fmt.fmt "trunc_of_zint/narrow_of_zint_opt "
-        |> Zint.fmt ~alt:true ~base:Fmt.Hex ~pretty:true i
+        |> Zint.fmt ~alt:true ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> "
-        |> I128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (I128.trunc_of_zint i)
+        |> I128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (I128.trunc_of_zint i)
         |> Fmt.fmt "/"
         |> (Option.fmt I128.pp) (I128.narrow_of_zint_opt i)
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/convert/test_wU_wI.ml
+++ b/bootstrap/test/basis/convert/test_wU_wI.ml
@@ -10,11 +10,11 @@ let test () =
       ~f:(fun formatter u ->
         formatter
         |> Fmt.fmt "bits_to_i128/like_to_i128_opt "
-        |> U128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true u
+        |> U128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
-        |> I128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (U128.bits_to_i128 u)
+        |> I128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (U128.bits_to_i128 u)
         |> Fmt.fmt "/"
-        |> (Option.fmt (I128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true)) (U128.like_to_i128_opt u)
+        |> (Option.fmt (I128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true)) (U128.like_to_i128_opt u)
         |> Fmt.fmt "\n"
       )
   )
@@ -24,9 +24,9 @@ let test () =
       ~f:(fun formatter i ->
         formatter
         |> Fmt.fmt "bits_of_i128/like_of_i128_opt "
-        |> I128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true i
+        |> I128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> "
-        |> U128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (U128.bits_of_i128 i)
+        |> U128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (U128.bits_of_i128 i)
         |> Fmt.fmt "/"
         |> (Option.fmt U128.pp) (U128.like_of_i128_opt i)
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/convert/test_wU_wN.ml
+++ b/bootstrap/test/basis/convert/test_wU_wN.ml
@@ -9,9 +9,9 @@ let test () =
       ~f:(fun formatter u ->
         formatter
         |> Fmt.fmt "extend_to_nat "
-        |> U128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true u
+        |> U128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
-        |> Nat.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (U128.extend_to_nat u)
+        |> Nat.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (U128.extend_to_nat u)
         |> Fmt.fmt "\n"
       )
   )
@@ -23,9 +23,9 @@ let test () =
       ~f:(fun formatter u ->
         formatter
         |> Fmt.fmt "trunc_of_nat/narrow_of_nat_opt "
-        |> Nat.fmt ~alt:true ~base:Fmt.Hex ~pretty:true u
+        |> Nat.fmt ~alt:true ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
-        |> U128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (U128.trunc_of_nat u)
+        |> U128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (U128.trunc_of_nat u)
         |> Fmt.fmt "/"
         |> (Option.fmt U128.pp) (U128.narrow_of_nat_opt u)
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/convert/test_wU_wU.ml
+++ b/bootstrap/test/basis/convert/test_wU_wU.ml
@@ -9,9 +9,9 @@ let test () =
       ~f:(fun formatter u ->
         formatter
         |> Fmt.fmt "extend_to_u512 "
-        |> U128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true u
+        |> U128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
-        |> U512.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (U128.extend_to_u512 u)
+        |> U512.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (U128.extend_to_u512 u)
         |> Fmt.fmt "\n"
       )
   )
@@ -23,9 +23,9 @@ let test () =
       ~f:(fun formatter u ->
         formatter
         |> Fmt.fmt "trunc_of_u512/narrow_of_u512_opt "
-        |> U512.fmt ~alt:true ~base:Fmt.Hex ~pretty:true u
+        |> U512.fmt ~alt:true ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
-        |> U128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (U128.trunc_of_u512 u)
+        |> U128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (U128.trunc_of_u512 u)
         |> Fmt.fmt "/"
         |> (Option.fmt U128.pp) (U128.narrow_of_u512_opt u)
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/convert/test_wU_wX.ml
+++ b/bootstrap/test/basis/convert/test_wU_wX.ml
@@ -22,9 +22,9 @@ let test () =
       ~f:(fun formatter u ->
         formatter
         |> Fmt.fmt "trunc_of_i512/narrow_of_i512_opt "
-        |> I512.fmt ~alt:true ~base:Fmt.Hex ~pretty:true u
+        |> I512.fmt ~alt:true ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
-        |> U128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (U128.trunc_of_i512 u)
+        |> U128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (U128.trunc_of_i512 u)
         |> Fmt.fmt "/"
         |> (Option.fmt U128.pp) (U128.narrow_of_i512_opt u)
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/convert/test_wU_wZ.ml
+++ b/bootstrap/test/basis/convert/test_wU_wZ.ml
@@ -22,9 +22,9 @@ let test () =
       ~f:(fun formatter u ->
         formatter
         |> Fmt.fmt "trunc_of_zint/narrow_of_zint_opt "
-        |> Zint.fmt ~alt:true ~base:Fmt.Hex ~pretty:true u
+        |> Zint.fmt ~alt:true ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
-        |> U128.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (U128.trunc_of_zint u)
+        |> U128.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (U128.trunc_of_zint u)
         |> Fmt.fmt "/"
         |> (Option.fmt U128.pp) (U128.narrow_of_zint_opt u)
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/hash/test_hash_fold_u64.ml
+++ b/bootstrap/test/basis/hash/test_hash_fold_u64.ml
@@ -16,7 +16,7 @@ let test () =
     | u64s :: u64s_list' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> (Array.pp (Uns.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex)) u64s
+        |> (Array.pp (Uns.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex)) u64s
         |> Fmt.fmt " -> "
         |> pp (t_of_state State.(hash_fold u64s empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/hash/test_hash_fold_u8.ml
+++ b/bootstrap/test/basis/hash/test_hash_fold_u8.ml
@@ -16,7 +16,7 @@ let test () =
     | u8s :: u8s_list' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> (Array.pp (Uns.fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex)) u8s
+        |> (Array.pp (Uns.fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex)) u8s
         |> Fmt.fmt " -> "
         |> pp (t_of_state State.(hash_fold u8s empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/i16/test_bit_and_bit_or_bit_xor.ml
+++ b/bootstrap/test/basis/i16/test_bit_and_bit_or_bit_xor.ml
@@ -8,15 +8,15 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{and,or,xor} "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (bit_and x y)
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (bit_and x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (bit_or x y)
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (bit_or x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (bit_xor x y)
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (bit_xor x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/i16/test_bit_not.ml
+++ b/bootstrap/test/basis/i16/test_bit_not.ml
@@ -8,9 +8,9 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_not "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (bit_not x)
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (bit_not x)
         |> Fmt.fmt "\n"
         |> ignore;
         test xs'

--- a/bootstrap/test/basis/i16/test_bit_pop_bit_clz_bit_ctz.ml
+++ b/bootstrap/test/basis/i16/test_bit_pop_bit_clz_bit_ctz.ml
@@ -8,7 +8,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{pop,clz,ctz} "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Uns.pp (bit_pop x)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/i16/test_conversion.ml
+++ b/bootstrap/test/basis/i16/test_conversion.ml
@@ -12,13 +12,13 @@ let test () =
         let t' = trunc_of_sint i' in
         File.Fmt.stdout
         |> Fmt.fmt "trunc_of_sint "
-        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true i
+        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> extend_to_sint "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true t
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true t
         |> Fmt.fmt " -> trunc_of_sint "
         |> Sint.pp i'
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true t'
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true t'
         |> Fmt.fmt "\n"
         |> ignore;
         let t = trunc_of_uns (Uns.bits_of_sint i) in
@@ -26,13 +26,13 @@ let test () =
         let t' = trunc_of_uns u in
         File.Fmt.stdout
         |> Fmt.fmt "trunc_of_uns "
-        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true i
+        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> extend_to_uns "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true t
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true t
         |> Fmt.fmt " -> trunc_of_uns "
-        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex u
+        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex u
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true t'
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true t'
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/i16/test_exp.ml
+++ b/bootstrap/test/basis/i16/test_exp.ml
@@ -7,11 +7,11 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " ** "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (x ** y)
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (x ** y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/i16/test_fmt.ml
+++ b/bootstrap/test/basis/i16/test_fmt.ml
@@ -10,7 +10,7 @@ let test () =
           File.Fmt.stdout
           |> pp x
           |> Fmt.fmt " "
-          |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+          |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
           |> Fmt.fmt "\n"
         in
         fn xs'

--- a/bootstrap/test/basis/i16/test_hash_fold.ml
+++ b/bootstrap/test/basis/i16/test_hash_fold.ml
@@ -9,7 +9,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Hash.pp (Hash.t_of_state (hash_fold x Hash.State.empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/i16/test_limits.ml
+++ b/bootstrap/test/basis/i16/test_limits.ml
@@ -9,11 +9,11 @@ let test () =
   |> Fmt.fmt "\nmin_value="
   |> pp min_value
   |> Fmt.fmt " "
-  |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true min_value
+  |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true min_value
   |> Fmt.fmt "\nmax_value="
   |> pp max_value
   |> Fmt.fmt " "
-  |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true max_value
+  |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true max_value
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/i16/test_of_real_to_real.ml
+++ b/bootstrap/test/basis/i16/test_of_real_to_real.ml
@@ -10,11 +10,11 @@ let test () =
         let x = of_real r in
         File.Fmt.stdout
         |> Fmt.fmt "of_real "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "; to_real -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex (to_real x)
+        |> Real.fmt ~alt:true ~radix:Radix.Hex (to_real x)
         |> Fmt.fmt "\n"
         |> ignore;
         test_rs rs'
@@ -44,11 +44,11 @@ let test () =
         let r = to_real x in
         File.Fmt.stdout
         |> Fmt.fmt "to_real "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt "; of_real -> "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (of_real r)
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (of_real r)
         |> Fmt.fmt "\n"
         |> ignore;
         test_xs xs'

--- a/bootstrap/test/basis/i16/test_pp.ml
+++ b/bootstrap/test/basis/i16/test_pp.ml
@@ -9,7 +9,7 @@ let test () =
         File.Fmt.stdout
         |> pp x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/i16/test_rel.ml
+++ b/bootstrap/test/basis/i16/test_rel.ml
@@ -3,7 +3,7 @@ open! Basis
 open I16
 
 let pp_x x formatter =
-  formatter |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+  formatter |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
 
 let test () =
   let fn x y formatter = begin

--- a/bootstrap/test/basis/i16/test_wraparound.ml
+++ b/bootstrap/test/basis/i16/test_wraparound.ml
@@ -7,11 +7,11 @@ let test () =
   |> Fmt.fmt "max_value + "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (max_value + one)
+  |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (max_value + one)
   |> Fmt.fmt "\nmin_value - "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (min_value - one)
+  |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (min_value - one)
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/i256/test_add_sub.ml
+++ b/bootstrap/test/basis/i256/test_add_sub.ml
@@ -7,13 +7,13 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " +,- "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (x + y)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (x + y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (x - y)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (x - y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/i256/test_bit_and_bit_or_bit_xor.ml
+++ b/bootstrap/test/basis/i256/test_bit_and_bit_or_bit_xor.ml
@@ -8,15 +8,15 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{and,or,xor} "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (bit_and x y)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (bit_and x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (bit_or x y)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (bit_or x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (bit_xor x y)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (bit_xor x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/i256/test_bit_not.ml
+++ b/bootstrap/test/basis/i256/test_bit_not.ml
@@ -8,9 +8,9 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_not "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (bit_not x)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (bit_not x)
         |> Fmt.fmt "\n"
         |> ignore;
         test xs'

--- a/bootstrap/test/basis/i256/test_bit_pop_bit_clz_bit_ctz.ml
+++ b/bootstrap/test/basis/i256/test_bit_pop_bit_clz_bit_ctz.ml
@@ -8,7 +8,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{pop,clz,ctz} "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Uns.pp (bit_pop x)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/i256/test_constants.ml
+++ b/bootstrap/test/basis/i256/test_constants.ml
@@ -5,19 +5,19 @@ open I256
 let test () =
   File.Fmt.stdout
   |> Fmt.fmt "zero="
-  |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true zero
+  |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true zero
   |> Fmt.fmt " "
   |> pp zero
   |> Fmt.fmt "\none="
-  |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true one
+  |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true one
   |> Fmt.fmt " "
   |> pp one
   |> Fmt.fmt "\nmin_value="
-  |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true min_value
+  |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true min_value
   |> Fmt.fmt " "
   |> pp min_value
   |> Fmt.fmt "\nmax_value="
-  |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true max_value
+  |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true max_value
   |> Fmt.fmt " "
   |> pp max_value
   |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/i256/test_floor_lg_ceil_lg.ml
+++ b/bootstrap/test/basis/i256/test_floor_lg_ceil_lg.ml
@@ -8,7 +8,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "floor_lg,ceil_lg "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> pp (floor_lg x)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/i256/test_floor_pow2_ceil_pow2.ml
+++ b/bootstrap/test/basis/i256/test_floor_pow2_ceil_pow2.ml
@@ -8,11 +8,11 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "floor_pow2,ceil_pow2 "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (floor_pow2 x)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (floor_pow2 x)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (ceil_pow2 x)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (ceil_pow2 x)
         |> Fmt.fmt "\n"
         |> ignore;
         test xs'

--- a/bootstrap/test/basis/i256/test_fmt.ml
+++ b/bootstrap/test/basis/i256/test_fmt.ml
@@ -10,7 +10,7 @@ let test () =
           File.Fmt.stdout
           |> pp x
           |> Fmt.fmt " "
-          |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+          |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
           |> Fmt.fmt "\n"
         in
         fn xs'

--- a/bootstrap/test/basis/i256/test_hash_fold.ml
+++ b/bootstrap/test/basis/i256/test_hash_fold.ml
@@ -9,7 +9,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Hash.pp (Hash.t_of_state (hash_fold x Hash.State.empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/i256/test_is_pow2.ml
+++ b/bootstrap/test/basis/i256/test_is_pow2.ml
@@ -8,7 +8,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "is_pow2 "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Bool.pp (is_pow2 x)
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/i256/test_min_max.ml
+++ b/bootstrap/test/basis/i256/test_min_max.ml
@@ -8,13 +8,13 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "min,max "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (min x y)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (min x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (max x y)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (max x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/i256/test_mul.ml
+++ b/bootstrap/test/basis/i256/test_mul.ml
@@ -8,11 +8,11 @@ let test () =
     | (x, y) :: pairs' -> begin
         let z = x * y in
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " * "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true z
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true z
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/i256/test_narrowing.ml
+++ b/bootstrap/test/basis/i256/test_narrowing.ml
@@ -6,13 +6,13 @@ let test () =
   let fifteen = of_string "15" in
   File.Fmt.stdout
   |> Fmt.fmt "neg_one + one -> "
-  |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (neg_one + one)
+  |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (neg_one + one)
   |> Fmt.fmt "\nzero - one -> "
-  |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (zero - one)
+  |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (zero - one)
   |> Fmt.fmt "\nneg_one * "
   |> pp fifteen
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (neg_one * fifteen)
+  |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (neg_one * fifteen)
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/i256/test_of_real_to_real.ml
+++ b/bootstrap/test/basis/i256/test_of_real_to_real.ml
@@ -10,11 +10,11 @@ let test () =
         let x = of_real r in
         File.Fmt.stdout
         |> Fmt.fmt "of_real "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "; to_real -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex (to_real x)
+        |> Real.fmt ~alt:true ~radix:Radix.Hex (to_real x)
         |> Fmt.fmt "\n"
         |> ignore;
         test_rs rs'
@@ -52,11 +52,11 @@ let test () =
         let r = to_real x in
         File.Fmt.stdout
         |> Fmt.fmt "to_real "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt "; of_real -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (of_real r)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (of_real r)
         |> Fmt.fmt "\n"
         |> ignore;
         test_xs xs'

--- a/bootstrap/test/basis/i256/test_of_string.ml
+++ b/bootstrap/test/basis/i256/test_of_string.ml
@@ -12,7 +12,7 @@ let test () =
         |> Fmt.fmt " -> "
         |> pp (of_string s)
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (of_string s)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (of_string s)
         |> Fmt.fmt "\n"
         |> ignore;
         test_strs strs'

--- a/bootstrap/test/basis/i256/test_pp.ml
+++ b/bootstrap/test/basis/i256/test_pp.ml
@@ -9,7 +9,7 @@ let test () =
         File.Fmt.stdout
         |> pp x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/i256/test_rel.ml
+++ b/bootstrap/test/basis/i256/test_rel.ml
@@ -3,7 +3,7 @@ open! Basis
 open I256
 
 let pp_x x formatter =
-  formatter |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+  formatter |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
 
 let test () =
   let fn x y formatter = begin

--- a/bootstrap/test/basis/i32/test_bit_and_bit_or_bit_xor.ml
+++ b/bootstrap/test/basis/i32/test_bit_and_bit_or_bit_xor.ml
@@ -8,15 +8,15 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{and,or,xor} "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (bit_and x y)
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (bit_and x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (bit_or x y)
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (bit_or x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (bit_xor x y)
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (bit_xor x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/i32/test_bit_not.ml
+++ b/bootstrap/test/basis/i32/test_bit_not.ml
@@ -8,9 +8,9 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_not "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (bit_not x)
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (bit_not x)
         |> Fmt.fmt "\n"
         |> ignore;
         test xs'

--- a/bootstrap/test/basis/i32/test_bit_pop_bit_clz_bit_ctz.ml
+++ b/bootstrap/test/basis/i32/test_bit_pop_bit_clz_bit_ctz.ml
@@ -8,7 +8,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{pop,clz,ctz} "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Uns.pp (bit_pop x)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/i32/test_conversion.ml
+++ b/bootstrap/test/basis/i32/test_conversion.ml
@@ -12,13 +12,13 @@ let test () =
         let t' = trunc_of_sint i' in
         File.Fmt.stdout
         |> Fmt.fmt "trunc_of_sint "
-        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true i
+        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> extend_to_sint "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true t
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true t
         |> Fmt.fmt " -> trunc_of_sint "
         |> Sint.pp i'
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true t'
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true t'
         |> Fmt.fmt "\n"
         |> ignore;
         let t = trunc_of_uns (Uns.bits_of_sint i) in
@@ -26,13 +26,13 @@ let test () =
         let t' = trunc_of_uns u in
         File.Fmt.stdout
         |> Fmt.fmt "trunc_of_uns "
-        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true i
+        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> extend_to_uns "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true t
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true t
         |> Fmt.fmt " -> trunc_of_uns "
-        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex u
+        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex u
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true t'
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true t'
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/i32/test_exp.ml
+++ b/bootstrap/test/basis/i32/test_exp.ml
@@ -7,11 +7,11 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " ** "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (x ** y)
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (x ** y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/i32/test_fmt.ml
+++ b/bootstrap/test/basis/i32/test_fmt.ml
@@ -10,7 +10,7 @@ let test () =
           File.Fmt.stdout
           |> pp x
           |> Fmt.fmt " "
-          |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+          |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
           |> Fmt.fmt "\n"
         in
         fn xs'

--- a/bootstrap/test/basis/i32/test_hash_fold.ml
+++ b/bootstrap/test/basis/i32/test_hash_fold.ml
@@ -9,7 +9,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Hash.pp (Hash.t_of_state (hash_fold x Hash.State.empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/i32/test_limits.ml
+++ b/bootstrap/test/basis/i32/test_limits.ml
@@ -9,11 +9,11 @@ let test () =
   |> Fmt.fmt "\nmin_value="
   |> pp min_value
   |> Fmt.fmt " "
-  |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true min_value
+  |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true min_value
   |> Fmt.fmt "\nmax_value="
   |> pp max_value
   |> Fmt.fmt " "
-  |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true max_value
+  |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true max_value
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/i32/test_of_real_to_real.ml
+++ b/bootstrap/test/basis/i32/test_of_real_to_real.ml
@@ -10,11 +10,11 @@ let test () =
         let x = of_real r in
         File.Fmt.stdout
         |> Fmt.fmt "of_real "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "; to_real -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex (to_real x)
+        |> Real.fmt ~alt:true ~radix:Radix.Hex (to_real x)
         |> Fmt.fmt "\n"
         |> ignore;
         test_rs rs'
@@ -44,11 +44,11 @@ let test () =
         let r = to_real x in
         File.Fmt.stdout
         |> Fmt.fmt "to_real "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt "; of_real -> "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (of_real r)
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (of_real r)
         |> Fmt.fmt "\n"
         |> ignore;
         test_xs xs'

--- a/bootstrap/test/basis/i32/test_pp.ml
+++ b/bootstrap/test/basis/i32/test_pp.ml
@@ -9,7 +9,7 @@ let test () =
         File.Fmt.stdout
         |> pp x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/i32/test_rel.ml
+++ b/bootstrap/test/basis/i32/test_rel.ml
@@ -3,7 +3,7 @@ open! Basis
 open I32
 
 let pp_x x formatter =
-  formatter |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+  formatter |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
 
 let test () =
   let fn x y formatter = begin

--- a/bootstrap/test/basis/i32/test_wraparound.ml
+++ b/bootstrap/test/basis/i32/test_wraparound.ml
@@ -7,11 +7,11 @@ let test () =
   |> Fmt.fmt "max_value + "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (max_value + one)
+  |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (max_value + one)
   |> Fmt.fmt "\nmin_value - "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (min_value - one)
+  |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (min_value - one)
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/i64/test_bit_and_bit_or_bit_xor.ml
+++ b/bootstrap/test/basis/i64/test_bit_and_bit_or_bit_xor.ml
@@ -8,15 +8,15 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{and,or,xor} "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true (bit_and x y)
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true (bit_and x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true (bit_or x y)
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true (bit_or x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true (bit_xor x y)
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true (bit_xor x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/i64/test_bit_not.ml
+++ b/bootstrap/test/basis/i64/test_bit_not.ml
@@ -8,9 +8,9 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_not "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true (bit_not x)
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true (bit_not x)
         |> Fmt.fmt "\n"
         |> ignore;
         test xs'

--- a/bootstrap/test/basis/i64/test_bit_pop_bit_clz_bit_ctz.ml
+++ b/bootstrap/test/basis/i64/test_bit_pop_bit_clz_bit_ctz.ml
@@ -8,7 +8,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{pop,clz,ctz} "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Uns.pp (bit_pop x)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/i64/test_exp.ml
+++ b/bootstrap/test/basis/i64/test_exp.ml
@@ -7,11 +7,11 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " ** "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true (x ** y)
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true (x ** y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/i64/test_fmt.ml
+++ b/bootstrap/test/basis/i64/test_fmt.ml
@@ -13,9 +13,9 @@ let test () =
     | x :: xs' -> begin
         List.fold ~init:(
           formatter
-          |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex x
+          |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex x
           |> Fmt.fmt "\n"
-        ) [Fmt.Bin; Fmt.Oct; Fmt.Dec; Fmt.Hex] ~f:(fun formatter base ->
+        ) [Radix.Bin; Radix.Oct; Radix.Dec; Radix.Hex] ~f:(fun formatter radix ->
           List.fold ~init:formatter [Fmt.Implicit; Fmt.Explicit; Fmt.Space]
             ~f:(fun formatter sign ->
               List.fold ~init:formatter [false; true] ~f:(fun formatter alt ->
@@ -27,7 +27,7 @@ let test () =
                         |> Fmt.fmt "["
                         |> String.fmt ~pad:(Codepoint.of_char '_') ~width:75L (
                           String.Fmt.empty
-                          |> fmt ~pad:"·" ~just ~sign ~alt ~zpad ~width ~base x
+                          |> fmt ~pad:"·" ~just ~sign ~alt ~zpad ~width ~radix x
                           |> Fmt.to_string
                         )
                         |> Fmt.fmt "] %'·'"
@@ -47,11 +47,11 @@ let test () =
                         |> Fmt.fmt (match zpad with false -> "" | true -> "0")
                         |> (match width with 0L -> Fmt.fmt "" | _ -> Uns.fmt width)
                         |> Fmt.fmt (
-                          match base with
-                          | Fmt.Bin -> "b"
-                          | Fmt.Oct -> "o"
-                          | Fmt.Dec -> "d"
-                          | Fmt.Hex -> "h"
+                          match radix with
+                          | Radix.Bin -> "b"
+                          | Radix.Oct -> "o"
+                          | Radix.Dec -> "d"
+                          | Radix.Hex -> "h"
                         )
                         |> Fmt.fmt "i\n"
                       )
@@ -78,7 +78,7 @@ let test () =
   in
   File.Fmt.stdout
   |> Fmt.fmt (match verbose with true -> output | false -> "")
-  |> Fmt.fmt (U128.to_string ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true
+  |> Fmt.fmt (U128.to_string ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true
       (Hash.State.empty |> String.hash_fold output |> Hash.t_of_state))
 
 let _ = test ()

--- a/bootstrap/test/basis/i64/test_hash_fold.ml
+++ b/bootstrap/test/basis/i64/test_hash_fold.ml
@@ -9,7 +9,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Hash.pp (Hash.t_of_state (hash_fold x Hash.State.empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/i64/test_limits.ml
+++ b/bootstrap/test/basis/i64/test_limits.ml
@@ -5,9 +5,9 @@ open I64
 let test () =
   File.Fmt.stdout
   |> Fmt.fmt "min_value="
-  |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true min_value
+  |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true min_value
   |> Fmt.fmt "\nmax_value="
-  |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true max_value
+  |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true max_value
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/i64/test_narrowing.ml
+++ b/bootstrap/test/basis/i64/test_narrowing.ml
@@ -8,15 +8,15 @@ let test () =
   |> Fmt.fmt "max_value + "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true (max_value + one)
+  |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true (max_value + one)
   |> Fmt.fmt "\nmin_value - "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true (min_value - one)
+  |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true (min_value - one)
   |> Fmt.fmt "\nmax_value * "
   |> pp fifteen
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true (max_value * fifteen)
+  |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true (max_value * fifteen)
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/i64/test_of_real_to_real.ml
+++ b/bootstrap/test/basis/i64/test_of_real_to_real.ml
@@ -10,11 +10,11 @@ let test () =
         let x = of_real r in
         File.Fmt.stdout
         |> Fmt.fmt "of_real "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "; to_real -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex (to_real x)
+        |> Real.fmt ~alt:true ~radix:Radix.Hex (to_real x)
         |> Fmt.fmt "\n"
         |> ignore;
         test_rs rs'
@@ -40,11 +40,11 @@ let test () =
         let r = to_real x in
         File.Fmt.stdout
         |> Fmt.fmt "to_real "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt "; of_real -> "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true (of_real r)
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true (of_real r)
         |> Fmt.fmt "\n"
         |> ignore;
         test_xs xs'

--- a/bootstrap/test/basis/i64/test_of_sint_to_sint.ml
+++ b/bootstrap/test/basis/i64/test_of_sint_to_sint.ml
@@ -10,11 +10,11 @@ let test () =
         let sx = x in
         File.Fmt.stdout
         |> Fmt.fmt "to_sint "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true x
+        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "; of_sint -> "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true sx
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true sx
         |> Fmt.fmt "\n"
         |> ignore;
         test_xs xs'

--- a/bootstrap/test/basis/i64/test_pp.ml
+++ b/bootstrap/test/basis/i64/test_pp.ml
@@ -7,13 +7,13 @@ let test () =
     | [] -> ()
     | x :: xs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Bin ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Bin ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~base:Fmt.Oct ~pretty:true x
+        |> fmt ~alt:true ~radix:Radix.Oct ~pretty:true x
         |> Fmt.fmt " "
         |> pp x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/i64/test_rel.ml
+++ b/bootstrap/test/basis/i64/test_rel.ml
@@ -3,7 +3,7 @@ open! Basis
 open I64
 
 let pp_x x formatter =
-  formatter |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true x
+  formatter |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true x
 
 let test () =
   let fn x y formatter = begin

--- a/bootstrap/test/basis/i8/test_bit_and_bit_or_bit_xor.ml
+++ b/bootstrap/test/basis/i8/test_bit_and_bit_or_bit_xor.ml
@@ -8,15 +8,15 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{and,or,xor} "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (bit_and x y)
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (bit_and x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (bit_or x y)
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (bit_or x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (bit_xor x y)
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (bit_xor x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/i8/test_bit_not.ml
+++ b/bootstrap/test/basis/i8/test_bit_not.ml
@@ -8,9 +8,9 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_not "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (bit_not x)
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (bit_not x)
         |> Fmt.fmt "\n"
         |> ignore;
         test xs'

--- a/bootstrap/test/basis/i8/test_bit_pop_bit_clz_bit_ctz.ml
+++ b/bootstrap/test/basis/i8/test_bit_pop_bit_clz_bit_ctz.ml
@@ -8,7 +8,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{pop,clz,ctz} "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Uns.pp (bit_pop x)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/i8/test_conversion.ml
+++ b/bootstrap/test/basis/i8/test_conversion.ml
@@ -12,13 +12,13 @@ let test () =
         let t' = trunc_of_sint i' in
         File.Fmt.stdout
         |> Fmt.fmt "trunc_of_sint "
-        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true i
+        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> extend_to_sint "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true t
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true t
         |> Fmt.fmt " -> trunc_of_sint "
         |> Sint.fmt ~pretty:true i'
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true t'
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true t'
         |> Fmt.fmt "\n"
         |> ignore;
         let t = trunc_of_uns (Uns.bits_of_sint i) in
@@ -26,13 +26,13 @@ let test () =
         let t' = trunc_of_uns u in
         File.Fmt.stdout
         |> Fmt.fmt "trunc_of_uns "
-        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true i
+        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> extend_to_uns "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true t
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true t
         |> Fmt.fmt " -> trunc_of_uns "
-        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex u
+        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex u
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true t'
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true t'
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/i8/test_exp.ml
+++ b/bootstrap/test/basis/i8/test_exp.ml
@@ -7,11 +7,11 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " ** "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (x ** y)
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (x ** y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/i8/test_fmt.ml
+++ b/bootstrap/test/basis/i8/test_fmt.ml
@@ -10,7 +10,7 @@ let test () =
           File.Fmt.stdout
           |> pp x
           |> Fmt.fmt " "
-          |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+          |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
           |> Fmt.fmt "\n"
         in
         fn xs'

--- a/bootstrap/test/basis/i8/test_hash_fold.ml
+++ b/bootstrap/test/basis/i8/test_hash_fold.ml
@@ -9,7 +9,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Hash.pp (Hash.t_of_state (hash_fold x Hash.State.empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/i8/test_limits.ml
+++ b/bootstrap/test/basis/i8/test_limits.ml
@@ -9,11 +9,11 @@ let test () =
   |> Fmt.fmt "\nmin_value="
   |> pp min_value
   |> Fmt.fmt " "
-  |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true min_value
+  |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true min_value
   |> Fmt.fmt "\nmax_value="
   |> pp max_value
   |> Fmt.fmt " "
-  |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true max_value
+  |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true max_value
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/i8/test_of_real_to_real.ml
+++ b/bootstrap/test/basis/i8/test_of_real_to_real.ml
@@ -10,11 +10,11 @@ let test () =
         let x = of_real r in
         File.Fmt.stdout
         |> Fmt.fmt "of_real "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "; to_real -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex (to_real x)
+        |> Real.fmt ~alt:true ~radix:Radix.Hex (to_real x)
         |> Fmt.fmt "\n"
         |> ignore;
         test_rs rs'
@@ -44,11 +44,11 @@ let test () =
         let r = to_real x in
         File.Fmt.stdout
         |> Fmt.fmt "to_real "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt "; of_real -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (of_real r)
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (of_real r)
         |> Fmt.fmt "\n"
         |> ignore;
         test_xs xs'

--- a/bootstrap/test/basis/i8/test_pp.ml
+++ b/bootstrap/test/basis/i8/test_pp.ml
@@ -9,7 +9,7 @@ let test () =
         File.Fmt.stdout
         |> pp x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/i8/test_rel.ml
+++ b/bootstrap/test/basis/i8/test_rel.ml
@@ -3,7 +3,7 @@ open! Basis
 open I8
 
 let pp_x x formatter =
-  formatter |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+  formatter |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
 
 let test () =
   let fn x y formatter = begin

--- a/bootstrap/test/basis/i8/test_wraparound.ml
+++ b/bootstrap/test/basis/i8/test_wraparound.ml
@@ -7,11 +7,11 @@ let test () =
   |> Fmt.fmt "max_value + "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (max_value + one)
+  |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (max_value + one)
   |> Fmt.fmt "\nmin_value - "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (min_value - one)
+  |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (min_value - one)
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/nat/test_add_sub.ml
+++ b/bootstrap/test/basis/nat/test_add_sub.ml
@@ -7,13 +7,13 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " +,- "
-        |> fmt ~alt:true ~base:Fmt.Hex y
+        |> fmt ~alt:true ~radix:Radix.Hex y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (x + y)
+        |> fmt ~alt:true ~radix:Radix.Hex (x + y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~base:Fmt.Hex (x - y)
+        |> fmt ~alt:true ~radix:Radix.Hex (x - y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/nat/test_bit_and_bit_or_bit_xor.ml
+++ b/bootstrap/test/basis/nat/test_bit_and_bit_or_bit_xor.ml
@@ -8,15 +8,15 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{and,or,xor} "
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~base:Fmt.Hex y
+        |> fmt ~alt:true ~radix:Radix.Hex y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (bit_and x y)
+        |> fmt ~alt:true ~radix:Radix.Hex (bit_and x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~base:Fmt.Hex (bit_or x y)
+        |> fmt ~alt:true ~radix:Radix.Hex (bit_or x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~base:Fmt.Hex (bit_xor x y)
+        |> fmt ~alt:true ~radix:Radix.Hex (bit_xor x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/nat/test_bit_not.ml
+++ b/bootstrap/test/basis/nat/test_bit_not.ml
@@ -8,9 +8,9 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_not "
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (bit_not x)
+        |> fmt ~alt:true ~radix:Radix.Hex (bit_not x)
         |> Fmt.fmt "\n"
         |> ignore;
         test xs'

--- a/bootstrap/test/basis/nat/test_bit_pop_bit_clz_bit_ctz.ml
+++ b/bootstrap/test/basis/nat/test_bit_pop_bit_clz_bit_ctz.ml
@@ -8,7 +8,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_length, bit_{pop,clz,ctz} "
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " -> "
         |> Uns.pp (bit_length x)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/nat/test_constants.ml
+++ b/bootstrap/test/basis/nat/test_constants.ml
@@ -5,9 +5,9 @@ open Nat
 let test () =
   File.Fmt.stdout
   |> Fmt.fmt "zero="
-  |> fmt ~alt:true ~base:Fmt.Hex zero
+  |> fmt ~alt:true ~radix:Radix.Hex zero
   |> Fmt.fmt "\none="
-  |> fmt ~alt:true ~base:Fmt.Hex one
+  |> fmt ~alt:true ~radix:Radix.Hex one
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/nat/test_convert_zint.ml
+++ b/bootstrap/test/basis/nat/test_convert_zint.ml
@@ -10,11 +10,11 @@ let test () =
       ~f:(fun formatter u ->
         formatter
         |> Fmt.fmt "bits_to_zint/like_to_zint_opt "
-        |> Nat.fmt ~alt:true ~base:Fmt.Hex ~pretty:true u
+        |> Nat.fmt ~alt:true ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
-        |> Zint.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (Nat.bits_to_zint u)
+        |> Zint.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (Nat.bits_to_zint u)
         |> Fmt.fmt "/"
-        |> (Option.fmt (Zint.fmt ~alt:true ~base:Fmt.Hex ~pretty:true)) (Nat.like_to_zint_opt u)
+        |> (Option.fmt (Zint.fmt ~alt:true ~radix:Radix.Hex ~pretty:true)) (Nat.like_to_zint_opt u)
         |> Fmt.fmt "\n"
       )
   )
@@ -25,11 +25,11 @@ let test () =
       ~f:(fun formatter i ->
         formatter
         |> Fmt.fmt "bits_of_zint/like_of_zint_opt "
-        |> Zint.fmt ~alt:true ~base:Fmt.Hex ~pretty:true i
+        |> Zint.fmt ~alt:true ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> "
-        |> Nat.fmt ~alt:true ~base:Fmt.Hex ~pretty:true (Nat.bits_of_zint i)
+        |> Nat.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (Nat.bits_of_zint i)
         |> Fmt.fmt "/"
-        |> (Option.fmt (Nat.fmt ~alt:true ~base:Fmt.Hex)) (Nat.like_of_zint_opt i)
+        |> (Option.fmt (Nat.fmt ~alt:true ~radix:Radix.Hex)) (Nat.like_of_zint_opt i)
         |> Fmt.fmt "\n"
       )
   )

--- a/bootstrap/test/basis/nat/test_div_mod.ml
+++ b/bootstrap/test/basis/nat/test_div_mod.ml
@@ -9,13 +9,13 @@ let test () =
         let quotient = x / y in
         let remainder = x % y in
         File.Fmt.stdout
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " /,% "
-        |> fmt ~alt:true ~base:Fmt.Hex y
+        |> fmt ~alt:true ~radix:Radix.Hex y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex quotient
+        |> fmt ~alt:true ~radix:Radix.Hex quotient
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~base:Fmt.Hex remainder
+        |> fmt ~alt:true ~radix:Radix.Hex remainder
         |> Fmt.fmt "\n"
         |> ignore;
         assert (x = (y * quotient + remainder));

--- a/bootstrap/test/basis/nat/test_exp.ml
+++ b/bootstrap/test/basis/nat/test_exp.ml
@@ -7,11 +7,11 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " ** "
-        |> fmt ~alt:true ~base:Fmt.Hex y
+        |> fmt ~alt:true ~radix:Radix.Hex y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (x ** y)
+        |> fmt ~alt:true ~radix:Radix.Hex (x ** y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/nat/test_floor_lg_ceil_lg.ml
+++ b/bootstrap/test/basis/nat/test_floor_lg_ceil_lg.ml
@@ -8,7 +8,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "floor_lg,ceil_lg "
-        |> fmt ~alt:true ~base:Fmt.Hex u
+        |> fmt ~alt:true ~radix:Radix.Hex u
         |> Fmt.fmt " -> "
         |> fmt (floor_lg u)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/nat/test_floor_pow2_ceil_pow2.ml
+++ b/bootstrap/test/basis/nat/test_floor_pow2_ceil_pow2.ml
@@ -8,11 +8,11 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "floor_pow2,ceil_pow2 "
-        |> fmt ~alt:true ~base:Fmt.Hex u
+        |> fmt ~alt:true ~radix:Radix.Hex u
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (floor_pow2 u)
+        |> fmt ~alt:true ~radix:Radix.Hex (floor_pow2 u)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~base:Fmt.Hex (ceil_pow2 u)
+        |> fmt ~alt:true ~radix:Radix.Hex (ceil_pow2 u)
         |> Fmt.fmt "\n"
         |> ignore;
         test us'

--- a/bootstrap/test/basis/nat/test_hash_fold.ml
+++ b/bootstrap/test/basis/nat/test_hash_fold.ml
@@ -9,7 +9,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> fmt ~alt:true ~base:Fmt.Hex u
+        |> fmt ~alt:true ~radix:Radix.Hex u
         |> Fmt.fmt " -> "
         |> Hash.pp (Hash.t_of_state (hash_fold u Hash.State.empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/nat/test_is_pow2.ml
+++ b/bootstrap/test/basis/nat/test_is_pow2.ml
@@ -8,7 +8,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "is_pow2 "
-        |> fmt ~alt:true ~base:Fmt.Hex u
+        |> fmt ~alt:true ~radix:Radix.Hex u
         |> Fmt.fmt " -> "
         |> Bool.pp (is_pow2 u)
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/nat/test_min_max.ml
+++ b/bootstrap/test/basis/nat/test_min_max.ml
@@ -8,13 +8,13 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "min,max "
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~base:Fmt.Hex y
+        |> fmt ~alt:true ~radix:Radix.Hex y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (min x y)
+        |> fmt ~alt:true ~radix:Radix.Hex (min x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~base:Fmt.Hex (max x y)
+        |> fmt ~alt:true ~radix:Radix.Hex (max x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/nat/test_mul.ml
+++ b/bootstrap/test/basis/nat/test_mul.ml
@@ -8,11 +8,11 @@ let test () =
     | (x, y) :: pairs' -> begin
         let z = (x * y) in
         File.Fmt.stdout
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " * "
-        |> fmt ~alt:true ~base:Fmt.Hex y
+        |> fmt ~alt:true ~radix:Radix.Hex y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex z
+        |> fmt ~alt:true ~radix:Radix.Hex z
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/nat/test_of_real_to_real.ml
+++ b/bootstrap/test/basis/nat/test_of_real_to_real.ml
@@ -10,11 +10,11 @@ let test () =
         let x = of_real r in
         File.Fmt.stdout
         |> Fmt.fmt "of_real "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt "; to_real -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex (to_real x)
+        |> Real.fmt ~alt:true ~radix:Radix.Hex (to_real x)
         |> Fmt.fmt "\n"
         |> ignore;
         test_rs rs'
@@ -52,11 +52,11 @@ let test () =
         let r = to_real x in
         File.Fmt.stdout
         |> Fmt.fmt "to_real "
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt "; of_real -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (of_real r)
+        |> fmt ~alt:true ~radix:Radix.Hex (of_real r)
         |> Fmt.fmt "\n"
         |> ignore;
         test_xs xs'

--- a/bootstrap/test/basis/nat/test_of_string.ml
+++ b/bootstrap/test/basis/nat/test_of_string.ml
@@ -10,7 +10,7 @@ let test () =
         |> Fmt.fmt "of_string "
         |> String.pp s
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (of_string s)
+        |> fmt ~alt:true ~radix:Radix.Hex (of_string s)
         |> Fmt.fmt "\n"
         |> ignore;
         test_strs strs'

--- a/bootstrap/test/basis/nat/test_pp.ml
+++ b/bootstrap/test/basis/nat/test_pp.ml
@@ -7,13 +7,13 @@ let test () =
     | [] -> ()
     | x :: xs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~base:Fmt.Bin ~pretty:true x
+        |> fmt ~alt:true ~radix:Radix.Bin ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~base:Fmt.Oct ~pretty:true x
+        |> fmt ~alt:true ~radix:Radix.Oct ~pretty:true x
         |> Fmt.fmt " "
         |> pp x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/nat/test_rel.ml
+++ b/bootstrap/test/basis/nat/test_rel.ml
@@ -3,7 +3,7 @@ open! Basis
 open Nat
 
 let pp_x u formatter =
-  formatter |> fmt ~alt:true ~base:Fmt.Hex u
+  formatter |> fmt ~alt:true ~radix:Radix.Hex u
 
 let test () =
   let fn x y formatter = begin

--- a/bootstrap/test/basis/nat/test_widening.ml
+++ b/bootstrap/test/basis/nat/test_widening.ml
@@ -7,7 +7,7 @@ let test () =
   let fifteen = of_string "15" in
   File.Fmt.stdout
   |> Fmt.fmt "u64_max -> "
-  |> fmt ~alt:true ~base:Fmt.Hex ~pretty:true u64_max
+  |> fmt ~alt:true ~radix:Radix.Hex ~pretty:true u64_max
   |> Fmt.fmt "\n"
   |> ignore;
 
@@ -16,7 +16,7 @@ let test () =
   |> Fmt.fmt "u64_max + "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~base:Fmt.Hex ~pretty:true r
+  |> fmt ~alt:true ~radix:Radix.Hex ~pretty:true r
   |> Fmt.fmt " "
   |> pp r
   |> Fmt.fmt "\n"
@@ -27,7 +27,7 @@ let test () =
   |> Fmt.fmt "u64_max * "
   |> pp fifteen
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~base:Fmt.Hex ~pretty:true r
+  |> fmt ~alt:true ~radix:Radix.Hex ~pretty:true r
   |> Fmt.fmt " "
   |> pp r
   |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/real/test_classify.ml
+++ b/bootstrap/test/basis/real/test_classify.ml
@@ -8,7 +8,7 @@ let test () =
     | [] -> ()
     | t :: ts' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~base:Fmt.Hex t
+        |> fmt ~alt:true ~radix:Radix.Hex t
         |> Fmt.fmt " -> "
         |> Class.pp (classify t)
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/real/test_constants.ml
+++ b/bootstrap/test/basis/real/test_constants.ml
@@ -5,17 +5,17 @@ open Real
 let test () =
   File.Fmt.stdout
   |> Fmt.fmt "one: "
-  |> fmt ~alt:true ~base:Fmt.Hex one
+  |> fmt ~alt:true ~radix:Radix.Hex one
   |> Fmt.fmt "\nneg_one: "
-  |> fmt ~alt:true ~base:Fmt.Hex neg_one
+  |> fmt ~alt:true ~radix:Radix.Hex neg_one
   |> Fmt.fmt "\nnan: "
-  |> fmt ~alt:true ~base:Fmt.Hex nan
+  |> fmt ~alt:true ~radix:Radix.Hex nan
   |> Fmt.fmt "\ninf: "
-  |> fmt ~alt:true ~base:Fmt.Hex inf
+  |> fmt ~alt:true ~radix:Radix.Hex inf
   |> Fmt.fmt "\nneg_inf: "
-  |> fmt ~alt:true ~base:Fmt.Hex neg_inf
+  |> fmt ~alt:true ~radix:Radix.Hex neg_inf
   |> Fmt.fmt "\npi: "
-  |> fmt ~alt:true ~base:Fmt.Hex pi
+  |> fmt ~alt:true ~radix:Radix.Hex pi
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/real/test_create.ml
+++ b/bootstrap/test/basis/real/test_create.ml
@@ -14,9 +14,9 @@ let test () =
         |> Fmt.fmt ", e="
         |> Sint.pp e
         |> Fmt.fmt ", m="
-        |> Uns.fmt ~alt:true ~zpad:true ~width:13L ~base:Fmt.Hex m
+        |> Uns.fmt ~alt:true ~zpad:true ~width:13L ~radix:Radix.Hex m
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex f
+        |> fmt ~alt:true ~radix:Radix.Hex f
         |> Fmt.fmt "\n"
         |> ignore;
         fn tups'

--- a/bootstrap/test/basis/real/test_ex.ml
+++ b/bootstrap/test/basis/real/test_ex.ml
@@ -9,9 +9,9 @@ let test () =
     | t :: ts' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "ex "
-        |> fmt ~alt:true ~base:Fmt.Hex t
+        |> fmt ~alt:true ~radix:Radix.Hex t
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (ex t)
+        |> fmt ~alt:true ~radix:Radix.Hex (ex t)
         |> Fmt.fmt "\n"
         |> ignore;
         fn ts'

--- a/bootstrap/test/basis/real/test_fmt.ml
+++ b/bootstrap/test/basis/real/test_fmt.ml
@@ -13,9 +13,9 @@ let test () =
     | x :: xs' ->
       List.fold ~init:(
         formatter
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt "\n"
-      ) [Fmt.Bin; Fmt.Oct; Fmt.Dec; Fmt.Hex] ~f:(fun formatter base ->
+      ) [Radix.Bin; Radix.Oct; Radix.Dec; Radix.Hex] ~f:(fun formatter radix ->
         List.fold ~init:formatter [Fmt.Implicit; Fmt.Explicit; Fmt.Space] ~f:(fun formatter sign ->
           List.fold ~init:formatter [false; true] ~f:(fun formatter alt ->
             List.fold ~init:formatter [Fmt.Normalized; Fmt.RadixPoint; Fmt.Compact]
@@ -24,7 +24,7 @@ let test () =
                 |> Fmt.fmt "["
                 |> Fmt.fmt ~pad:"_" ~width:5L (
                   String.Fmt.empty
-                  |> fmt ~alt ~sign ~notation ~base x
+                  |> fmt ~alt ~sign ~notation ~radix x
                   |> Fmt.to_string
                 )
                 |> Fmt.fmt "] %"
@@ -36,11 +36,11 @@ let test () =
                 )
                 |> Fmt.fmt (match alt with false -> "" | true -> "#")
                 |> Fmt.fmt (
-                  match base with
-                  | Fmt.Bin -> "b"
-                  | Fmt.Oct -> "o"
-                  | Fmt.Dec -> "d"
-                  | Fmt.Hex -> "h"
+                  match radix with
+                  | Radix.Bin -> "b"
+                  | Radix.Oct -> "o"
+                  | Radix.Dec -> "d"
+                  | Radix.Hex -> "h"
                 )
                 |> Fmt.fmt (
                   match notation with
@@ -66,7 +66,7 @@ let test () =
   in
   File.Fmt.stdout
   |> Fmt.fmt (match verbose with true -> output | false -> "")
-  |> Fmt.fmt (U128.to_string ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true
+  |> Fmt.fmt (U128.to_string ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true
       (Hash.State.empty |> String.hash_fold output |> Hash.t_of_state))
 
 let _ = test ()

--- a/bootstrap/test/basis/real/test_fmt_e.ml
+++ b/bootstrap/test/basis/real/test_fmt_e.ml
@@ -13,9 +13,9 @@ let test () =
     | x :: xs' ->
       List.fold ~init:(
         formatter
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt "\n"
-      ) [Fmt.Dec] ~f:(fun formatter base ->
+      ) [Radix.Dec] ~f:(fun formatter radix ->
         List.fold ~init:formatter [Fmt.Implicit; Fmt.Explicit; Fmt.Space] ~f:(fun formatter sign ->
           List.fold ~init:formatter [false; true] ~f:(fun formatter alt ->
             List.fold ~init:formatter [false; true] ~f:(fun formatter zpad ->
@@ -31,7 +31,7 @@ let test () =
                             |> Fmt.fmt ~pad:"_" ~width:41L (
                               String.Fmt.empty
                               |> fmt ~pad:"·" ~just ~sign ~alt ~zpad ~width ~pmode ~precision
-                                ~notation ~base x
+                                ~notation ~radix x
                               |> Fmt.to_string
                             )
                             |> Fmt.fmt "] %'·'"
@@ -63,11 +63,11 @@ let test () =
                               )
                             )
                             |> Fmt.fmt (
-                              match base with
-                              | Fmt.Bin -> "b"
-                              | Fmt.Oct -> "o"
-                              | Fmt.Dec -> "d"
-                              | Fmt.Hex -> "h"
+                              match radix with
+                              | Radix.Bin -> "b"
+                              | Radix.Oct -> "o"
+                              | Radix.Dec -> "d"
+                              | Radix.Hex -> "h"
                             )
                             |> Fmt.fmt (
                               match notation with
@@ -107,7 +107,7 @@ let test () =
   in
   File.Fmt.stdout
   |> Fmt.fmt (match verbose with true -> output | false -> "")
-  |> Fmt.fmt (U128.to_string ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true
+  |> Fmt.fmt (U128.to_string ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true
       (Hash.State.empty |> String.hash_fold output |> Hash.t_of_state))
 
 let _ = test ()

--- a/bootstrap/test/basis/real/test_fmt_p.ml
+++ b/bootstrap/test/basis/real/test_fmt_p.ml
@@ -13,18 +13,18 @@ let test () =
     | x :: xs' ->
       List.fold ~init:(
         formatter
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt "\n"
-      ) [Fmt.Bin; Fmt.Oct; Fmt.Hex] ~f:(fun formatter base ->
+      ) [Radix.Bin; Radix.Oct; Radix.Hex] ~f:(fun formatter radix ->
         List.fold ~init:formatter [Fmt.Implicit; Fmt.Explicit; Fmt.Space] ~f:(fun formatter sign ->
           List.fold ~init:formatter [false; true] ~f:(fun formatter alt ->
             List.fold ~init:formatter [false; true] ~f:(fun formatter zpad ->
               List.fold ~init:formatter [0L; 20L] ~f:(fun formatter width ->
-                List.fold ~init:formatter (match base with
-                  | Fmt.Bin -> [(Fmt.Limited, 0L); (Fmt.Limited, 9L); (Fmt.Fixed, 9L)]
-                  | Fmt.Oct -> [(Fmt.Limited, 0L); (Fmt.Limited, 4L); (Fmt.Fixed, 4L)]
-                  | Fmt.Dec -> not_reached ()
-                  | Fmt.Hex -> [(Fmt.Limited, 0L); (Fmt.Limited, 5L); (Fmt.Fixed, 5L)])
+                List.fold ~init:formatter (match radix with
+                  | Radix.Bin -> [(Fmt.Limited, 0L); (Fmt.Limited, 9L); (Fmt.Fixed, 9L)]
+                  | Radix.Oct -> [(Fmt.Limited, 0L); (Fmt.Limited, 4L); (Fmt.Fixed, 4L)]
+                  | Radix.Dec -> not_reached ()
+                  | Radix.Hex -> [(Fmt.Limited, 0L); (Fmt.Limited, 5L); (Fmt.Fixed, 5L)])
                   ~f:(fun formatter (pmode, precision) ->
                     List.fold ~init:formatter [Fmt.Normalized; Fmt.RadixPoint; Fmt.Compact]
                       ~f:(fun formatter notation ->
@@ -35,9 +35,10 @@ let test () =
                             |> Fmt.fmt ~pad:"_" ~width:21L (
                               String.Fmt.empty
                               |> (match precision with
-                                | 0L -> fmt ~pad:"·" ~just ~sign ~alt ~zpad ~width ~notation ~base x
+                                | 0L ->
+                                  fmt ~pad:"·" ~just ~sign ~alt ~zpad ~width ~notation ~radix x
                                 | _ -> fmt ~pad:"·" ~just ~sign ~alt ~zpad ~width ~pmode ~precision
-                                    ~notation ~base x
+                                    ~notation ~radix x
                               )
                               |> Fmt.to_string
                             )
@@ -70,11 +71,11 @@ let test () =
                               )
                             )
                             |> Fmt.fmt (
-                              match base with
-                              | Fmt.Bin -> "b"
-                              | Fmt.Oct -> "o"
-                              | Fmt.Dec -> "d"
-                              | Fmt.Hex -> "h"
+                              match radix with
+                              | Radix.Bin -> "b"
+                              | Radix.Oct -> "o"
+                              | Radix.Dec -> "d"
+                              | Radix.Hex -> "h"
                             )
                             |> Fmt.fmt (
                               match notation with
@@ -108,7 +109,7 @@ let test () =
   in
   File.Fmt.stdout
   |> Fmt.fmt (match verbose with true -> output | false -> "")
-  |> Fmt.fmt (U128.to_string ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true
+  |> Fmt.fmt (U128.to_string ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true
       (Hash.State.empty |> String.hash_fold output |> Hash.t_of_state))
 
 let _ = test ()

--- a/bootstrap/test/basis/real/test_hash_fold.ml
+++ b/bootstrap/test/basis/real/test_hash_fold.ml
@@ -9,7 +9,7 @@ let test () =
     | x :: reals' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " -> "
         |> Hash.pp (Hash.t_of_state (hash_fold x Hash.State.empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/real/test_ln.ml
+++ b/bootstrap/test/basis/real/test_ln.ml
@@ -10,9 +10,9 @@ let test () =
     | t :: ts' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "ln "
-        |> fmt ~alt:true ~base:Fmt.Hex t
+        |> fmt ~alt:true ~radix:Radix.Hex t
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (norm_nan (ln t))
+        |> fmt ~alt:true ~radix:Radix.Hex (norm_nan (ln t))
         |> Fmt.fmt "\n"
         |> ignore;
         fn ts'

--- a/bootstrap/test/basis/real/test_ln1p.ml
+++ b/bootstrap/test/basis/real/test_ln1p.ml
@@ -10,11 +10,11 @@ let test () =
     | t :: ts' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "ln,ln1p "
-        |> fmt ~alt:true ~base:Fmt.Hex t
+        |> fmt ~alt:true ~radix:Radix.Hex t
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (norm_nan (ln (1. + t)))
+        |> fmt ~alt:true ~radix:Radix.Hex (norm_nan (ln (1. + t)))
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~base:Fmt.Hex (norm_nan (ln1p t))
+        |> fmt ~alt:true ~radix:Radix.Hex (norm_nan (ln1p t))
         |> Fmt.fmt "\n"
         |> ignore;
         fn ts'

--- a/bootstrap/test/basis/real/test_log.ml
+++ b/bootstrap/test/basis/real/test_log.ml
@@ -10,9 +10,9 @@ let test () =
     | t :: ts' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "log "
-        |> fmt ~alt:true ~base:Fmt.Hex t
+        |> fmt ~alt:true ~radix:Radix.Hex t
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (norm_nan (log t))
+        |> fmt ~alt:true ~radix:Radix.Hex (norm_nan (log t))
         |> Fmt.fmt "\n"
         |> ignore;
         fn ts'

--- a/bootstrap/test/basis/real/test_m2x_f2x.ml
+++ b/bootstrap/test/basis/real/test_m2x_f2x.ml
@@ -12,13 +12,13 @@ let test () =
         let f' = f2x m ~p:x in
         File.Fmt.stdout
         |> Fmt.fmt "m2x "
-        |> fmt ~alt:true ~base:Fmt.Hex f
+        |> fmt ~alt:true ~radix:Radix.Hex f
         |> Fmt.fmt " -> f2x "
-        |> fmt ~alt:true ~base:Fmt.Hex m
+        |> fmt ~alt:true ~radix:Radix.Hex m
         |> Fmt.fmt " ~p:"
         |> Sint.pp x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex f'
+        |> fmt ~alt:true ~radix:Radix.Hex f'
         |> Fmt.fmt "\n"
         |> ignore;
         fn tups'

--- a/bootstrap/test/basis/real/test_of_string.ml
+++ b/bootstrap/test/basis/real/test_of_string.ml
@@ -153,7 +153,7 @@ let test () =
     let r = of_string s in
     File.Fmt.stdout
     |> Fmt.fmt "\t->\t" |> pp r
-    |> Fmt.fmt "\t" |> fmt ~alt:true ~base:Fmt.Hex ~notation:Fmt.Normalized ~precision:13L r
+    |> Fmt.fmt "\t" |> fmt ~alt:true ~radix:Radix.Hex ~notation:Fmt.Normalized ~precision:13L r
     |> Fmt.fmt "\n" |> ignore
   )
 

--- a/bootstrap/test/basis/real/test_pow.ml
+++ b/bootstrap/test/basis/real/test_pow.ml
@@ -10,15 +10,15 @@ let test () =
         let xf = of_sint x in
         File.Fmt.stdout
         |> Fmt.fmt "** pow int_pow "
-        |> fmt ~alt:true ~base:Fmt.Hex b
+        |> fmt ~alt:true ~radix:Radix.Hex b
         |> Fmt.fmt " ~p:"
         |> Sint.pp x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (b ** xf)
+        |> fmt ~alt:true ~radix:Radix.Hex (b ** xf)
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~base:Fmt.Hex (pow b ~p:xf)
+        |> fmt ~alt:true ~radix:Radix.Hex (pow b ~p:xf)
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~base:Fmt.Hex (int_pow b ~p:x)
+        |> fmt ~alt:true ~radix:Radix.Hex (int_pow b ~p:x)
         |> Fmt.fmt "\n"
         |> ignore;
         fn pairs'

--- a/bootstrap/test/basis/real/test_round.ml
+++ b/bootstrap/test/basis/real/test_round.ml
@@ -9,17 +9,17 @@ let test () =
     | t :: ts' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "round "
-        |> fmt ~alt:true ~base:Fmt.Hex t
+        |> fmt ~alt:true ~radix:Radix.Hex t
         |> Fmt.fmt " -> (Down: "
-        |> fmt ~alt:true ~base:Fmt.Hex (round ~dir:Down t)
+        |> fmt ~alt:true ~radix:Radix.Hex (round ~dir:Down t)
         |> Fmt.fmt ") (Up: "
-        |> fmt ~alt:true ~base:Fmt.Hex (round ~dir:Up t)
+        |> fmt ~alt:true ~radix:Radix.Hex (round ~dir:Up t)
         |> Fmt.fmt ") Nearest: "
-        |> fmt ~alt:true ~base:Fmt.Hex (round ~dir:Nearest t)
+        |> fmt ~alt:true ~radix:Radix.Hex (round ~dir:Nearest t)
         |> Fmt.fmt ") ([default]: "
-        |> fmt ~alt:true ~base:Fmt.Hex (round t)
+        |> fmt ~alt:true ~radix:Radix.Hex (round t)
         |> Fmt.fmt ") (Zero: "
-        |> fmt ~alt:true ~base:Fmt.Hex (round ~dir:Zero t)
+        |> fmt ~alt:true ~radix:Radix.Hex (round ~dir:Zero t)
         |> Fmt.fmt ")\n"
         |> ignore;
         fn ts'

--- a/bootstrap/test/basis/string/test_escaped.ml
+++ b/bootstrap/test/basis/string/test_escaped.ml
@@ -8,7 +8,7 @@ let test () =
     | 0x80L -> ()
     | _ -> begin
         File.Fmt.stdout
-        |> Uns.fmt ~alt:true ~zpad:true ~width:2L ~base:Basis.Fmt.Hex i
+        |> Uns.fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex i
         |> Basis.Fmt.fmt " -> \""
         |> fmt (escaped (of_codepoint Codepoint.(trunc_of_uns i)))
         |> Basis.Fmt.fmt "\"\n"

--- a/bootstrap/test/basis/string/test_get.ml
+++ b/bootstrap/test/basis/string/test_get.ml
@@ -17,7 +17,7 @@ let test () =
       | false -> begin
           File.Fmt.stdout
           |> Basis.Fmt.fmt " "
-          |> Byte.fmt ~alt:true ~base:Basis.Fmt.Hex ~pretty:true (B.get i s)
+          |> Byte.fmt ~alt:true ~radix:Radix.Hex ~pretty:true (B.get i s)
           |> ignore;
           fn (Uns.succ i)
         end

--- a/bootstrap/test/basis/text/test_of_bytes_stream_replace.ml
+++ b/bootstrap/test/basis/text/test_of_bytes_stream_replace.ml
@@ -18,7 +18,7 @@ let stream_of_byte_list bl =
 let test () =
   let fn bl = begin
     File.Fmt.stdout
-    |> (List.pp (Byte.fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true)) bl
+    |> (List.pp (Byte.fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true)) bl
     |> Fmt.fmt "\n" |> ignore;
     let text = of_bytes_stream (stream_of_byte_list bl) in
 

--- a/bootstrap/test/basis/u128/test_add_sub.ml
+++ b/bootstrap/test/basis/u128/test_add_sub.ml
@@ -7,13 +7,13 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " +,- "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (x + y)
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (x + y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (x - y)
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (x - y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u128/test_bit_and_bit_or_bit_xor.ml
+++ b/bootstrap/test/basis/u128/test_bit_and_bit_or_bit_xor.ml
@@ -8,15 +8,15 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{and,or,xor} "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (bit_and x y)
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (bit_and x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (bit_or x y)
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (bit_or x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (bit_xor x y)
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (bit_xor x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u128/test_bit_not.ml
+++ b/bootstrap/test/basis/u128/test_bit_not.ml
@@ -8,9 +8,9 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_not "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (bit_not x)
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (bit_not x)
         |> Fmt.fmt "\n"
         |> ignore;
         test xs'

--- a/bootstrap/test/basis/u128/test_bit_pop_bit_clz_bit_ctz.ml
+++ b/bootstrap/test/basis/u128/test_bit_pop_bit_clz_bit_ctz.ml
@@ -8,7 +8,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{pop,clz,ctz} "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Uns.pp (bit_pop x)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/u128/test_constants.ml
+++ b/bootstrap/test/basis/u128/test_constants.ml
@@ -5,13 +5,13 @@ open U128
 let test () =
   File.Fmt.stdout
   |> Fmt.fmt "zero="
-  |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true zero
+  |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true zero
   |> Fmt.fmt "\none="
-  |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true one
+  |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true one
   |> Fmt.fmt "\nmin_value="
-  |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true min_value
+  |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true min_value
   |> Fmt.fmt "\nmax_value="
-  |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true max_value
+  |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true max_value
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/u128/test_div_mod.ml
+++ b/bootstrap/test/basis/u128/test_div_mod.ml
@@ -9,13 +9,13 @@ let test () =
         let quotient = x / y in
         let remainder = x % y in
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " /,% "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true quotient
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true quotient
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true remainder
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true remainder
         |> Fmt.fmt "\n"
         |> ignore;
         assert (x = (y * quotient + remainder));

--- a/bootstrap/test/basis/u128/test_exp.ml
+++ b/bootstrap/test/basis/u128/test_exp.ml
@@ -7,11 +7,11 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " ** "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (x ** y)
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (x ** y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u128/test_floor_lg_ceil_lg.ml
+++ b/bootstrap/test/basis/u128/test_floor_lg_ceil_lg.ml
@@ -8,7 +8,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "floor_lg,ceil_lg "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true u
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
         |> pp (floor_lg u)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/u128/test_floor_pow2_ceil_pow2.ml
+++ b/bootstrap/test/basis/u128/test_floor_pow2_ceil_pow2.ml
@@ -8,11 +8,11 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "floor_pow2,ceil_pow2 "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true u
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (floor_pow2 u)
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (floor_pow2 u)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (ceil_pow2 u)
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (ceil_pow2 u)
         |> Fmt.fmt "\n"
         |> ignore;
         test us'

--- a/bootstrap/test/basis/u128/test_fmt.ml
+++ b/bootstrap/test/basis/u128/test_fmt.ml
@@ -10,7 +10,7 @@ let test () =
           File.Fmt.stdout
           |> pp x
           |> Fmt.fmt " "
-          |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true x
+          |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true x
           |> Fmt.fmt "\n"
         in
         fn xs'

--- a/bootstrap/test/basis/u128/test_hash_fold.ml
+++ b/bootstrap/test/basis/u128/test_hash_fold.ml
@@ -9,7 +9,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true u
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
         |> Hash.pp (Hash.t_of_state (hash_fold u Hash.State.empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/u128/test_is_pow2.ml
+++ b/bootstrap/test/basis/u128/test_is_pow2.ml
@@ -8,7 +8,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "is_pow2 "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true u
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
         |> Bool.pp (is_pow2 u)
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/u128/test_min_max.ml
+++ b/bootstrap/test/basis/u128/test_min_max.ml
@@ -8,13 +8,13 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "min,max "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (min x y)
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (min x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (max x y)
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (max x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u128/test_mul.ml
+++ b/bootstrap/test/basis/u128/test_mul.ml
@@ -8,11 +8,11 @@ let test () =
     | (x, y) :: pairs' -> begin
         let z = x * y in
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " * "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true z
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true z
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u128/test_narrowing.ml
+++ b/bootstrap/test/basis/u128/test_narrowing.ml
@@ -8,15 +8,15 @@ let test () =
   |> Fmt.fmt "max_value + "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (max_value + one)
+  |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (max_value + one)
   |> Fmt.fmt "\nmin_value - "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (min_value - one)
+  |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (min_value - one)
   |> Fmt.fmt "\nmax_value * "
   |> pp fifteen
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (max_value * fifteen)
+  |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (max_value * fifteen)
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/u128/test_of_real_to_real.ml
+++ b/bootstrap/test/basis/u128/test_of_real_to_real.ml
@@ -10,11 +10,11 @@ let test () =
         let x = of_real r in
         File.Fmt.stdout
         |> Fmt.fmt "of_real "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "; to_real -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex (to_real x)
+        |> Real.fmt ~alt:true ~radix:Radix.Hex (to_real x)
         |> Fmt.fmt "\n"
         |> ignore;
         test_rs rs'
@@ -47,11 +47,11 @@ let test () =
         let r = to_real x in
         File.Fmt.stdout
         |> Fmt.fmt "to_real "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt "; of_real -> "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (of_real r)
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (of_real r)
         |> Fmt.fmt "\n"
         |> ignore;
         test_xs xs'

--- a/bootstrap/test/basis/u128/test_of_string.ml
+++ b/bootstrap/test/basis/u128/test_of_string.ml
@@ -10,7 +10,7 @@ let test () =
         |> Fmt.fmt "of_string "
         |> String.pp s
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true (of_string s)
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true (of_string s)
         |> Fmt.fmt "\n"
         |> ignore;
         test_strs strs'

--- a/bootstrap/test/basis/u128/test_pp.ml
+++ b/bootstrap/test/basis/u128/test_pp.ml
@@ -9,7 +9,7 @@ let test () =
         File.Fmt.stdout
         |> pp x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/u128/test_rel.ml
+++ b/bootstrap/test/basis/u128/test_rel.ml
@@ -3,7 +3,7 @@ open! Basis
 open U128
 
 let pp_x x formatter =
-  formatter |> fmt ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true x
+  formatter |> fmt ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true x
 
 let test () =
   let fn x y formatter = begin

--- a/bootstrap/test/basis/u16/test_bit_and_bit_or_bit_xor.ml
+++ b/bootstrap/test/basis/u16/test_bit_and_bit_or_bit_xor.ml
@@ -8,15 +8,15 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{and,or,xor} "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (bit_and x y)
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (bit_and x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (bit_or x y)
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (bit_or x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (bit_xor x y)
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (bit_xor x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u16/test_bit_not.ml
+++ b/bootstrap/test/basis/u16/test_bit_not.ml
@@ -8,9 +8,9 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_not "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (bit_not x)
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (bit_not x)
         |> Fmt.fmt "\n"
         |> ignore;
         test xs'

--- a/bootstrap/test/basis/u16/test_bit_pop_bit_clz_bit_ctz.ml
+++ b/bootstrap/test/basis/u16/test_bit_pop_bit_clz_bit_ctz.ml
@@ -8,7 +8,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{pop,clz,ctz} "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Uns.pp (bit_pop x)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/u16/test_conversion.ml
+++ b/bootstrap/test/basis/u16/test_conversion.ml
@@ -12,13 +12,13 @@ let test () =
         let t' = trunc_of_sint i' in
         File.Fmt.stdout
         |> Fmt.fmt "trunc_of_sint "
-        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true i
+        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> extend_to_sint "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true t
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true t
         |> Fmt.fmt " -> trunc_of_sint "
-        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true i'
+        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true i'
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true t'
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true t'
         |> Fmt.fmt "\n"
         |> ignore;
         let t = trunc_of_uns (Uns.bits_of_sint i) in
@@ -26,13 +26,13 @@ let test () =
         let t' = trunc_of_uns u in
         File.Fmt.stdout
         |> Fmt.fmt "trunc_of_uns "
-        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true x
+        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> extend_to_uns "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true t
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true t
         |> Fmt.fmt " -> trunc_of_uns "
-        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex u
+        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex u
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true t'
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true t'
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/u16/test_exp.ml
+++ b/bootstrap/test/basis/u16/test_exp.ml
@@ -7,11 +7,11 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " ** "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (x ** y)
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (x ** y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u16/test_fmt.ml
+++ b/bootstrap/test/basis/u16/test_fmt.ml
@@ -9,7 +9,7 @@ let test () =
           File.Fmt.stdout
           |> pp x
           |> Fmt.fmt " "
-          |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+          |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
           |> Fmt.fmt "\n"
         in
         fn xs'

--- a/bootstrap/test/basis/u16/test_hash_fold.ml
+++ b/bootstrap/test/basis/u16/test_hash_fold.ml
@@ -9,7 +9,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true u
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
         |> Hash.pp (Hash.t_of_state (hash_fold u Hash.State.empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/u16/test_limits.ml
+++ b/bootstrap/test/basis/u16/test_limits.ml
@@ -7,9 +7,9 @@ let test () =
   |> Fmt.fmt "bit_length="
   |> Uns.pp (bit_pop (bit_not zero))
   |> Fmt.fmt "\nmin_value="
-  |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true min_value
+  |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true min_value
   |> Fmt.fmt "\nmax_value="
-  |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true max_value
+  |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true max_value
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/u16/test_of_real_to_real.ml
+++ b/bootstrap/test/basis/u16/test_of_real_to_real.ml
@@ -10,11 +10,11 @@ let test () =
         let x = of_real r in
         File.Fmt.stdout
         |> Fmt.fmt "of_real "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "; to_real -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex (to_real x)
+        |> Real.fmt ~alt:true ~radix:Radix.Hex (to_real x)
         |> Fmt.fmt "\n"
         |> ignore;
         test_rs rs'
@@ -44,11 +44,11 @@ let test () =
         let r = to_real x in
         File.Fmt.stdout
         |> Fmt.fmt "to_real "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt "; of_real -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (of_real r)
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (of_real r)
         |> Fmt.fmt "\n"
         |> ignore;
         test_xs xs'

--- a/bootstrap/test/basis/u16/test_pp.ml
+++ b/bootstrap/test/basis/u16/test_pp.ml
@@ -9,7 +9,7 @@ let test () =
         File.Fmt.stdout
         |> pp x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/u16/test_rel.ml
+++ b/bootstrap/test/basis/u16/test_rel.ml
@@ -3,7 +3,7 @@ open! Basis
 open U16
 
 let pp_x x formatter =
-  formatter |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true x
+  formatter |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true x
 
 let test () =
   let fn x y formatter = begin

--- a/bootstrap/test/basis/u16/test_wraparound.ml
+++ b/bootstrap/test/basis/u16/test_wraparound.ml
@@ -8,15 +8,15 @@ let test () =
   |> Fmt.fmt "max_value + "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (max_value + one)
+  |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (max_value + one)
   |> Fmt.fmt "\nmin_value - "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (min_value - one)
+  |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (min_value - one)
   |> Fmt.fmt "\nmax_value * "
   |> pp fifteen
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:4L ~base:Fmt.Hex ~pretty:true (max_value * fifteen)
+  |> fmt ~alt:true ~zpad:true ~width:4L ~radix:Radix.Hex ~pretty:true (max_value * fifteen)
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/u256/test_add_sub.ml
+++ b/bootstrap/test/basis/u256/test_add_sub.ml
@@ -7,13 +7,13 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " +,- "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (x + y)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (x + y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (x - y)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (x - y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u256/test_bit_and_bit_or_bit_xor.ml
+++ b/bootstrap/test/basis/u256/test_bit_and_bit_or_bit_xor.ml
@@ -8,15 +8,15 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{and,or,xor} "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (bit_and x y)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (bit_and x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (bit_or x y)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (bit_or x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (bit_xor x y)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (bit_xor x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u256/test_bit_not.ml
+++ b/bootstrap/test/basis/u256/test_bit_not.ml
@@ -8,9 +8,9 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_not "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (bit_not x)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (bit_not x)
         |> Fmt.fmt "\n"
         |> ignore;
         test xs'

--- a/bootstrap/test/basis/u256/test_bit_pop_bit_clz_bit_ctz.ml
+++ b/bootstrap/test/basis/u256/test_bit_pop_bit_clz_bit_ctz.ml
@@ -8,7 +8,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{pop,clz,ctz} "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Uns.pp (bit_pop x)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/u256/test_constants.ml
+++ b/bootstrap/test/basis/u256/test_constants.ml
@@ -5,13 +5,13 @@ open U256
 let test () =
   File.Fmt.stdout
   |> Fmt.fmt "zero="
-  |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true zero
+  |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true zero
   |> Fmt.fmt "\none="
-  |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true one
+  |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true one
   |> Fmt.fmt "\nmin_value="
-  |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true min_value
+  |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true min_value
   |> Fmt.fmt "\nmax_value="
-  |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true max_value
+  |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true max_value
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/u256/test_div_mod.ml
+++ b/bootstrap/test/basis/u256/test_div_mod.ml
@@ -9,13 +9,13 @@ let test () =
         let quotient = x / y in
         let remainder = x % y in
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " /,% "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true quotient
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true quotient
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true remainder
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true remainder
         |> Fmt.fmt "\n"
         |> ignore;
         assert (x = (y * quotient + remainder));

--- a/bootstrap/test/basis/u256/test_exp.ml
+++ b/bootstrap/test/basis/u256/test_exp.ml
@@ -7,11 +7,11 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " ** "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (x ** y)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (x ** y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u256/test_floor_lg_ceil_lg.ml
+++ b/bootstrap/test/basis/u256/test_floor_lg_ceil_lg.ml
@@ -8,7 +8,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "floor_lg,ceil_lg "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true u
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
         |> pp (floor_lg u)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/u256/test_floor_pow2_ceil_pow2.ml
+++ b/bootstrap/test/basis/u256/test_floor_pow2_ceil_pow2.ml
@@ -8,11 +8,11 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "floor_pow2,ceil_pow2 "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true u
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (floor_pow2 u)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (floor_pow2 u)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (ceil_pow2 u)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (ceil_pow2 u)
         |> Fmt.fmt "\n"
         |> ignore;
         test us'

--- a/bootstrap/test/basis/u256/test_fmt.ml
+++ b/bootstrap/test/basis/u256/test_fmt.ml
@@ -10,7 +10,7 @@ let test () =
           File.Fmt.stdout
           |> pp x
           |> Fmt.fmt " "
-          |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+          |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
           |> Fmt.fmt "\n"
         in
         fn xs'

--- a/bootstrap/test/basis/u256/test_hash_fold.ml
+++ b/bootstrap/test/basis/u256/test_hash_fold.ml
@@ -9,7 +9,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true u
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
         |> Hash.pp (Hash.t_of_state (hash_fold u Hash.State.empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/u256/test_is_pow2.ml
+++ b/bootstrap/test/basis/u256/test_is_pow2.ml
@@ -8,7 +8,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "is_pow2 "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true u
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
         |> Bool.pp (is_pow2 u)
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/u256/test_min_max.ml
+++ b/bootstrap/test/basis/u256/test_min_max.ml
@@ -8,13 +8,13 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "min,max "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (min x y)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (min x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (max x y)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (max x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u256/test_mul.ml
+++ b/bootstrap/test/basis/u256/test_mul.ml
@@ -8,11 +8,11 @@ let test () =
     | (x, y) :: pairs' -> begin
         let z = x * y in
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " * "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true z
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true z
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u256/test_narrowing.ml
+++ b/bootstrap/test/basis/u256/test_narrowing.ml
@@ -8,15 +8,15 @@ let test () =
   |> Fmt.fmt "max_value + "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (max_value + one)
+  |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (max_value + one)
   |> Fmt.fmt "\nmin_value - "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (min_value - one)
+  |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (min_value - one)
   |> Fmt.fmt "\nmax_value * "
   |> pp fifteen
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (max_value * fifteen)
+  |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (max_value * fifteen)
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/u256/test_of_real_to_real.ml
+++ b/bootstrap/test/basis/u256/test_of_real_to_real.ml
@@ -10,11 +10,11 @@ let test () =
         let x = of_real r in
         File.Fmt.stdout
         |> Fmt.fmt "of_real "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "; to_real -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex (to_real x)
+        |> Real.fmt ~alt:true ~radix:Radix.Hex (to_real x)
         |> Fmt.fmt "\n"
         |> ignore;
         test_rs rs'
@@ -51,11 +51,11 @@ let test () =
         let r = to_real x in
         File.Fmt.stdout
         |> Fmt.fmt "to_real "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt "; of_real -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (of_real r)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (of_real r)
         |> Fmt.fmt "\n"
         |> ignore;
         test_xs xs'

--- a/bootstrap/test/basis/u256/test_of_string.ml
+++ b/bootstrap/test/basis/u256/test_of_string.ml
@@ -10,7 +10,7 @@ let test () =
         |> Fmt.fmt "of_string "
         |> String.pp s
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true (of_string s)
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true (of_string s)
         |> Fmt.fmt "\n"
         |> ignore;
         test_strs strs'

--- a/bootstrap/test/basis/u256/test_pp.ml
+++ b/bootstrap/test/basis/u256/test_pp.ml
@@ -9,7 +9,7 @@ let test () =
         File.Fmt.stdout
         |> pp x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/u256/test_rel.ml
+++ b/bootstrap/test/basis/u256/test_rel.ml
@@ -3,7 +3,7 @@ open! Basis
 open U256
 
 let pp_x x formatter =
-  formatter |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Hex ~pretty:true x
+  formatter |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Hex ~pretty:true x
 
 let test () =
   let fn x y formatter = begin

--- a/bootstrap/test/basis/u32/test_bit_and_bit_or_bit_xor.ml
+++ b/bootstrap/test/basis/u32/test_bit_and_bit_or_bit_xor.ml
@@ -8,15 +8,15 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{and,or,xor} "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (bit_and x y)
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (bit_and x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (bit_or x y)
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (bit_or x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (bit_xor x y)
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (bit_xor x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u32/test_bit_not.ml
+++ b/bootstrap/test/basis/u32/test_bit_not.ml
@@ -8,9 +8,9 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_not "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (bit_not x)
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (bit_not x)
         |> Fmt.fmt "\n"
         |> ignore;
         test xs'

--- a/bootstrap/test/basis/u32/test_bit_pop_bit_clz_bit_ctz.ml
+++ b/bootstrap/test/basis/u32/test_bit_pop_bit_clz_bit_ctz.ml
@@ -8,7 +8,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{pop,clz,ctz} "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Uns.pp (bit_pop x)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/u32/test_conversion.ml
+++ b/bootstrap/test/basis/u32/test_conversion.ml
@@ -12,13 +12,13 @@ let test () =
         let t' = trunc_of_sint i' in
         File.Fmt.stdout
         |> Fmt.fmt "trunc_of_sint "
-        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true i
+        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> extend_to_sint "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true t
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true t
         |> Fmt.fmt " -> trunc_of_sint "
-        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true i'
+        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true i'
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true t'
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true t'
         |> Fmt.fmt "\n"
         |> ignore;
         let t = trunc_of_uns (Uns.bits_of_sint i) in
@@ -26,13 +26,13 @@ let test () =
         let t' = trunc_of_uns u in
         File.Fmt.stdout
         |> Fmt.fmt "trunc_of_uns "
-        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex x
+        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex x
         |> Fmt.fmt " -> extend_to_uns "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true t
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true t
         |> Fmt.fmt " -> trunc_of_uns "
-        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex u
+        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex u
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true t'
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true t'
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/u32/test_exp.ml
+++ b/bootstrap/test/basis/u32/test_exp.ml
@@ -7,11 +7,11 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " ** "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (x ** y)
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (x ** y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u32/test_fmt.ml
+++ b/bootstrap/test/basis/u32/test_fmt.ml
@@ -10,7 +10,7 @@ let test () =
           File.Fmt.stdout
           |> pp x
           |> Fmt.fmt " "
-          |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+          |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
           |> Fmt.fmt "\n"
         in
         fn xs'

--- a/bootstrap/test/basis/u32/test_hash_fold.ml
+++ b/bootstrap/test/basis/u32/test_hash_fold.ml
@@ -9,7 +9,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true u
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
         |> Hash.pp (Hash.t_of_state (hash_fold u Hash.State.empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/u32/test_limits.ml
+++ b/bootstrap/test/basis/u32/test_limits.ml
@@ -7,9 +7,9 @@ let test () =
   |> Fmt.fmt "bit_length="
   |> Uns.pp (bit_pop (bit_not zero))
   |> Fmt.fmt "\nmin_value="
-  |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true min_value
+  |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true min_value
   |> Fmt.fmt "\nmax_value="
-  |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true max_value
+  |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true max_value
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/u32/test_of_real_to_real.ml
+++ b/bootstrap/test/basis/u32/test_of_real_to_real.ml
@@ -10,11 +10,11 @@ let test () =
         let x = of_real r in
         File.Fmt.stdout
         |> Fmt.fmt "of_real "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "; to_real -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex (to_real x)
+        |> Real.fmt ~alt:true ~radix:Radix.Hex (to_real x)
         |> Fmt.fmt "\n"
         |> ignore;
         test_rs rs'
@@ -44,11 +44,11 @@ let test () =
         let r = to_real x in
         File.Fmt.stdout
         |> Fmt.fmt "to_real "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt "; of_real -> "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (of_real r)
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (of_real r)
         |> Fmt.fmt "\n"
         |> ignore;
         test_xs xs'

--- a/bootstrap/test/basis/u32/test_pp.ml
+++ b/bootstrap/test/basis/u32/test_pp.ml
@@ -9,7 +9,7 @@ let test () =
         File.Fmt.stdout
         |> pp x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/u32/test_rel.ml
+++ b/bootstrap/test/basis/u32/test_rel.ml
@@ -3,7 +3,7 @@ open! Basis
 open U32
 
 let pp_x x formatter =
-  formatter |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+  formatter |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
 
 let test () =
   let fn x y formatter = begin

--- a/bootstrap/test/basis/u32/test_wraparound.ml
+++ b/bootstrap/test/basis/u32/test_wraparound.ml
@@ -8,15 +8,15 @@ let test () =
   |> Fmt.fmt "max_value + "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (max_value + one)
+  |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (max_value + one)
   |> Fmt.fmt "\nmin_value - "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (min_value - one)
+  |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (min_value - one)
   |> Fmt.fmt "\nmax_value * "
   |> pp fifteen
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true (max_value * fifteen)
+  |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true (max_value * fifteen)
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/u64/test_bit_and_bit_or_bit_xor.ml
+++ b/bootstrap/test/basis/u64/test_bit_and_bit_or_bit_xor.ml
@@ -8,15 +8,15 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{and,or,xor} "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex x
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex y
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex (bit_and x y)
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex (bit_and x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex (bit_or x y)
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex (bit_or x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex (bit_xor x y)
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex (bit_xor x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u64/test_bit_not.ml
+++ b/bootstrap/test/basis/u64/test_bit_not.ml
@@ -8,9 +8,9 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_not "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex x
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex (bit_not x)
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex (bit_not x)
         |> Fmt.fmt "\n"
         |> ignore;
         test xs'

--- a/bootstrap/test/basis/u64/test_bit_pop_bit_clz_bit_ctz.ml
+++ b/bootstrap/test/basis/u64/test_bit_pop_bit_clz_bit_ctz.ml
@@ -8,7 +8,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{pop,clz,ctz} "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex u
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex u
         |> Fmt.fmt " -> "
         |> Uns.pp (bit_pop u)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/u64/test_exp.ml
+++ b/bootstrap/test/basis/u64/test_exp.ml
@@ -7,11 +7,11 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex x
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex x
         |> Fmt.fmt " ** "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex y
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex (x ** y)
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex (x ** y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u64/test_fmt.ml
+++ b/bootstrap/test/basis/u64/test_fmt.ml
@@ -13,9 +13,9 @@ let test () =
     | x :: xs' -> begin
         List.fold ~init:(
           formatter
-          |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex x
+          |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex x
           |> Fmt.fmt "\n"
-        ) [Fmt.Bin; Fmt.Oct; Fmt.Dec; Fmt.Hex] ~f:(fun formatter base ->
+        ) [Radix.Bin; Radix.Oct; Radix.Dec; Radix.Hex] ~f:(fun formatter radix ->
           List.fold ~init:formatter [Fmt.Implicit; Fmt.Explicit; Fmt.Space]
             ~f:(fun formatter sign ->
               List.fold ~init:formatter [false; true] ~f:(fun formatter alt ->
@@ -27,7 +27,7 @@ let test () =
                         |> Fmt.fmt "["
                         |> Fmt.fmt ~pad:"_" ~width:74L (
                           String.Fmt.empty
-                          |> fmt ~pad:"·" ~just ~sign ~alt ~zpad ~width ~base x
+                          |> fmt ~pad:"·" ~just ~sign ~alt ~zpad ~width ~radix x
                           |> Fmt.to_string
                         )
                         |> Fmt.fmt "] %'·'"
@@ -47,11 +47,11 @@ let test () =
                         |> Fmt.fmt (match zpad with false -> "" | true -> "0")
                         |> (match width with 0L -> Fmt.fmt "" | _ -> fmt width)
                         |> Fmt.fmt (
-                          match base with
-                          | Fmt.Bin -> "b"
-                          | Fmt.Oct -> "o"
-                          | Fmt.Dec -> "d"
-                          | Fmt.Hex -> "h"
+                          match radix with
+                          | Radix.Bin -> "b"
+                          | Radix.Oct -> "o"
+                          | Radix.Dec -> "d"
+                          | Radix.Hex -> "h"
                         )
                         |> Fmt.fmt "\n"
                       )
@@ -76,7 +76,7 @@ let test () =
   in
   File.Fmt.stdout
   |> Fmt.fmt (match verbose with true -> output | false -> "")
-  |> Fmt.fmt (U128.to_string ~alt:true ~zpad:true ~width:32L ~base:Fmt.Hex ~pretty:true
+  |> Fmt.fmt (U128.to_string ~alt:true ~zpad:true ~width:32L ~radix:Radix.Hex ~pretty:true
       (Hash.State.empty |> String.hash_fold output |> Hash.t_of_state))
 
 let _ = test ()

--- a/bootstrap/test/basis/u64/test_hash_fold.ml
+++ b/bootstrap/test/basis/u64/test_hash_fold.ml
@@ -9,7 +9,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex u
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex u
         |> Fmt.fmt " -> "
         |> Hash.pp (Hash.t_of_state (hash_fold u Hash.State.empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/u64/test_limits.ml
+++ b/bootstrap/test/basis/u64/test_limits.ml
@@ -5,9 +5,9 @@ open U64
 let test () =
   File.Fmt.stdout
   |> Fmt.fmt "min_value="
-  |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex min_value
+  |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex min_value
   |> Fmt.fmt "\nmax_value="
-  |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex max_value
+  |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex max_value
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/u64/test_narrowing.ml
+++ b/bootstrap/test/basis/u64/test_narrowing.ml
@@ -8,15 +8,15 @@ let test () =
   |> Fmt.fmt "max_value + "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex (max_value + one)
+  |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex (max_value + one)
   |> Fmt.fmt "\nmin_value - "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex (min_value - one)
+  |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex (min_value - one)
   |> Fmt.fmt "\nmax_value * "
   |> pp fifteen
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex (max_value * fifteen)
+  |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex (max_value * fifteen)
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/u64/test_of_real_to_real.ml
+++ b/bootstrap/test/basis/u64/test_of_real_to_real.ml
@@ -10,11 +10,11 @@ let test () =
         let x = of_real r in
         File.Fmt.stdout
         |> Fmt.fmt "of_real "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex x
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex x
         |> Fmt.fmt "; to_real -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex (to_real x)
+        |> Real.fmt ~alt:true ~radix:Radix.Hex (to_real x)
         |> Fmt.fmt "\n"
         |> ignore;
         test_rs rs'
@@ -47,11 +47,11 @@ let test () =
         let r = to_real x in
         File.Fmt.stdout
         |> Fmt.fmt "to_real "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex x
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex x
         |> Fmt.fmt " -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt "; of_real -> "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex (of_real r)
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex (of_real r)
         |> Fmt.fmt "\n"
         |> ignore;
         test_xs xs'

--- a/bootstrap/test/basis/u64/test_pp.ml
+++ b/bootstrap/test/basis/u64/test_pp.ml
@@ -7,13 +7,13 @@ let test () =
     | [] -> ()
     | x :: xs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:64L ~base:Fmt.Bin x
+        |> fmt ~alt:true ~zpad:true ~width:64L ~radix:Radix.Bin x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~base:Fmt.Oct x
+        |> fmt ~alt:true ~radix:Radix.Oct x
         |> Fmt.fmt " "
         |> pp x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex x
+        |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex x
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/u64/test_rel.ml
+++ b/bootstrap/test/basis/u64/test_rel.ml
@@ -3,7 +3,7 @@ open! Basis
 open U64
 
 let pp_x x formatter =
-  formatter |> fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex x
+  formatter |> fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex x
 
 let test () =
   let fn x y formatter = begin

--- a/bootstrap/test/basis/u8/test_bit_and_bit_or_bit_xor.ml
+++ b/bootstrap/test/basis/u8/test_bit_and_bit_or_bit_xor.ml
@@ -8,15 +8,15 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{and,or,xor} "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (bit_and x y)
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (bit_and x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (bit_or x y)
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (bit_or x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (bit_xor x y)
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (bit_xor x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u8/test_bit_not.ml
+++ b/bootstrap/test/basis/u8/test_bit_not.ml
@@ -8,9 +8,9 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_not "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (bit_not x)
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (bit_not x)
         |> Fmt.fmt "\n"
         |> ignore;
         test xs'

--- a/bootstrap/test/basis/u8/test_bit_pop_bit_clz_bit_ctz.ml
+++ b/bootstrap/test/basis/u8/test_bit_pop_bit_clz_bit_ctz.ml
@@ -8,7 +8,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{pop,clz,ctz} "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
         |> Uns.pp (bit_pop x)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/u8/test_conversion.ml
+++ b/bootstrap/test/basis/u8/test_conversion.ml
@@ -12,13 +12,13 @@ let test () =
         let t' = trunc_of_sint i' in
         File.Fmt.stdout
         |> Fmt.fmt "trunc_of_sint "
-        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true i
+        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> extend_to_sint "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true t
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true t
         |> Fmt.fmt " -> trunc_of_sint "
         |> Sint.pp i
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true t'
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true t'
         |> Fmt.fmt "\n"
         |> ignore;
         let t = trunc_of_uns (Uns.bits_of_sint i) in
@@ -26,13 +26,13 @@ let test () =
         let t' = trunc_of_uns u in
         File.Fmt.stdout
         |> Fmt.fmt "trunc_of_uns "
-        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true i
+        |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true i
         |> Fmt.fmt " -> extend_to_uns "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true t
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true t
         |> Fmt.fmt " -> trunc_of_uns "
-        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex u
+        |> Uns.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex u
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true t'
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true t'
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/u8/test_exp.ml
+++ b/bootstrap/test/basis/u8/test_exp.ml
@@ -7,11 +7,11 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " ** "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true y
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (x ** y)
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (x ** y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/u8/test_fmt.ml
+++ b/bootstrap/test/basis/u8/test_fmt.ml
@@ -8,13 +8,13 @@ let test () =
     | x :: xs' -> begin
         let _ =
           File.Fmt.stdout
-          |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Bin ~pretty:true x
+          |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Bin ~pretty:true x
           |> Fmt.fmt ", "
-          |> fmt ~alt:true ~zpad:true ~width:3L ~base:Fmt.Oct ~pretty:true x
+          |> fmt ~alt:true ~zpad:true ~width:3L ~radix:Radix.Oct ~pretty:true x
           |> Fmt.fmt ", "
           |> pp x
           |> Fmt.fmt ", "
-          |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+          |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
           |> Fmt.fmt "\n"
         in
         fn xs'

--- a/bootstrap/test/basis/u8/test_hash_fold.ml
+++ b/bootstrap/test/basis/u8/test_hash_fold.ml
@@ -9,7 +9,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true u
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
         |> Hash.pp (Hash.t_of_state (hash_fold u Hash.State.empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/u8/test_limits.ml
+++ b/bootstrap/test/basis/u8/test_limits.ml
@@ -7,9 +7,9 @@ let test () =
   |> Fmt.fmt "bit_length="
   |> Uns.pp (bit_pop (bit_not zero))
   |> Fmt.fmt "\nmin_value="
-  |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true min_value
+  |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true min_value
   |> Fmt.fmt "\nmax_value="
-  |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true max_value
+  |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true max_value
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/u8/test_of_real_to_real.ml
+++ b/bootstrap/test/basis/u8/test_of_real_to_real.ml
@@ -10,11 +10,11 @@ let test () =
         let x = of_real r in
         File.Fmt.stdout
         |> Fmt.fmt "of_real "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "; to_real -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex (to_real x)
+        |> Real.fmt ~alt:true ~radix:Radix.Hex (to_real x)
         |> Fmt.fmt "\n"
         |> ignore;
         test_rs rs'
@@ -44,11 +44,11 @@ let test () =
         let r = to_real x in
         File.Fmt.stdout
         |> Fmt.fmt "to_real "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt "; of_real -> "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (of_real r)
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (of_real r)
         |> Fmt.fmt "\n"
         |> ignore;
         test_xs xs'

--- a/bootstrap/test/basis/u8/test_pp.ml
+++ b/bootstrap/test/basis/u8/test_pp.ml
@@ -8,13 +8,13 @@ let test () =
     | [] -> ()
     | x :: xs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Bin ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Bin ~pretty:true x
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:3L ~base:Fmt.Oct ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:3L ~radix:Radix.Oct ~pretty:true x
         |> Fmt.fmt ", "
         |> pp x
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "\n"
         |> ignore;
         print_xs xs'
@@ -33,7 +33,7 @@ let test2 () =
         File.Fmt.stdout
         |> pp x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/u8/test_rel.ml
+++ b/bootstrap/test/basis/u8/test_rel.ml
@@ -3,7 +3,7 @@ open! Basis
 open U8
 
 let pp_x x formatter =
-  formatter |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true x
+  formatter |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true x
 
 let test () =
   let fn x y formatter = begin

--- a/bootstrap/test/basis/u8/test_wraparound.ml
+++ b/bootstrap/test/basis/u8/test_wraparound.ml
@@ -8,15 +8,15 @@ let test () =
   |> Fmt.fmt "max_value + "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (max_value + one)
+  |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (max_value + one)
   |> Fmt.fmt "\nmin_value - "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (min_value - one)
+  |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (min_value - one)
   |> Fmt.fmt "\nmax_value * "
   |> pp fifteen
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~zpad:true ~width:2L ~base:Fmt.Hex ~pretty:true (max_value * fifteen)
+  |> fmt ~alt:true ~zpad:true ~width:2L ~radix:Radix.Hex ~pretty:true (max_value * fifteen)
   |> Fmt.fmt "\n"
   |> ignore
 

--- a/bootstrap/test/basis/zint/test_add_sub.ml
+++ b/bootstrap/test/basis/zint/test_add_sub.ml
@@ -8,13 +8,13 @@ let test () =
     | (x, y) :: pairs' -> begin
 
         File.Fmt.stdout
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " +,- "
-        |> fmt ~alt:true ~base:Fmt.Hex y
+        |> fmt ~alt:true ~radix:Radix.Hex y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (x + y)
+        |> fmt ~alt:true ~radix:Radix.Hex (x + y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~base:Fmt.Hex (x - y)
+        |> fmt ~alt:true ~radix:Radix.Hex (x - y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/zint/test_bit_and_bit_or_bit_xor.ml
+++ b/bootstrap/test/basis/zint/test_bit_and_bit_or_bit_xor.ml
@@ -8,15 +8,15 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_{and,or,xor} "
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~base:Fmt.Hex y
+        |> fmt ~alt:true ~radix:Radix.Hex y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (bit_and x y)
+        |> fmt ~alt:true ~radix:Radix.Hex (bit_and x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~base:Fmt.Hex (bit_or x y)
+        |> fmt ~alt:true ~radix:Radix.Hex (bit_or x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~base:Fmt.Hex (bit_xor x y)
+        |> fmt ~alt:true ~radix:Radix.Hex (bit_xor x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/zint/test_bit_not.ml
+++ b/bootstrap/test/basis/zint/test_bit_not.ml
@@ -8,9 +8,9 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_not "
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (bit_not x)
+        |> fmt ~alt:true ~radix:Radix.Hex (bit_not x)
         |> Fmt.fmt "\n"
         |> ignore;
         test xs'

--- a/bootstrap/test/basis/zint/test_bit_pop_bit_clz_bit_ctz.ml
+++ b/bootstrap/test/basis/zint/test_bit_pop_bit_clz_bit_ctz.ml
@@ -8,7 +8,7 @@ let test () =
     | x :: xs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "bit_length, bit_{pop,clz,ctz} "
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " -> "
         |> Uns.fmt (bit_length x)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/zint/test_div_mod.ml
+++ b/bootstrap/test/basis/zint/test_div_mod.ml
@@ -9,13 +9,13 @@ let test () =
         let quotient = x / y in
         let remainder = x % y in
         File.Fmt.stdout
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " /,% "
-        |> fmt ~alt:true ~base:Fmt.Hex y
+        |> fmt ~alt:true ~radix:Radix.Hex y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex quotient
+        |> fmt ~alt:true ~radix:Radix.Hex quotient
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~base:Fmt.Hex remainder
+        |> fmt ~alt:true ~radix:Radix.Hex remainder
         |> Fmt.fmt "\n"
         |> ignore;
         assert (x = (y * quotient + remainder));

--- a/bootstrap/test/basis/zint/test_exp.ml
+++ b/bootstrap/test/basis/zint/test_exp.ml
@@ -7,11 +7,11 @@ let test () =
     | [] -> ()
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " ** "
-        |> fmt ~alt:true ~base:Fmt.Hex y
+        |> fmt ~alt:true ~radix:Radix.Hex y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (x ** y)
+        |> fmt ~alt:true ~radix:Radix.Hex (x ** y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/zint/test_floor_lg_ceil_lg.ml
+++ b/bootstrap/test/basis/zint/test_floor_lg_ceil_lg.ml
@@ -8,7 +8,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "floor_lg,ceil_lg "
-        |> fmt ~alt:true ~base:Fmt.Hex ~pretty:true u
+        |> fmt ~alt:true ~radix:Radix.Hex ~pretty:true u
         |> Fmt.fmt " -> "
         |> pp (floor_lg u)
         |> Fmt.fmt ", "

--- a/bootstrap/test/basis/zint/test_floor_pow2_ceil_pow2.ml
+++ b/bootstrap/test/basis/zint/test_floor_pow2_ceil_pow2.ml
@@ -8,11 +8,11 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "floor_pow2,ceil_pow2 "
-        |> fmt ~alt:true ~base:Fmt.Hex u
+        |> fmt ~alt:true ~radix:Radix.Hex u
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (floor_pow2 u)
+        |> fmt ~alt:true ~radix:Radix.Hex (floor_pow2 u)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~base:Fmt.Hex (ceil_pow2 u)
+        |> fmt ~alt:true ~radix:Radix.Hex (ceil_pow2 u)
         |> Fmt.fmt "\n"
         |> ignore;
         test us'

--- a/bootstrap/test/basis/zint/test_hash_fold.ml
+++ b/bootstrap/test/basis/zint/test_hash_fold.ml
@@ -9,7 +9,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "hash_fold "
-        |> fmt ~alt:true ~base:Fmt.Hex u
+        |> fmt ~alt:true ~radix:Radix.Hex u
         |> Fmt.fmt " -> "
         |> Hash.pp (Hash.t_of_state (hash_fold u Hash.State.empty))
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/zint/test_is_pow2.ml
+++ b/bootstrap/test/basis/zint/test_is_pow2.ml
@@ -8,7 +8,7 @@ let test () =
     | u :: us' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "is_pow2 "
-        |> fmt ~alt:true ~base:Fmt.Hex u
+        |> fmt ~alt:true ~radix:Radix.Hex u
         |> Fmt.fmt " -> "
         |> Bool.fmt (is_pow2 u)
         |> Fmt.fmt "\n"

--- a/bootstrap/test/basis/zint/test_min_max.ml
+++ b/bootstrap/test/basis/zint/test_min_max.ml
@@ -8,13 +8,13 @@ let test () =
     | (x, y) :: pairs' -> begin
         File.Fmt.stdout
         |> Fmt.fmt "min,max "
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~base:Fmt.Hex y
+        |> fmt ~alt:true ~radix:Radix.Hex y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (min x y)
+        |> fmt ~alt:true ~radix:Radix.Hex (min x y)
         |> Fmt.fmt ", "
-        |> fmt ~alt:true ~base:Fmt.Hex (max x y)
+        |> fmt ~alt:true ~radix:Radix.Hex (max x y)
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/zint/test_mul.ml
+++ b/bootstrap/test/basis/zint/test_mul.ml
@@ -8,11 +8,11 @@ let test () =
     | (x, y) :: pairs' -> begin
         let z = (x * y) in
         File.Fmt.stdout
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " * "
-        |> fmt ~alt:true ~base:Fmt.Hex y
+        |> fmt ~alt:true ~radix:Radix.Hex y
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex z
+        |> fmt ~alt:true ~radix:Radix.Hex z
         |> Fmt.fmt "\n"
         |> ignore;
         test_pairs pairs'

--- a/bootstrap/test/basis/zint/test_neg_abs.ml
+++ b/bootstrap/test/basis/zint/test_neg_abs.ml
@@ -9,11 +9,11 @@ let test () =
         let fn u = begin
           File.Fmt.stdout
           |> Fmt.fmt "neg,abs "
-          |> fmt ~alt:true ~base:Fmt.Hex u
+          |> fmt ~alt:true ~radix:Radix.Hex u
           |> Fmt.fmt " -> "
-          |> fmt ~alt:true ~base:Fmt.Hex (neg u)
+          |> fmt ~alt:true ~radix:Radix.Hex (neg u)
           |> Fmt.fmt ", "
-          |> fmt ~alt:true ~base:Fmt.Hex (abs u)
+          |> fmt ~alt:true ~radix:Radix.Hex (abs u)
           |> Fmt.fmt "\n"
           |> ignore
         end in

--- a/bootstrap/test/basis/zint/test_of_real_to_real.ml
+++ b/bootstrap/test/basis/zint/test_of_real_to_real.ml
@@ -10,11 +10,11 @@ let test () =
         let x = of_real r in
         File.Fmt.stdout
         |> Fmt.fmt "of_real "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt "; to_real -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex (to_real x)
+        |> Real.fmt ~alt:true ~radix:Radix.Hex (to_real x)
         |> Fmt.fmt "\n"
         |> ignore;
         test_rs rs'
@@ -52,11 +52,11 @@ let test () =
         let r = to_real x in
         File.Fmt.stdout
         |> Fmt.fmt "to_real "
-        |> fmt ~alt:true ~base:Fmt.Hex x
+        |> fmt ~alt:true ~radix:Radix.Hex x
         |> Fmt.fmt " -> "
-        |> Real.fmt ~alt:true ~base:Fmt.Hex r
+        |> Real.fmt ~alt:true ~radix:Radix.Hex r
         |> Fmt.fmt "; of_real -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (of_real r)
+        |> fmt ~alt:true ~radix:Radix.Hex (of_real r)
         |> Fmt.fmt "\n"
         |> ignore;
         test_xs xs'

--- a/bootstrap/test/basis/zint/test_of_string.ml
+++ b/bootstrap/test/basis/zint/test_of_string.ml
@@ -10,7 +10,7 @@ let test () =
         |> Fmt.fmt "of_string "
         |> String.pp s
         |> Fmt.fmt " -> "
-        |> fmt ~alt:true ~base:Fmt.Hex (of_string s)
+        |> fmt ~alt:true ~radix:Radix.Hex (of_string s)
         |> Fmt.fmt "\n"
         |> ignore;
         test_strs strs'

--- a/bootstrap/test/basis/zint/test_pp.ml
+++ b/bootstrap/test/basis/zint/test_pp.ml
@@ -7,15 +7,15 @@ let test () =
     | [] -> ()
     | x :: xs' -> begin
         File.Fmt.stdout
-        |> fmt ~alt:true ~base:Fmt.Bin ~pretty:true x
+        |> fmt ~alt:true ~radix:Radix.Bin ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~base:Fmt.Oct ~pretty:true x
+        |> fmt ~alt:true ~radix:Radix.Oct ~pretty:true x
         |> Fmt.fmt " "
         |> pp x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt " "
-        |> fmt ~alt:true ~zpad:true ~width:8L ~base:Fmt.Hex ~pretty:true x
+        |> fmt ~alt:true ~zpad:true ~width:8L ~radix:Radix.Hex ~pretty:true x
         |> Fmt.fmt "\n"
         |> ignore;
         fn xs'

--- a/bootstrap/test/basis/zint/test_rel.ml
+++ b/bootstrap/test/basis/zint/test_rel.ml
@@ -3,7 +3,7 @@ open! Basis
 open Zint
 
 let pp_x u formatter =
-  formatter |> fmt ~alt:true ~base:Fmt.Hex u
+  formatter |> fmt ~alt:true ~radix:Radix.Hex u
 
 let test () =
   let fn x y formatter = begin

--- a/bootstrap/test/basis/zint/test_to_i64_to_sint.ml
+++ b/bootstrap/test/basis/zint/test_to_i64_to_sint.ml
@@ -9,11 +9,11 @@ let test () =
         let fn u = begin
           File.Fmt.stdout
           |> Fmt.fmt "to_i64,to_sint "
-          |> fmt ~alt:true ~base:Fmt.Hex ~pretty:true u
+          |> fmt ~alt:true ~radix:Radix.Hex ~pretty:true u
           |> Fmt.fmt " -> "
-          |> I64.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true (to_i64 u)
+          |> I64.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true (to_i64 u)
           |> Fmt.fmt ", "
-          |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~base:Fmt.Hex ~pretty:true (to_sint u)
+          |> Sint.fmt ~alt:true ~zpad:true ~width:16L ~radix:Radix.Hex ~pretty:true (to_sint u)
           |> Fmt.fmt "\n"
           |> ignore
         end in

--- a/bootstrap/test/basis/zint/test_widening.ml
+++ b/bootstrap/test/basis/zint/test_widening.ml
@@ -7,7 +7,7 @@ let test () =
   let fifteen = of_string "15" in
   File.Fmt.stdout
   |> Fmt.fmt "u64_max -> "
-  |> fmt ~alt:true ~base:Fmt.Hex ~pretty:true u64_max
+  |> fmt ~alt:true ~radix:Radix.Hex ~pretty:true u64_max
   |> Fmt.fmt "\n"
   |> ignore;
 
@@ -16,7 +16,7 @@ let test () =
   |> Fmt.fmt "u64_max + "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~base:Fmt.Hex ~pretty:true r
+  |> fmt ~alt:true ~radix:Radix.Hex ~pretty:true r
   |> Fmt.fmt " "
   |> pp r
   |> Fmt.fmt "\n"
@@ -28,7 +28,7 @@ let test () =
   |> Fmt.fmt " - "
   |> pp one
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~base:Fmt.Hex ~pretty:true r
+  |> fmt ~alt:true ~radix:Radix.Hex ~pretty:true r
   |> Fmt.fmt " "
   |> pp r
   |> Fmt.fmt "\n"
@@ -39,7 +39,7 @@ let test () =
   |> Fmt.fmt "u64_max * "
   |> pp fifteen
   |> Fmt.fmt " -> "
-  |> fmt ~alt:true ~base:Fmt.Hex ~pretty:true r
+  |> fmt ~alt:true ~radix:Radix.Hex ~pretty:true r
   |> Fmt.fmt " "
   |> pp r
   |> Fmt.fmt "\n"

--- a/bootstrap/test/hmc/realer/test_to_r.ml
+++ b/bootstrap/test/hmc/realer/test_to_r.ml
@@ -61,11 +61,11 @@ let test () =
     |> Fmt.fmt "  to_r64 -> "
     |> Fmt.fmt (prec_s prec64)
     |> Fmt.fmt " "
-    |> Real.fmt ~precision:13L ~notation:Fmt.Normalized ~base:Fmt.Hex r64
+    |> Real.fmt ~precision:13L ~notation:Fmt.Normalized ~radix:Radix.Hex r64
     |> Fmt.fmt "\n  to_r32 -> "
     |> Fmt.fmt (prec_s prec32)
     |> Fmt.fmt " "
-    |> Real.fmt ~precision:6L ~notation:Fmt.Normalized ~base:Fmt.Hex r32
+    |> Real.fmt ~precision:6L ~notation:Fmt.Normalized ~radix:Radix.Hex r32
     |> Fmt.fmt "\n"
     |> ignore;
   )

--- a/doc/design/syntax.md
+++ b/doc/design/syntax.md
@@ -192,7 +192,7 @@ special in that it creates no lexical binding at all.
 ### Integer
 
 Integers are either signed or unsigned, though a leading sign is always a separate token. Integer
-literals may be specified in any of four bases, as determined by optional base prefix:
+literals may be specified in any of four radixes, as determined by optional radix prefix:
 
 - `0b`: Binary, where digits are in `[01]`.
 - `0o`: Octal, where digits are in `[0-7]`.
@@ -262,21 +262,21 @@ ways:
 - Type suffix
 
 Reals are signed, though a leading sign is always a separate token. Real number literal mantissas
-may be specified in any of four bases, as determined by optional base prefix:
+may be specified in any of four radixes, as determined by optional radix prefix:
 
 - `0b`: Binary, where digits are in `[01]`. All well formed binary literals have bit-precise machine
   representations.
 - `0o`: Octal, where digits are in `[0-7]`. All well formed octal literals have bit-precise machine
   representations.
 - Default: Decimal, where digits are in `[0-9]`. Not all decimal-format literals have bit-precise
-  machine representations; favor the other bases if this is of significance to the application.
+  machine representations; favor the other radixes if this is of significance to the application.
 - `0x`: Hexadecimal, where digits are in `[0-9a-f]`. All well formed hexadecimal literals have
   bit-precise machine representations.
 
 Optional signed exponents are separated from a binary/octal/hexadecimal mantissa by a `p` codepoint,
 or from a decimal mantissa by an `e` codepoint. The optional exponent sign is in `[-+]`. The
-exponent is always expressed as a decimal value, where digits are in `[0-9]`, but the implicit base
-of the exponent depends on the mantissa's base prefix:
+exponent is always expressed as a decimal value, where digits are in `[0-9]`, but the implicit radix
+of the exponent depends on the mantissa's radix prefix:
 
 - Binary (`0b<mantissa>p<exponent>`): *mantissa<sub>2</sub>* × 2<sup>*exponent<sub>10</sub>*</sup>
 - Octal (`0o<mantissa>p<exponent>`): *mantissa<sub>8</sub>* × 2<sup>*exponent<sub>10</sub>*</sup>
@@ -494,7 +494,7 @@ context:
 
   Format specifiers are of the form:
   ```
-  %['<pad>'][<just>][<sign>][<alt>][<zpad>][<width>][.=?<precision>][<base>][<notation>][<pretty>][<type>](^...^)
+  %['<pad>'][<just>][<sign>][<alt>][<zpad>][<width>][.=?<precision>][<radix>][<notation>][<pretty>][<type>](^...^)
   ```
   + `'<pad>'` (`?pad:codepoint`): Pad with specified codepoint (default: `' '`; complete codepoint
     literal syntax supported)
@@ -506,7 +506,7 @@ context:
     * `+`: Explicit sign, even when positive
     * `_`: Space in place of sign if sign is non-negative
   + `<alt>` (`?alt:bool`): `#` enables alternate formatting (default: `false`)
-    * Numeric types: Prefix with base, separate digit groups with `_`
+    * Numeric types: Prefix with radix, separate digit groups with `_`
       - Binary: `0b` prefix, groups of 8
       - Octal: `0o` prefix, groups of 3
       - Decimal: No prefix, groups of 3
@@ -526,14 +526,14 @@ context:
     * `.=3`: Fixed precision
     * `.3`: Limited precision
     * `.*`: Parametric limited precision in digits, e.g. `%*(^width^).*(^precision^)r(^some_r^)`
-  + `<base>` (`?base:Fmt.base`): Numerical base (default: `Fmt.Dec`)
+  + `<radix>` (`?radix:Radix.t`): Numerical radix (default: `Radix.Dec`)
     * `b`: Binary
     * `o`: Octal
     * `d`: Decimal
     * `x`: Hexadecimal
   + `<notation>` (`?notation:Fmt.notation`): Real-specific notation (default: `Fmt.Compact`)
     * `m`: Normalized scientific form, i.e. decimal exponential or binary floating point notation
-      (mnemonic: Mantissa × base <sup>exponent</sup>)
+      (mnemonic: Mantissa × radix <sup>exponent</sup>)
     * `a`: Radix point form (mnemonic: rAdix point)
     * `c`: Trailing zeros omitted, and the radix point omitted in normalized form unless followed by
       non-zero mantissa digits (mnemonic: Compact)


### PR DESCRIPTION
Consolidate the three identical `base` types in `Fmt`, `Scan`, and `Real` into
`Radix.t`, and rename the `~base` formatting parameter to `~radix`. This has the
side benefit of avoiding confusion between `radix` and `base`/`past`.