### PR TITLE
Rename `ubuntu` user to `hemlock`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN apt-get update \
         opam \
         sudo \
     && rm -rf /var/lib/apt/lists/* \
-    && useradd -l -m -U -G sudo -s /bin/bash hemlock \
+    && mv /home/ubuntu /home/hemlock \
+    && groupmod -n hemlock ubuntu \
+    && usermod -d /home/hemlock -c Hemlock -l hemlock ubuntu \
     && echo "hemlock ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 ARG HEMLOCK_BOOTSTRAP_OCAML_VERSION=4.14.0
 USER hemlock


### PR DESCRIPTION
Docker images now include the `ubuntu` user, which conflicts with the typical uid/gid 1000/1000, and therefore thwarts bind mounts. Rename the user.