### PR TITLE
Relax attrib key equality assertions during remerging

### DIFF
--- a/bootstrap/bin/hocc/attrib.ml
+++ b/bootstrap/bin/hocc/attrib.ml
@@ -49,6 +49,12 @@ module T = struct
     Symbol.Index.(s0 = s1) &&
     Contrib.(x0 = x1)
 
+  let remergeable_keys
+      {conflict_state_index=csi0; symbol_index=s0; _}
+      {conflict_state_index=csi1; symbol_index=s1; _} =
+    StateIndex.(csi0 = csi1) &&
+    Symbol.Index.(s0 = s1)
+
   let equal
       ({isucc_lr1itemset=is0; contrib=c0; _} as t0)
       ({isucc_lr1itemset=is1; contrib=c1; _} as t1) =
@@ -103,12 +109,18 @@ module T = struct
     Lr1Itemset.is_empty isucc_lr1itemset &&
     Contrib.is_empty contrib
 
-  let union
+  let union_impl equalish_keys
       ({conflict_state_index; symbol_index; conflict; isucc_lr1itemset=is0; contrib=c0} as t0)
       ({isucc_lr1itemset=is1; contrib=c1; _} as t1) =
-    assert (equal_keys t0 t1);
+    assert (equalish_keys t0 t1);
     init ~conflict_state_index ~symbol_index ~conflict ~isucc_lr1itemset:(Lr1Itemset.union is0 is1)
       ~contrib:(Contrib.union c0 c1)
+
+  let union t0 t1 =
+    union_impl equal_keys t0 t1
+
+  let union_remerged t0 t1 =
+    union_impl remergeable_keys t0 t1
 
   let inter
       ({conflict_state_index; symbol_index; conflict; isucc_lr1itemset=is0; contrib=c0} as t0)

--- a/bootstrap/bin/hocc/attrib.mli
+++ b/bootstrap/bin/hocc/attrib.mli
@@ -21,6 +21,11 @@ val equal_keys: t -> t -> bool
 (** [equal t0 t1] returns true iff the contents of [t0] and [t1] have equal ([conflict_state_index],
     [symbol_index], [conflict]) keys. *)
 
+val remergeable_keys: t -> t -> bool
+(** [equal t0 t1] returns true iff the contents of [t0] and [t1] have equal ([conflict_state_index],
+    [symbol_index]) keys. This is a weaker condition than [equal_keys], necessary to allow remerging
+    of functionally equivalent states despite potential attrib differences. *)
+
 val equal: t -> t -> bool
 (** [equal t0 t1] returns true iff the contents of [t0] and [t1] are identical. The keys must be
     equal. *)
@@ -58,6 +63,10 @@ val is_empty: t -> bool
 val union: t -> t -> t
 (** [union t0 t1] returns an attribution with the union of attribution values in [t0] and [t1]. The
     keys must be equal. *)
+
+val union_remerged: t -> t -> t
+(** [union t0 t1] returns an attribution with the union of attribution values in [t0] and [t1]. The
+    keys must be remergeable. *)
 
 val inter: t -> t -> t
 (** [inter t0 t1] returns an attribution with the intersection of attribution values in [t0] and


### PR DESCRIPTION
Functionally equivalent states can be remerged even in the presence of unequal attribs. Relax assertions during remerging so that attrib unions succeed.