### PR TITLE
Move default docker build args to Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG HEMLOCK_PLATFORM=$BUILDPLATFORM
-ARG HEMLOCK_UBUNTU_TAG
+ARG HEMLOCK_UBUNTU_TAG=rolling
 FROM --platform=${HEMLOCK_PLATFORM} ubuntu:${HEMLOCK_UBUNTU_TAG} AS base
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
@@ -12,7 +12,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* \
     && useradd -l -m -U -G sudo -s /bin/bash hemlock \
     && echo "hemlock ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
-ARG HEMLOCK_BOOTSTRAP_OCAML_VERSION
+ARG HEMLOCK_BOOTSTRAP_OCAML_VERSION=4.14.0
 USER hemlock
 WORKDIR /home/hemlock
 COPY --chown=hemlock:hemlock bootstrap/Hemlock.opam .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ services:
   base:
     build:
       args:
-        - HEMLOCK_BOOTSTRAP_OCAML_VERSION=4.14.0
+        - HEMLOCK_BOOTSTRAP_OCAML_VERSION
         - HEMLOCK_PLATFORM
-        - HEMLOCK_UBUNTU_TAG=rolling
+        - HEMLOCK_UBUNTU_TAG
       context: .
       target: base
     container_name: branchtaken__hemlock__base


### PR DESCRIPTION
This makes so that `docker buildx build .` can take advantage of the same default settings as `docker compose build`.