### PR TITLE
Fixes io_uring permission error in Docker.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,5 +8,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@main
-    - name: docker_compose_build_tested
-      run: docker compose build tested
+    - name: docker_compose_run_test
+      run: docker compose run --build test

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,12 @@ WORKDIR /home/hemlock/Hemlock
 COPY --chown=hemlock:hemlock /.git/ .git
 RUN git reset --hard
 
-FROM --platform=${HEMLOCK_PLATFORM} latest AS tested
+FROM --platform=${HEMLOCK_PLATFORM} latest AS test
 USER hemlock
 WORKDIR /home/hemlock/Hemlock/bootstrap
-RUN find . -type f -regex '.*\mli?' | xargs -- opam exec -- ocp-indent -i \
+CMD find . -type f -regex '.*\mli?' | xargs -- opam exec -- ocp-indent -i \
     && git diff --exit-code \
-    && opam exec -- dune build \
+    && opam exec -- dune build src \
     && opam exec -- dune runtest \
     && rm -rf _build
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,15 +9,19 @@ services:
       target: base
     container_name: branchtaken__hemlock__base
     image: branchtaken/hemlock:base
+    privileged: true
+    security_opt:
+      - seccomp:unconfined
   latest:
     build:
       target: latest
     container_name: branchtaken__hemlock__latest
     extends: base
     image: branchtaken/hemlock:latest
-  tested:
+  test:
     build:
-      target: tested
-    container_name: branchtaken__hemlock__tested
+      target: test
+    container_name: branchtaken__hemlock__test
     extends: latest
-    image: branchtaken/hemlock:tested
+    image: branchtaken/hemlock:test
+


### PR DESCRIPTION
`io_uring_enter`, `io_uring_register`, and `io_uring_setup` were taken out of the Docker default seccomp profile (see
https://github.com/moby/moby/commit/891241e7e74d4aae6de5f6125574eb994f25e169). This caused our tests to fail with `permission denied` when calling any of those system calls during `docker compose build tested`.

This commit changes our seccomp profile to unconfined and runs our containers as privileged. Also, since images can only be built with the default profile, we can no longer run our tests during image build time. They are now run as a container command.