### PR TITLE
Consolidate "build" and "runtest" CI jobs.

### DIFF
--- a/.github/workflows/bootstrap_platform.yml
+++ b/.github/workflows/bootstrap_platform.yml
@@ -31,36 +31,22 @@ jobs:
           target: latest
       - name: Run "ocp_indent"
         run: docker compose run ocp_indent
-  build:
-    name: Run "build"
+  build_and_runtest:
+    name: Run "build" and "runtest"
     runs-on: ${{ inputs.runs-on }}
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v6
         with:
-          cache-from: type=gha,scope=${{ inputs.architecture }}-build
-          cache-to: type=gha,mode=max,scope=${{ inputs.architecture }}-build
+          cache-from: type=gha,scope=${{ inputs.architecture }}-build_and_runtest
+          cache-to: type=gha,mode=max,scope=${{ inputs.architecture }}-build_and_runtest
           context: ./bootstrap
           load: true
           tags: branchtaken/hemlock/bootstrap:latest
           target: latest
       - name: Run "build"
         run: docker compose run build --verbose
-  runtest:
-    name: Run "runtest"
-    runs-on: ${{ inputs.runs-on }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
-        with:
-          cache-from: type=gha,scope=${{ inputs.architecture }}-runtest
-          cache-to: type=gha,mode=max,scope=${{ inputs.architecture }}-runtest
-          context: ./bootstrap
-          load: true
-          tags: branchtaken/hemlock/bootstrap:latest
-          target: latest
       - name: Run "runtest"
         run: docker compose run runtest --verbose
 


### PR DESCRIPTION
The "build" and "runtest" jobs are separated because I previously had trouble creating a clean handoff of the build artifacts. The barriers for that are no longer there, so we can run "build" and then "runtest" on the output artifacts.