### PR TITLE
Rename `File` c-layer methods.

### DIFF
--- a/bootstrap/src/basis/common.h
+++ b/bootstrap/src/basis/common.h
@@ -5,18 +5,18 @@
 #include <stdio.h>
 
 typedef enum {
-    HM_OE_ERROR = -1,
-    HM_OE_NONE
+    HEMLOCK_OE_ERROR = -1,
+    HEMLOCK_OE_NONE
     // All values > 0 are specific linux errno.
-} hm_opt_error_t;
+} hemlock_opt_error_t;
 
-#define HM_OE(oe, statement) do { \
+#define HEMLOCK_OE(oe, statement) do { \
     oe = statement; \
     switch (oe) { \
-        case HM_OE_ERROR: \
+        case HEMLOCK_OE_ERROR: \
             fprintf(stderr, "Error %s:%i: Unspecified error\n", __FILE__, __LINE__); \
             goto LABEL_OUT; \
-        case HM_OE_NONE: break; \
+        case HEMLOCK_OE_NONE: break; \
         default: \
             assert(oe > 0); \
             fprintf(stderr, "Error %s:%i: %s\n", __FILE__, __LINE__, strerror(oe)); \
@@ -24,9 +24,9 @@ typedef enum {
     } \
 } while (0)
 
-#define HM_OE_ERRNO_RESULT(oe, result, statement) do { \
+#define HEMLOCK_OE_ERRNO_RESULT(oe, result, statement) do { \
     result = statement; \
     if ((int64_t)result == -1) { \
-        HM_OE(oe, errno); \
+        HEMLOCK_OE(oe, errno); \
     }; \
 } while (0)

--- a/bootstrap/src/basis/executor.c
+++ b/bootstrap/src/basis/executor.c
@@ -12,25 +12,25 @@
 
 #include "executor.h"
 
-thread_local hm_executor_t executor = {0};
+thread_local hemlock_executor_t executor = {0};
 
-hm_opt_error_t
-hm_executor_setup(hm_executor_t *executor) {
-    return hm_ioring_setup(&executor->ioring);
+hemlock_opt_error_t
+hemlock_executor_setup(hemlock_executor_t *executor) {
+    return hemlock_ioring_setup(&executor->ioring);
 }
 
 void
-hm_executor_teardown(hm_executor_t *executor) {
-    hm_ioring_teardown(&executor->ioring);
+hemlock_executor_teardown(hemlock_executor_t *executor) {
+    hemlock_ioring_teardown(&executor->ioring);
 }
 
-hm_executor_t *
-hm_executor_get() {
+hemlock_executor_t *
+hemlock_executor_get() {
     return &executor;
 }
 
 CAMLprim value
-hm_basis_executor_finalize_result(int result) {
+hemlock_basis_executor_finalize_result(int result) {
     if (result == -1) {
         result = -errno;
     }
@@ -38,37 +38,38 @@ hm_basis_executor_finalize_result(int result) {
     return caml_copy_int64(result);
 }
 
-// hm_basis_executor_user_data_decref: !&Basis.File.{Open|Close|Read|Write}.t >{os}-> unit
+// hemlock_basis_executor_user_data_decref: !&Basis.File.{Open|Close|Read|Write}.t >{os}-> unit
 CAMLprim value
-hm_basis_executor_user_data_decref(value a_user_data) {
-    hm_user_data_decref((hm_user_data_t *)Int64_val(a_user_data));
+hemlock_basis_executor_user_data_decref(value a_user_data) {
+    hemlock_user_data_decref((hemlock_user_data_t *)Int64_val(a_user_data));
 
     return Val_unit;
 }
 
-// hm_basis_executor_user_data_pp: Basis.File.t -> &Basis.File.{Open|Close|Read|Write}.t >{os}-> unit
+// hemlock_basis_executor_user_data_pp:
+    // Basis.File.t -> &Basis.File.{Open|Close|Read|Write}.t >{os}-> unit
 CAMLprim value
-hm_basis_executor_user_data_pp(value a_fd, value a_user_data) {
-    hm_user_data_t *user_data = (hm_user_data_t *)Int64_val(a_user_data);
+hemlock_basis_executor_user_data_pp(value a_fd, value a_user_data) {
+    hemlock_user_data_t *user_data = (hemlock_user_data_t *)Int64_val(a_user_data);
     int fd = Int64_val(a_fd);
 
-    hm_user_data_pp(fd, 0, user_data);
+    hemlock_user_data_pp(fd, 0, user_data);
 
     return Val_unit;
 }
 
-// hm_basis_executor_complete_inner: !&Basis.File.{Open|Close|Write}.t >{os}-> int
+// hemlock_basis_executor_complete_inner: !&Basis.File.{Open|Close|Write}.t >{os}-> int
 CAMLprim value
-hm_basis_executor_complete_inner(value a_user_data) {
-    hm_user_data_t *user_data = (hm_user_data_t *)Int64_val(a_user_data);
+hemlock_basis_executor_complete_inner(value a_user_data) {
+    hemlock_user_data_t *user_data = (hemlock_user_data_t *)Int64_val(a_user_data);
 
-    int64_t res = hm_ioring_user_data_complete(user_data, &hm_executor_get()->ioring);
+    int64_t res = hemlock_ioring_user_data_complete(user_data, &hemlock_executor_get()->ioring);
 
     return caml_copy_int64(res);
 }
 
 CAMLprim value
-hm_basis_executor_submit_out(hm_opt_error_t oe, hm_user_data_t *user_data) {
+hemlock_basis_executor_submit_out(hemlock_opt_error_t oe, hemlock_user_data_t *user_data) {
     value a_ret = caml_alloc_tuple(2);
     Store_field(a_ret, 0, caml_copy_int64((uint64_t)oe));
     Store_field(a_ret, 1, caml_copy_int64((uint64_t)user_data));
@@ -76,55 +77,55 @@ hm_basis_executor_submit_out(hm_opt_error_t oe, hm_user_data_t *user_data) {
     return a_ret;
 }
 
-// hm_basis_executor_nop_submit_inner: unit >{os}-> (int * &Basis.File.Nop.t)
+// hemlock_basis_executor_nop_submit_inner: unit >{os}-> (int * &Basis.File.Nop.t)
 CAMLprim value
-hm_basis_executor_nop_submit_inner(value a_unit) {
-    hm_opt_error_t oe = HM_OE_NONE;
+hemlock_basis_executor_nop_submit_inner(value a_unit) {
+    hemlock_opt_error_t oe = HEMLOCK_OE_NONE;
 
-    hm_user_data_t *user_data = NULL;
-    HM_OE(oe, hm_ioring_nop_submit(&user_data, &hm_executor_get()->ioring));
+    hemlock_user_data_t *user_data = NULL;
+    HEMLOCK_OE(oe, hemlock_ioring_nop_submit(&user_data, &hemlock_executor_get()->ioring));
 
 LABEL_OUT:
-    return hm_basis_executor_submit_out(oe, user_data);
+    return hemlock_basis_executor_submit_out(oe, user_data);
 }
 
-// hm_basis_executor_setup_inner: unit >{os}-> int
+// hemlock_basis_executor_setup_inner: unit >{os}-> int
 CAMLprim value
-hm_basis_executor_setup_inner(value a_unit) {
-    return caml_copy_int64(hm_executor_setup(hm_executor_get()));
+hemlock_basis_executor_setup_inner(value a_unit) {
+    return caml_copy_int64(hemlock_executor_setup(hemlock_executor_get()));
 }
 
-// hm_basis_executor_teardown_inner: unit >{os}-> unit
+// hemlock_basis_executor_teardown_inner: unit >{os}-> unit
 CAMLprim value
-hm_basis_executor_teardown_inner(value a_unit) {
-    hm_executor_teardown(hm_executor_get());
+hemlock_basis_executor_teardown_inner(value a_unit) {
+    hemlock_executor_teardown(hemlock_executor_get());
 
     return Val_unit;
 }
 
-// hm_basis_executor_cqring_pp: Basis.File.t >{os}-> unit
+// hemlock_basis_executor_cqring_pp: Basis.File.t >{os}-> unit
 CAMLprim value
-hm_basis_executor_cqring_pp(value a_fd) {
+hemlock_basis_executor_cqring_pp(value a_fd) {
     int fd = Int64_val(a_fd);
-    hm_cqring_pp(fd, 0, &hm_executor_get()->ioring.cqring);
+    hemlock_cqring_pp(fd, 0, &hemlock_executor_get()->ioring.cqring);
 
     return Val_unit;
 }
 
-// hm_basis_executor_sqring_pp: Basis.File.t >{os}-> unit
+// hemlock_basis_executor_sqring_pp: Basis.File.t >{os}-> unit
 CAMLprim value
-hm_basis_executor_sqring_pp(value a_fd) {
+hemlock_basis_executor_sqring_pp(value a_fd) {
     int fd = Int64_val(a_fd);
-    hm_sqring_pp(fd, 0, &hm_executor_get()->ioring.sqring);
+    hemlock_sqring_pp(fd, 0, &hemlock_executor_get()->ioring.sqring);
 
     return Val_unit;
 }
 
-// hm_basis_executor_ioring_pp: Basis.File.t >{os}-> unit
+// hemlock_basis_executor_ioring_pp: Basis.File.t >{os}-> unit
 CAMLprim value
-hm_basis_executor_ioring_pp(value a_fd) {
+hemlock_basis_executor_ioring_pp(value a_fd) {
     int fd = Int64_val(a_fd);
-    hm_ioring_pp(fd, 0, &hm_executor_get()->ioring);
+    hemlock_ioring_pp(fd, 0, &hemlock_executor_get()->ioring);
 
     return Val_unit;
 }

--- a/bootstrap/src/basis/executor.h
+++ b/bootstrap/src/basis/executor.h
@@ -2,21 +2,23 @@
 #include "ioring.h"
 
 typedef struct {
-    hm_ioring_t ioring;
-} hm_executor_t;
+    hemlock_ioring_t ioring;
+} hemlock_executor_t;
 
-hm_opt_error_t hm_executor_setup(hm_executor_t *executor);
-void hm_executor_teardown(hm_executor_t *executor);
-hm_executor_t *hm_executor_get();
+hemlock_opt_error_t hemlock_executor_setup(hemlock_executor_t *executor);
+void hemlock_executor_teardown(hemlock_executor_t *executor);
+hemlock_executor_t *hemlock_executor_get();
 
-CAMLprim value hm_basis_executor_finalize_result(int result);
-CAMLprim value hm_basis_executor_user_data_decref(value a_user_data);
-CAMLprim value hm_basis_executor_user_data_pp(value a_fd, value a_user_data);
-CAMLprim value hm_basis_executor_complete_inner(value a_user_data);
-CAMLprim value hm_basis_executor_submit_out(hm_opt_error_t oe, hm_user_data_t *user_data);
-CAMLprim value hm_basis_executor_nop_submit_inner(value a_unit);
-CAMLprim value hm_basis_executor_setup_inner(value a_unit);
-CAMLprim value hm_basis_executor_teardown_inner(value a_unit);
-CAMLprim value hm_basis_executor_cqring_pp(value a_fd);
-CAMLprim value hm_basis_executor_sqring_pp(value a_fd);
-CAMLprim value hm_basis_executor_ioring_pp(value a_fd);
+CAMLprim value hemlock_basis_executor_finalize_result(int result);
+CAMLprim value hemlock_basis_executor_user_data_decref(value a_user_data);
+CAMLprim value hemlock_basis_executor_user_data_pp(value a_fd, value a_user_data);
+CAMLprim value hemlock_basis_executor_complete_inner(value a_user_data);
+CAMLprim value hemlock_basis_executor_submit_out(
+    hemlock_opt_error_t oe, hemlock_user_data_t *user_data
+);
+CAMLprim value hemlock_basis_executor_nop_submit_inner(value a_unit);
+CAMLprim value hemlock_basis_executor_setup_inner(value a_unit);
+CAMLprim value hemlock_basis_executor_teardown_inner(value a_unit);
+CAMLprim value hemlock_basis_executor_cqring_pp(value a_fd);
+CAMLprim value hemlock_basis_executor_sqring_pp(value a_fd);
+CAMLprim value hemlock_basis_executor_ioring_pp(value a_fd);

--- a/bootstrap/src/basis/file.ml
+++ b/bootstrap/src/basis/file.ml
@@ -28,17 +28,17 @@ let bytes_of_slice slice =
     Char.chr (Uns.trunc_to_int (U8.extend_to_uns (Array.get (base + (Int64.of_int i)) container)))
   )
 
-external stdin_inner: unit -> t = "hm_basis_file_stdin_inner"
+external stdin_inner: unit -> t = "hemlock_basis_file_stdin_inner"
 
 let stdin =
   stdin_inner ()
 
-external stdout_inner: unit -> t = "hm_basis_file_stdout_inner"
+external stdout_inner: unit -> t = "hemlock_basis_file_stdout_inner"
 
 let stdout =
   stdout_inner ()
 
-external stderr_inner: unit -> t = "hm_basis_file_stderr_inner"
+external stderr_inner: unit -> t = "hemlock_basis_file_stderr_inner"
 
 let stderr =
   stderr_inner ()
@@ -46,8 +46,8 @@ let stderr =
 let fd t =
   t
 
-external user_data_decref: uns -> unit = "hm_basis_executor_user_data_decref"
-external complete_inner: uns -> sint = "hm_basis_executor_complete_inner"
+external user_data_decref: uns -> unit = "hemlock_basis_executor_user_data_decref"
+external complete_inner: uns -> sint = "hemlock_basis_executor_complete_inner"
 
 let register_user_data_finalizer user_data =
   match user_data = 0L with
@@ -62,7 +62,7 @@ module Open = struct
   type t = uns
 
   external submit_inner: Flag.t -> uns -> Stdlib.Bytes.t -> (sint * t) =
-    "hm_basis_file_open_submit_inner"
+    "hemlock_basis_file_open_submit_inner"
 
   let submit ?(flag=Flag.R_O) ?(mode=0o660L) path =
     let path_bytes = bytes_of_slice (Path.to_bytes path) in
@@ -101,7 +101,7 @@ module Close = struct
   type file = t
   type t = uns
 
-  external submit_inner: file -> (sint * t) = "hm_basis_file_close_submit_inner"
+  external submit_inner: file -> (sint * t) = "hemlock_basis_file_close_submit_inner"
 
   let submit file =
     let value, t = submit_inner file in
@@ -145,7 +145,7 @@ module Read = struct
 
   let default_n = 1024L
 
-  external submit_inner: uns -> file -> (sint * inner) = "hm_basis_file_read_submit_inner"
+  external submit_inner: uns -> file -> (sint * inner) = "hemlock_basis_file_read_submit_inner"
 
   let submit ?n ?buffer file =
     let n, buffer = begin
@@ -174,7 +174,7 @@ module Read = struct
     | Ok t -> t
 
   external complete_inner: Stdlib.Bytes.t -> inner -> sint =
-    "hm_basis_file_read_complete_inner"
+    "hemlock_basis_file_read_complete_inner"
 
   let complete t =
     let base = Bytes.(Cursor.index (Slice.base t.buffer)) in
@@ -215,7 +215,7 @@ module Write = struct
   }
 
   external submit_inner: Stdlib.Bytes.t -> file -> (sint * inner) =
-    "hm_basis_file_write_submit_inner"
+    "hemlock_basis_file_write_submit_inner"
 
   let submit buffer file =
     let bytes = bytes_of_slice buffer in
@@ -285,19 +285,19 @@ let seek_hlt_base inner rel_off t =
       halt (Errno.to_string error)
     end
 
-external seek_inner: sint -> t -> sint = "hm_basis_file_seek_inner"
+external seek_inner: sint -> t -> sint = "hemlock_basis_file_seek_inner"
 
 let seek = seek_base seek_inner
 
 let seek_hlt = seek_hlt_base seek_inner
 
-external seek_hd_inner: sint -> t -> sint = "hm_basis_file_seek_hd_inner"
+external seek_hd_inner: sint -> t -> sint = "hemlock_basis_file_seek_hd_inner"
 
 let seek_hd = seek_base seek_hd_inner
 
 let seek_hd_hlt = seek_hlt_base seek_hd_inner
 
-external seek_tl_inner: sint -> t -> sint = "hm_basis_file_seek_tl_inner"
+external seek_tl_inner: sint -> t -> sint = "hemlock_basis_file_seek_tl_inner"
 
 let seek_tl = seek_base seek_tl_inner
 
@@ -458,7 +458,7 @@ module Fmt = struct
     ()
 end
 
-external setup_inner: unit -> sint = "hm_basis_executor_setup_inner"
+external setup_inner: unit -> sint = "hemlock_basis_executor_setup_inner"
 
 let () = begin
   match setup_inner () = 0L with
@@ -466,7 +466,7 @@ let () = begin
   | true -> ()
 end
 
-external teardown_inner: unit -> unit = "hm_basis_executor_teardown_inner"
+external teardown_inner: unit -> unit = "hemlock_basis_executor_teardown_inner"
 
 let () = Stdlib.at_exit (fun () ->
   let _ = Fmt.teardown () in

--- a/bootstrap/src/basis/ioring.c
+++ b/bootstrap/src/basis/ioring.c
@@ -47,7 +47,7 @@
  *   sqring->tail: Signals that we've added submissions to the tail of the queue.
  *   cqring->head: Signals that we've removed completions from the head of the queue.
  */
-#define HM_ATOMIC_STORE_RELEASE(p, v) \
+#define HEMLOCK_ATOMIC_STORE_RELEASE(p, v) \
     atomic_store_explicit((_Atomic __typeof__(*(p)) *)(p), (v), memory_order_release)
 
 /*
@@ -56,14 +56,14 @@
  *   sqring->head: Signals that the kernel has removed submissions from the head of the queue.
  *   cqring->tail: Signals that the kernel has added completions to the tail of the queue.
  */
-#define HM_ATOMIC_LOAD_ACQUIRE(p) \
+#define HEMLOCK_ATOMIC_LOAD_ACQUIRE(p) \
    atomic_load_explicit((_Atomic __typeof__(*(p)) *)(p), memory_order_acquire)
 
 // Pretty-printer formatting.
-#define HM_INDENT_SIZE 4
+#define HEMLOCK_INDENT_SIZE 4
 
 // io_uring queue size must be a power of two.
-#define HM_IORING_ENTRIES 32
+#define HEMLOCK_IORING_ENTRIES 32
 
 static int
 io_uring_setup(uint32_t entries, struct io_uring_params *p) {
@@ -76,7 +76,7 @@ io_uring_enter(unsigned int fd, uint32_t to_submit, uint32_t min_complete, uint3
 }
 
 static void
-hm_opcode_pp(int fd, int indent, unsigned opcode) {
+hemlock_opcode_pp(int fd, int indent, unsigned opcode) {
     switch (opcode) {
     case IORING_OP_NOP:
       dprintf(fd, "%*sopcode: IORING_OP_NOP\n", indent, "");
@@ -100,7 +100,7 @@ hm_opcode_pp(int fd, int indent, unsigned opcode) {
 }
 
 static void
-hm_pathname_pp(int fd, int indent,  uint8_t *pathname) {
+hemlock_pathname_pp(int fd, int indent,  uint8_t *pathname) {
     if (pathname == NULL) {
         dprintf(fd, "%*spathname: NULL\n", indent, "");
     } else {
@@ -109,12 +109,12 @@ hm_pathname_pp(int fd, int indent,  uint8_t *pathname) {
 }
 
 static void
-hm_sqe_pp(int fd, int indent, struct io_uring_sqe *sqe) {
+hemlock_sqe_pp(int fd, int indent, struct io_uring_sqe *sqe) {
     if (sqe == NULL) {
         dprintf(fd, "%*ssqe: NULL\n", indent, "");
     } else {
         dprintf(fd, "%*ssqe:\n", indent, "");
-        indent += HM_INDENT_SIZE;
+        indent += HEMLOCK_INDENT_SIZE;
         dprintf(fd,
             "%*sflags: %u\n"
             "%*sioprio: %u\n"
@@ -124,18 +124,18 @@ hm_sqe_pp(int fd, int indent, struct io_uring_sqe *sqe) {
             indent, "", sqe->ioprio,
             indent, "", sqe->fd
         );
-        hm_opcode_pp(fd, indent, sqe->opcode);
-        hm_user_data_pp(fd, indent, (hm_user_data_t *)sqe->user_data);
+        hemlock_opcode_pp(fd, indent, sqe->opcode);
+        hemlock_user_data_pp(fd, indent, (hemlock_user_data_t *)sqe->user_data);
     }
 }
 
 static void
-hm_cqe_pp(int fd, int indent, struct io_uring_cqe *cqe) {
+hemlock_cqe_pp(int fd, int indent, struct io_uring_cqe *cqe) {
     if (cqe == NULL) {
         dprintf(fd, "%*scqe: NULL\n", indent, "");
     } else {
         dprintf(fd, "%*scqe:\n", indent, "");
-        indent += HM_INDENT_SIZE;
+        indent += HEMLOCK_INDENT_SIZE;
         dprintf(fd,
             "%*sres: %i\n"
             "%*sflags: %u\n"
@@ -144,46 +144,46 @@ hm_cqe_pp(int fd, int indent, struct io_uring_cqe *cqe) {
             indent, "", cqe->flags
         );
         if (cqe->user_data != 0 &&
-          cqe->user_data == ((hm_user_data_t *)cqe->user_data)->cqe.user_data) {
+          cqe->user_data == ((hemlock_user_data_t *)cqe->user_data)->cqe.user_data) {
             dprintf(fd, "%*suser_data: <same as parent>\n", indent, "");
         } else {
-            hm_user_data_pp(fd, indent, (hm_user_data_t *)cqe->user_data);
+            hemlock_user_data_pp(fd, indent, (hemlock_user_data_t *)cqe->user_data);
         }
     }
 }
 
 static bool
-hm_user_data_is_complete(hm_user_data_t *user_data) {
+hemlock_user_data_is_complete(hemlock_user_data_t *user_data) {
     // When the cqe is copied out of the completion queue into this user_data, the cqe's user_data
     // field is a valid pointer (i.e. non-zero).
     return user_data->cqe.user_data != 0;
 }
 
 void
-hm_user_data_pp(int fd, int indent, hm_user_data_t *user_data) {
+hemlock_user_data_pp(int fd, int indent, hemlock_user_data_t *user_data) {
     if (user_data == NULL) {
         dprintf(fd, "%*suser_data: NULL\n", indent, "");
     } else {
         dprintf(fd, "%*suser_data:\n", indent, "");
-        indent += HM_INDENT_SIZE;
+        indent += HEMLOCK_INDENT_SIZE;
         dprintf(fd,
             "%*srefcount: %u\n",
             indent, "", user_data->refcount
         );
         switch (user_data->opcode) {
         case IORING_OP_OPENAT:
-            hm_pathname_pp(fd, indent, user_data->pathname);
+            hemlock_pathname_pp(fd, indent, user_data->pathname);
             break;
         default:
             break;
         }
-        hm_opcode_pp(fd, indent, user_data->opcode);
-        hm_cqe_pp(fd, indent, &user_data->cqe);
+        hemlock_opcode_pp(fd, indent, user_data->opcode);
+        hemlock_cqe_pp(fd, indent, &user_data->cqe);
     }
 }
 
 void
-hm_user_data_decref(hm_user_data_t *user_data) {
+hemlock_user_data_decref(hemlock_user_data_t *user_data) {
     user_data->refcount--;
     if (user_data->refcount == 0) {
         free(user_data);
@@ -191,12 +191,12 @@ hm_user_data_decref(hm_user_data_t *user_data) {
 }
 
 void
-hm_sqring_pp(int fd, int indent, hm_sqring_t *sqring) {
+hemlock_sqring_pp(int fd, int indent, hemlock_sqring_t *sqring) {
     if (sqring == NULL) {
         dprintf(fd, "%*ssqring: NULL\n", indent, "");
     } else {
         dprintf(fd, "%*ssqring:\n", indent, "");
-        indent += HM_INDENT_SIZE;
+        indent += HEMLOCK_INDENT_SIZE;
         dprintf(fd,
             "%*shead: %u\n"
             "%*stail: %u\n"
@@ -204,7 +204,7 @@ hm_sqring_pp(int fd, int indent, hm_sqring_t *sqring) {
             "%*sring_mask: %u\n"
             "%*sflags: %u\n"
             ,
-            indent, "", HM_ATOMIC_LOAD_ACQUIRE(sqring->head),
+            indent, "", HEMLOCK_ATOMIC_LOAD_ACQUIRE(sqring->head),
             indent, "", *sqring->tail,
             indent, "", *sqring->ring_entries,
             indent, "", *sqring->ring_mask,
@@ -217,20 +217,22 @@ hm_sqring_pp(int fd, int indent, hm_sqring_t *sqring) {
         dprintf(fd, "]\n");
 
         dprintf(fd, "%*s  sqes:\n", indent, "");
-        indent += HM_INDENT_SIZE;
-        for (unsigned head = HM_ATOMIC_LOAD_ACQUIRE(sqring->head); head < *sqring->tail; head++) {
-            hm_sqe_pp(fd, indent, &sqring->sqes[head & *sqring->ring_mask]);
+        indent += HEMLOCK_INDENT_SIZE;
+        for (
+            unsigned head = HEMLOCK_ATOMIC_LOAD_ACQUIRE(sqring->head); head < *sqring->tail; head++
+        ) {
+            hemlock_sqe_pp(fd, indent, &sqring->sqes[head & *sqring->ring_mask]);
         }
     }
 }
 
 void
-hm_cqring_pp(int fd, int indent, hm_cqring_t *cqring) {
+hemlock_cqring_pp(int fd, int indent, hemlock_cqring_t *cqring) {
     if (cqring == NULL) {
         dprintf(fd, "%*scqring: NULL\n", indent, "");
     } else {
         dprintf(fd, "%*scqring:\n", indent, "");
-        indent += HM_INDENT_SIZE;
+        indent += HEMLOCK_INDENT_SIZE;
         dprintf(fd,
             "%*shead: %u\n"
             "%*stail: %u\n"
@@ -239,34 +241,36 @@ hm_cqring_pp(int fd, int indent, hm_cqring_t *cqring) {
             "%*scqes:\n"
             ,
             indent, "", *cqring->head,
-            indent, "", HM_ATOMIC_LOAD_ACQUIRE(cqring->tail),
+            indent, "", HEMLOCK_ATOMIC_LOAD_ACQUIRE(cqring->tail),
             indent, "", *cqring->ring_entries,
             indent, "", *cqring->ring_mask,
             indent, ""
         );
-        indent += HM_INDENT_SIZE;
-        for (unsigned head = *cqring->head; head < HM_ATOMIC_LOAD_ACQUIRE(cqring->tail); head++) {
-            hm_cqe_pp(fd, indent, &cqring->cqes[head & *cqring->ring_mask]);
+        indent += HEMLOCK_INDENT_SIZE;
+        for (
+            unsigned head = *cqring->head; head < HEMLOCK_ATOMIC_LOAD_ACQUIRE(cqring->tail); head++
+        ) {
+            hemlock_cqe_pp(fd, indent, &cqring->cqes[head & *cqring->ring_mask]);
         }
     }
 }
 
 void
-hm_ioring_pp(int fd, int indent, hm_ioring_t *ioring) {
+hemlock_ioring_pp(int fd, int indent, hemlock_ioring_t *ioring) {
     if (ioring == NULL) {
         dprintf(fd, "%*sioring: NULL\n", indent, "");
     } else {
         dprintf(fd, "%*sioring:\n", indent, "");
-        indent += HM_INDENT_SIZE;
+        indent += HEMLOCK_INDENT_SIZE;
         dprintf(fd, "%*sfd: %i\n" , indent, "", ioring->fd);
-        hm_cqring_pp(fd, indent, &ioring->cqring);
-        hm_sqring_pp(fd, indent, &ioring->sqring);
+        hemlock_cqring_pp(fd, indent, &ioring->cqring);
+        hemlock_sqring_pp(fd, indent, &ioring->sqring);
     }
 }
 
-hm_user_data_t *
-hm_user_data_create() {
-    hm_user_data_t *user_data = (hm_user_data_t *)calloc(1, sizeof(hm_user_data_t));
+hemlock_user_data_t *
+hemlock_user_data_create() {
+    hemlock_user_data_t *user_data = (hemlock_user_data_t *)calloc(1, sizeof(hemlock_user_data_t));
     assert(user_data != NULL);
 
     // Refs from kernel and ocaml.
@@ -276,7 +280,7 @@ hm_user_data_create() {
 }
 
 static void
-hm_sqring_setup(void *vm, struct io_sqring_offsets const *offsets, hm_sqring_t *sqring) {
+hemlock_sqring_setup(void *vm, struct io_sqring_offsets const *offsets, hemlock_sqring_t *sqring) {
     sqring->head = vm + offsets->head;
     sqring->tail = vm + offsets->tail;
     sqring->ring_entries = vm + offsets->ring_entries;
@@ -289,7 +293,7 @@ hm_sqring_setup(void *vm, struct io_sqring_offsets const *offsets, hm_sqring_t *
 }
 
 static void
-hm_cqring_setup(void *vm, struct io_cqring_offsets const *offsets, hm_cqring_t *cqring) {
+hemlock_cqring_setup(void *vm, struct io_cqring_offsets const *offsets, hemlock_cqring_t *cqring) {
     cqring->head = vm + offsets->head;
     cqring->tail = vm + offsets->tail;
     cqring->ring_entries = vm + offsets->ring_entries;
@@ -298,28 +302,30 @@ hm_cqring_setup(void *vm, struct io_cqring_offsets const *offsets, hm_cqring_t *
 }
 
 static size_t
-hm_ioring_get_vm_size(hm_ioring_t *ioring) {
+hemlock_ioring_get_vm_size(hemlock_ioring_t *ioring) {
     return ioring->params.sq_off.array + ioring->params.sq_entries * sizeof(uint32_t);
 }
 
 static size_t
-hm_ioring_get_sqes_size(hm_ioring_t *ioring) {
+hemlock_ioring_get_sqes_size(hemlock_ioring_t *ioring) {
     return ioring->params.sq_entries * sizeof(struct io_uring_sqe);
 }
 
-hm_opt_error_t
-hm_ioring_setup(hm_ioring_t *ioring) {
-    hm_opt_error_t oe = HM_OE_NONE;
+hemlock_opt_error_t
+hemlock_ioring_setup(hemlock_ioring_t *ioring) {
+    hemlock_opt_error_t oe = HEMLOCK_OE_NONE;
 
     memset(ioring, 0, sizeof(*ioring));
-    HM_OE_ERRNO_RESULT(oe, ioring->fd, io_uring_setup(HM_IORING_ENTRIES, &ioring->params));
+    HEMLOCK_OE_ERRNO_RESULT(
+        oe, ioring->fd, io_uring_setup(HEMLOCK_IORING_ENTRIES, &ioring->params)
+    );
 
     assert(ioring->params.features & IORING_FEAT_SINGLE_MMAP);
     assert(ioring->params.features & IORING_FEAT_RW_CUR_POS);
 
     ioring->vm = mmap(
         0,
-        hm_ioring_get_vm_size(ioring),
+        hemlock_ioring_get_vm_size(ioring),
         PROT_READ | PROT_WRITE,
         MAP_SHARED | MAP_POPULATE,
         ioring->fd,
@@ -330,7 +336,7 @@ hm_ioring_setup(hm_ioring_t *ioring) {
     }
     ioring->sqring.sqes = (struct io_uring_sqe *)mmap(
         0,
-        hm_ioring_get_sqes_size(ioring),
+        hemlock_ioring_get_sqes_size(ioring),
         PROT_READ | PROT_WRITE,
         MAP_SHARED | MAP_POPULATE,
         ioring->fd,
@@ -340,41 +346,41 @@ hm_ioring_setup(hm_ioring_t *ioring) {
         abort();
     }
 
-    hm_sqring_setup(ioring->vm, &ioring->params.sq_off, &ioring->sqring);
-    hm_cqring_setup(ioring->vm, &ioring->params.cq_off, &ioring->cqring);
+    hemlock_sqring_setup(ioring->vm, &ioring->params.sq_off, &ioring->sqring);
+    hemlock_cqring_setup(ioring->vm, &ioring->params.cq_off, &ioring->cqring);
 
 LABEL_OUT:
     return oe;
 }
 
 void
-hm_ioring_teardown(hm_ioring_t *ioring) {
-    if (munmap(ioring->sqring.sqes, hm_ioring_get_sqes_size(ioring)) != 0 ||
-      munmap(ioring->vm, hm_ioring_get_vm_size(ioring)) != 0 ||
+hemlock_ioring_teardown(hemlock_ioring_t *ioring) {
+    if (munmap(ioring->sqring.sqes, hemlock_ioring_get_sqes_size(ioring)) != 0 ||
+      munmap(ioring->vm, hemlock_ioring_get_vm_size(ioring)) != 0 ||
       close(ioring->fd) != 0) {
         abort();
     }
 
-    memset(ioring, 0, sizeof(hm_ioring_t));
+    memset(ioring, 0, sizeof(hemlock_ioring_t));
 }
 
-static hm_opt_error_t
-hm_ioring_flush_cqes(uint32_t min_complete, hm_ioring_t *ioring) {
-    hm_opt_error_t oe = HM_OE_NONE;
-    hm_cqring_t *cqring = &ioring->cqring;
+static hemlock_opt_error_t
+hemlock_ioring_flush_cqes(uint32_t min_complete, hemlock_ioring_t *ioring) {
+    hemlock_opt_error_t oe = HEMLOCK_OE_NONE;
+    hemlock_cqring_t *cqring = &ioring->cqring;
 
     assert(min_complete <= *cqring->ring_entries);
 
-    uint32_t tail = HM_ATOMIC_LOAD_ACQUIRE(cqring->tail);
+    uint32_t tail = HEMLOCK_ATOMIC_LOAD_ACQUIRE(cqring->tail);
     uint32_t head = *cqring->head;
     if (tail - head < min_complete) {
         uint32_t n_complete;
-        HM_OE(oe, hm_ioring_enter(&n_complete, min_complete, ioring));
-        tail = HM_ATOMIC_LOAD_ACQUIRE(cqring->tail);
+        HEMLOCK_OE(oe, hemlock_ioring_enter(&n_complete, min_complete, ioring));
+        tail = HEMLOCK_ATOMIC_LOAD_ACQUIRE(cqring->tail);
     }
     for (; head < tail; head++) {
         struct io_uring_cqe *cqe = &cqring->cqes[head & *cqring->ring_mask];
-        hm_user_data_t *user_data = (hm_user_data_t *)cqe->user_data;
+        hemlock_user_data_t *user_data = (hemlock_user_data_t *)cqe->user_data;
         memcpy(&user_data->cqe, cqe, sizeof(struct io_uring_cqe));
         switch (user_data->opcode) {
         case IORING_OP_OPENAT:
@@ -388,61 +394,61 @@ hm_ioring_flush_cqes(uint32_t min_complete, hm_ioring_t *ioring) {
         default:
             break;
         };
-        hm_user_data_decref(user_data);
+        hemlock_user_data_decref(user_data);
     }
-    HM_ATOMIC_STORE_RELEASE(cqring->head, head);
+    HEMLOCK_ATOMIC_STORE_RELEASE(cqring->head, head);
 
 LABEL_OUT:
     return oe;
 }
 
-static hm_opt_error_t
-hm_ioring_flush_sqes(hm_ioring_t *ioring) {
-    hm_opt_error_t oe = HM_OE_NONE;
+static hemlock_opt_error_t
+hemlock_ioring_flush_sqes(hemlock_ioring_t *ioring) {
+    hemlock_opt_error_t oe = HEMLOCK_OE_NONE;
     uint32_t n_complete;
-    HM_OE(oe, hm_ioring_enter(&n_complete, 0, ioring));
+    HEMLOCK_OE(oe, hemlock_ioring_enter(&n_complete, 0, ioring));
     if (n_complete > 0) {
         // There are CQEs just sitting in the completion queue. Flush them.
-        HM_OE(oe, hm_ioring_flush_cqes(0, ioring));
+        HEMLOCK_OE(oe, hemlock_ioring_flush_cqes(0, ioring));
     }
 
 LABEL_OUT:
     return oe;
 }
 
-static hm_opt_error_t
-hm_ioring_get_sqe(struct io_uring_sqe **sqe, hm_ioring_t *ioring) {
-    hm_opt_error_t oe = HM_OE_NONE;
+static hemlock_opt_error_t
+hemlock_ioring_get_sqe(struct io_uring_sqe **sqe, hemlock_ioring_t *ioring) {
+    hemlock_opt_error_t oe = HEMLOCK_OE_NONE;
 
-    hm_sqring_t *sqring = &ioring->sqring;
-    if (*sqring->tail - HM_ATOMIC_LOAD_ACQUIRE(sqring->head) == *sqring->ring_entries) {
-        HM_OE(oe, hm_ioring_flush_sqes(ioring));
+    hemlock_sqring_t *sqring = &ioring->sqring;
+    if (*sqring->tail - HEMLOCK_ATOMIC_LOAD_ACQUIRE(sqring->head) == *sqring->ring_entries) {
+        HEMLOCK_OE(oe, hemlock_ioring_flush_sqes(ioring));
     }
 
     *sqe = &sqring->sqes[*sqring->tail & *sqring->ring_mask];
-    HM_ATOMIC_STORE_RELEASE(sqring->tail, *sqring->tail + 1);
+    HEMLOCK_ATOMIC_STORE_RELEASE(sqring->tail, *sqring->tail + 1);
     memset(*sqe, 0, sizeof(struct io_uring_sqe));
 
 LABEL_OUT:
     return oe;
 }
 
-hm_opt_error_t
-hm_ioring_enter(uint32_t *n_complete, uint32_t min_complete, hm_ioring_t *ioring) {
-    hm_opt_error_t oe = HM_OE_NONE;
+hemlock_opt_error_t
+hemlock_ioring_enter(uint32_t *n_complete, uint32_t min_complete, hemlock_ioring_t *ioring) {
+    hemlock_opt_error_t oe = HEMLOCK_OE_NONE;
 LABEL_OUT:
     switch (oe) {
     case EBUSY:
         // In Hemlock, this is the point at which the actor suspends and requires the executor to
         // reap CQEs. If the final SQE has IOSQE_IO_LINK set, no other actors may submit I/O on this
         // ioring until the current actor finishes submitting its chain of SQEs.
-        HM_OE(oe, hm_ioring_flush_cqes(1, ioring));
-    case HM_OE_NONE:
-        HM_OE_ERRNO_RESULT(
+        HEMLOCK_OE(oe, hemlock_ioring_flush_cqes(1, ioring));
+    case HEMLOCK_OE_NONE:
+        HEMLOCK_OE_ERRNO_RESULT(
           oe,
           *n_complete,
           io_uring_enter(ioring->fd, *ioring->sqring.tail -
-            HM_ATOMIC_LOAD_ACQUIRE(ioring->sqring.head), min_complete, IORING_ENTER_GETEVENTS)
+            HEMLOCK_ATOMIC_LOAD_ACQUIRE(ioring->sqring.head), min_complete, IORING_ENTER_GETEVENTS)
         );
         break;
     default:
@@ -453,18 +459,18 @@ LABEL_OUT:
 }
 
 int
-hm_ioring_user_data_complete(hm_user_data_t *user_data, hm_ioring_t *ioring) {
-    hm_opt_error_t oe = HM_OE_NONE;
+hemlock_ioring_user_data_complete(hemlock_user_data_t *user_data, hemlock_ioring_t *ioring) {
+    hemlock_opt_error_t oe = HEMLOCK_OE_NONE;
 
-    while (!hm_user_data_is_complete(user_data)) {
-        HM_OE(oe, hm_ioring_flush_cqes(1, ioring));
+    while (!hemlock_user_data_is_complete(user_data)) {
+        HEMLOCK_OE(oe, hemlock_ioring_flush_cqes(1, ioring));
     }
 
 LABEL_OUT:
-    if (oe == HM_OE_NONE) {
+    if (oe == HEMLOCK_OE_NONE) {
         // io_uring_cqe res returns -errno in the res field if there are errors. We do the same.
         return user_data->cqe.res;
-    } else if (oe == HM_OE_ERROR) {
+    } else if (oe == HEMLOCK_OE_ERROR) {
         // Generic error, but this function returns -errno on failure. Just use the most appropriate
         // system error.
         return -EIO;
@@ -474,13 +480,13 @@ LABEL_OUT:
     }
 }
 
-hm_opt_error_t
-hm_ioring_nop_submit(hm_user_data_t **user_data, hm_ioring_t *ioring) {
-    hm_opt_error_t oe = HM_OE_NONE;
+hemlock_opt_error_t
+hemlock_ioring_nop_submit(hemlock_user_data_t **user_data, hemlock_ioring_t *ioring) {
+    hemlock_opt_error_t oe = HEMLOCK_OE_NONE;
     struct io_uring_sqe *sqe;
-    HM_OE(oe, hm_ioring_get_sqe(&sqe, ioring));
+    HEMLOCK_OE(oe, hemlock_ioring_get_sqe(&sqe, ioring));
 
-    *user_data = hm_user_data_create();
+    *user_data = hemlock_user_data_create();
     (*user_data)->opcode = IORING_OP_NOP;
 
     sqe->user_data = (uint64_t)(*user_data);
@@ -490,14 +496,19 @@ LABEL_OUT:
     return oe;
 }
 
-hm_opt_error_t
-hm_ioring_open_submit(hm_user_data_t **user_data, uint8_t *pathname, int flags, mode_t mode,
-  hm_ioring_t *ioring) {
-    hm_opt_error_t oe = HM_OE_NONE;
+hemlock_opt_error_t
+hemlock_ioring_open_submit(
+    hemlock_user_data_t **user_data,
+    uint8_t *pathname,
+    int flags,
+    mode_t mode,
+    hemlock_ioring_t *ioring
+) {
+    hemlock_opt_error_t oe = HEMLOCK_OE_NONE;
     struct io_uring_sqe *sqe;
-    HM_OE(oe, hm_ioring_get_sqe(&sqe, ioring));
+    HEMLOCK_OE(oe, hemlock_ioring_get_sqe(&sqe, ioring));
 
-    *user_data = hm_user_data_create();
+    *user_data = hemlock_user_data_create();
     (*user_data)->opcode = IORING_OP_OPENAT;
     (*user_data)->pathname = pathname;
 
@@ -512,13 +523,13 @@ LABEL_OUT:
     return oe;
 }
 
-hm_opt_error_t
-hm_ioring_close_submit(hm_user_data_t **user_data, int fd, hm_ioring_t *ioring) {
-    hm_opt_error_t oe = HM_OE_NONE;
+hemlock_opt_error_t
+hemlock_ioring_close_submit(hemlock_user_data_t **user_data, int fd, hemlock_ioring_t *ioring) {
+    hemlock_opt_error_t oe = HEMLOCK_OE_NONE;
     struct io_uring_sqe *sqe;
-    HM_OE(oe, hm_ioring_get_sqe(&sqe, ioring));
+    HEMLOCK_OE(oe, hemlock_ioring_get_sqe(&sqe, ioring));
 
-    *user_data = hm_user_data_create();
+    *user_data = hemlock_user_data_create();
     (*user_data)->opcode = IORING_OP_CLOSE;
 
     sqe->user_data = (uint64_t)(*user_data);
@@ -529,14 +540,19 @@ LABEL_OUT:
     return oe;
 }
 
-hm_opt_error_t
-hm_ioring_read_submit(hm_user_data_t **user_data, int fd, uint8_t *buffer, uint64_t n,
-  hm_ioring_t *ioring) {
-    hm_opt_error_t oe = HM_OE_NONE;
+hemlock_opt_error_t
+hemlock_ioring_read_submit(
+    hemlock_user_data_t **user_data,
+    int fd,
+    uint8_t *buffer,
+    uint64_t n,
+    hemlock_ioring_t *ioring
+) {
+    hemlock_opt_error_t oe = HEMLOCK_OE_NONE;
     struct io_uring_sqe *sqe;
-    HM_OE(oe, hm_ioring_get_sqe(&sqe, ioring));
+    HEMLOCK_OE(oe, hemlock_ioring_get_sqe(&sqe, ioring));
 
-    *user_data = hm_user_data_create();
+    *user_data = hemlock_user_data_create();
     (*user_data)->opcode = IORING_OP_READ;
     (*user_data)->buffer = buffer;
 
@@ -551,14 +567,19 @@ LABEL_OUT:
     return oe;
 }
 
-hm_opt_error_t
-hm_ioring_write_submit(hm_user_data_t **user_data, int fd, uint8_t *buffer, uint64_t n,
-  hm_ioring_t *ioring) {
-    hm_opt_error_t oe = HM_OE_NONE;
+hemlock_opt_error_t
+hemlock_ioring_write_submit(
+    hemlock_user_data_t **user_data,
+    int fd,
+    uint8_t *buffer,
+    uint64_t n,
+    hemlock_ioring_t *ioring
+) {
+    hemlock_opt_error_t oe = HEMLOCK_OE_NONE;
     struct io_uring_sqe *sqe;
-    HM_OE(oe, hm_ioring_get_sqe(&sqe, ioring));
+    HEMLOCK_OE(oe, hemlock_ioring_get_sqe(&sqe, ioring));
 
-    *user_data = hm_user_data_create();
+    *user_data = hemlock_user_data_create();
     (*user_data)->opcode = IORING_OP_WRITE;
     (*user_data)->buffer = buffer;
 

--- a/bootstrap/src/basis/ioring.h
+++ b/bootstrap/src/basis/ioring.h
@@ -21,9 +21,9 @@ typedef struct {
 
     // Maximum of two refs. One from OCaml and one from the kernel.
     uint8_t refcount;
-} hm_user_data_t;
-void hm_user_data_pp(int fd, int indent, hm_user_data_t *user_data);
-void hm_user_data_decref(hm_user_data_t *user_data);
+} hemlock_user_data_t;
+void hemlock_user_data_pp(int fd, int indent, hemlock_user_data_t *user_data);
+void hemlock_user_data_decref(hemlock_user_data_t *user_data);
 
 // Utility type for tracking submission queue mmapped data structure fields.
 typedef struct {
@@ -34,8 +34,8 @@ typedef struct {
     unsigned *flags;
     unsigned *array;
     struct io_uring_sqe *sqes;
-} hm_sqring_t;
-void hm_sqring_pp(int fd, int indent, hm_sqring_t *sqring);
+} hemlock_sqring_t;
+void hemlock_sqring_pp(int fd, int indent, hemlock_sqring_t *sqring);
 
 // Utility type for tracking completion queue mmapped data structure fields.
 typedef struct {
@@ -44,8 +44,8 @@ typedef struct {
     unsigned *ring_entries;
     unsigned *ring_mask;
     struct io_uring_cqe *cqes;
-} hm_cqring_t;
-void hm_cqring_pp(int fd, int indent, hm_cqring_t *cqring);
+} hemlock_cqring_t;
+void hemlock_cqring_pp(int fd, int indent, hemlock_cqring_t *cqring);
 
 // Utility type for tracking io_uring fd and mmapped data structure fields.
 typedef struct {
@@ -58,19 +58,45 @@ typedef struct {
     // mmapped memory for io_uring instance.
     void *vm;
 
-    hm_sqring_t sqring;
-    hm_cqring_t cqring;
-} hm_ioring_t;
-void hm_ioring_pp(int fd, int indent, hm_ioring_t *ioring);
-hm_opt_error_t hm_ioring_setup(hm_ioring_t *ioring);
-void hm_ioring_teardown(hm_ioring_t *ioring);
-hm_opt_error_t hm_ioring_enter(uint32_t *n_complete, uint32_t min_complete, hm_ioring_t *ioring);
-int hm_ioring_user_data_complete(hm_user_data_t *user_data, hm_ioring_t *ioring);
-hm_opt_error_t hm_ioring_nop_submit(hm_user_data_t **user_data, hm_ioring_t *ioring);
-hm_opt_error_t hm_ioring_open_submit(hm_user_data_t **user_data, uint8_t *pathname, int flags,
-  mode_t mode, hm_ioring_t *ioring);
-hm_opt_error_t hm_ioring_close_submit(hm_user_data_t **user_data, int fd, hm_ioring_t *ioring);
-hm_opt_error_t hm_ioring_read_submit(hm_user_data_t **user_data, int fd, uint8_t *buffer,
-  uint64_t n, hm_ioring_t *ioring);
-hm_opt_error_t hm_ioring_write_submit(hm_user_data_t **user_data, int fd, uint8_t *buffer,
-  uint64_t n, hm_ioring_t *ioring);
+    hemlock_sqring_t sqring;
+    hemlock_cqring_t cqring;
+} hemlock_ioring_t;
+void hemlock_ioring_pp(int fd, int indent, hemlock_ioring_t *ioring);
+hemlock_opt_error_t hemlock_ioring_setup(hemlock_ioring_t *ioring);
+void hemlock_ioring_teardown(hemlock_ioring_t *ioring);
+hemlock_opt_error_t hemlock_ioring_enter(
+    uint32_t *n_complete,
+    uint32_t min_complete,
+    hemlock_ioring_t *ioring
+);
+int hemlock_ioring_user_data_complete(hemlock_user_data_t *user_data, hemlock_ioring_t *ioring);
+hemlock_opt_error_t hemlock_ioring_nop_submit(
+    hemlock_user_data_t **user_data,
+    hemlock_ioring_t *ioring
+);
+hemlock_opt_error_t hemlock_ioring_open_submit(
+    hemlock_user_data_t **user_data,
+    uint8_t *pathname,
+    int flags,
+    mode_t mode,
+    hemlock_ioring_t *ioring
+);
+hemlock_opt_error_t hemlock_ioring_close_submit(
+    hemlock_user_data_t **user_data,
+    int fd,
+    hemlock_ioring_t *ioring
+);
+hemlock_opt_error_t hemlock_ioring_read_submit(
+    hemlock_user_data_t **user_data,
+    int fd,
+    uint8_t *buffer,
+    uint64_t n,
+    hemlock_ioring_t *ioring
+);
+hemlock_opt_error_t hemlock_ioring_write_submit(
+    hemlock_user_data_t **user_data,
+    int fd,
+    uint8_t *buffer,
+    uint64_t n,
+    hemlock_ioring_t *ioring
+);

--- a/bootstrap/test/basis/file/test_file_full_sq.ml
+++ b/bootstrap/test/basis/file/test_file_full_sq.ml
@@ -1,9 +1,9 @@
 open Basis.Rudiments
 open Basis
 
-external nop_submit: unit -> (sint * uns) = "hm_basis_executor_nop_submit_inner"
-external sqring_pp: File.t -> unit = "hm_basis_executor_sqring_pp"
-external user_data_decref: uns -> unit = "hm_basis_executor_user_data_decref"
+external nop_submit: unit -> (sint * uns) = "hemlock_basis_executor_nop_submit_inner"
+external sqring_pp: File.t -> unit = "hemlock_basis_executor_sqring_pp"
+external user_data_decref: uns -> unit = "hemlock_basis_executor_user_data_decref"
 
 let () =
   let submit_nop () = begin

--- a/bootstrap/test/basis/file/test_file_open.ml
+++ b/bootstrap/test/basis/file/test_file_open.ml
@@ -1,7 +1,7 @@
 open Basis
 
-external user_data_pp: File.t -> File.Open.t -> unit = "hm_basis_executor_user_data_pp"
-external sqring_pp: File.t -> unit = "hm_basis_executor_sqring_pp"
+external user_data_pp: File.t -> File.Open.t -> unit = "hemlock_basis_executor_user_data_pp"
+external sqring_pp: File.t -> unit = "hemlock_basis_executor_sqring_pp"
 
 let () =
   let s = File.Open.submit_hlt ~flag:File.Flag.RW (Path.of_string "file") in


### PR DESCRIPTION
This makes all c-layer methods more consistent with the rest of the Hemlock project. Functions and macros previously prefixed with `hm_` or `HM_` are now prefixed with `hemlock_` or `HEMLOCK_` respectively.