### PR TITLE
Enhance state reindexing to reindex isocore set sequence numbers

### DIFF
--- a/bootstrap/bin/hocc/attrib.ml
+++ b/bootstrap/bin/hocc/attrib.ml
@@ -100,8 +100,8 @@ module T = struct
     in
     {t with conflict_state_index=conflict_state_index'}
 
-  let reindex index_map ({conflict_state_index; _} as t) =
-    match Ordmap.get conflict_state_index index_map with
+  let reindex state_index_map ({conflict_state_index; _} as t) =
+    match StateIndexMap.reindexed_state_index_opt conflict_state_index state_index_map with
     | None -> None
     | Some conflict_state_index' -> Some {t with conflict_state_index=conflict_state_index'}
 

--- a/bootstrap/bin/hocc/attrib.mli
+++ b/bootstrap/bin/hocc/attrib.mli
@@ -52,10 +52,10 @@ val remerge1: (StateIndex.t, StateIndex.t, StateIndex.cmper_witness) Ordmap.t ->
     translated according to [remergeable_index_map], where keys are the original indexes, and values
     are the reindexed indexes. *)
 
-val reindex: (StateIndex.t, StateIndex.t, StateIndex.cmper_witness) Ordmap.t -> t -> t option
-(** [reindex index_map t] creates an attrib with all state indexes translated according to
-    [index_map], where keys are the original indexes, and values are the reindexed indexes. If no
-    translation exists, returns [None] to indicate that the attrib is obsolete. *)
+val reindex: StateIndexMap.t -> t -> t option
+(** [reindex state_index_map t] creates an attrib with all state indexes translated according to
+    [state_index_map]. If no translation exists, returns [None] to indicate that the attrib is
+    obsolete. *)
 
 val is_empty: t -> bool
 (** [is_empty t] returns true if there are no attributions in [t]. *)

--- a/bootstrap/bin/hocc/attribs.ml
+++ b/bootstrap/bin/hocc/attribs.ml
@@ -187,10 +187,10 @@ let remerge1 remergeable_index_map t =
 let remerge remergeable_index_map t0 t1 =
   remerge1 remergeable_index_map (union t0 t1)
 
-let reindex index_map t =
+let reindex state_index_map t =
   Ordmap.fold ~init:empty
     ~f:(fun reindexed_t (_symbol_index, attrib) ->
-      match Attrib.reindex index_map attrib with
+      match Attrib.reindex state_index_map attrib with
       | None -> reindexed_t
       | Some attrib' -> insert_remerged attrib' reindexed_t
     ) t

--- a/bootstrap/bin/hocc/attribs.mli
+++ b/bootstrap/bin/hocc/attribs.mli
@@ -83,9 +83,9 @@ val remerge: (StateIndex.t, StateIndex.t, StateIndex.cmper_witness) Ordmap.t -> 
     remergeable attribs [t0] and [t1], translated according to [remergeable_index_map], where keys
     are the original indexes, and values are the reindexed indexes. *)
 
-val reindex: (StateIndex.t, StateIndex.t, StateIndex.cmper_witness) Ordmap.t -> t -> t
-(** [reindex index_map t] creates attribs with all state indexes translated according to
-    [index_map], where keys are the original indexes, and values are the reindexed indexes. *)
+val reindex: StateIndexMap.t -> t -> t
+(** [reindex state_index_map t] creates attribs with all state indexes translated according to
+    [state_index_map]. *)
 
 val fold_until: init:'accum -> f:('accum -> Attrib.t -> 'accum * bool) -> t -> 'accum
 (** [fold ~init ~f t] folds over the attribs in [t], using [init] as the initial accumulator value,

--- a/bootstrap/bin/hocc/isocores.ml
+++ b/bootstrap/bin/hocc/isocores.ml
@@ -78,7 +78,7 @@ let insert symbols (GotoNub.{isocores_sn_opt; _} as gotonub) ({isocores; statenu
       let statenub =
         StateNub.init symbols ~index:statenub_index ~isocores_sn ~isocore_set_sn gotonub in
       let statenubs_map' = Ordmap.insert_hlt ~k:statenub_index ~v:statenub statenubs_map in
-      let v = { isocore_set=Ordset.singleton (module StateNub.Index) statenub_index; isocores_sn} in
+      let v = {isocore_set=Ordset.singleton (module StateNub.Index) statenub_index; isocores_sn} in
       let isocores' = Map.insert_hlt ~k:core ~v isocores in
       statenub_index, {t with isocores=isocores'; statenubs_map=statenubs_map'}
     end
@@ -146,12 +146,12 @@ let remerge symbols remergeable_index_map statenub_index0 statenub_index1
   let t' = {t with statenubs_map=statenubs_map'} in
   remove_hlt statenub_index_hi t'
 
-let reindex index_map ({statenubs_map; _} as t) =
+let reindex state_index_map ({statenubs_map; _} as t) =
   let isocores', statenubs_map' =
     Ordmap.fold ~init:(Map.empty (module Lr0Itemset), Ordmap.empty (module StateNub.Index))
       ~f:(fun (isocores', statenubs_map') (index, statenub) ->
-        let index' = Ordmap.get_hlt index index_map in
-        let statenub' = StateNub.reindex index_map statenub in
+        let index' = StateIndexMap.reindexed_state_index index state_index_map in
+        let statenub' = StateNub.reindex state_index_map statenub in
         let core = Lr1Itemset.core StateNub.(statenub'.lr1itemsetclosure).kernel in
         let isocores' = Map.amend core ~f:(fun v_opt ->
           match v_opt with

--- a/bootstrap/bin/hocc/isocores.mli
+++ b/bootstrap/bin/hocc/isocores.mli
@@ -59,10 +59,10 @@ val remerge: Symbols.t
     comprising the remergeable state nubs corresponding to [statenub_index0] and [statenub_index1]
     and replaces the lower-indexed state nub with the merged result in a derivative of [t]. *)
 
-val reindex: (StateNub.Index.t, StateNub.Index.t, StateNub.Index.cmper_witness) Ordmap.t -> t -> t
-(** [reindex index_map t] creates a derivative of [t] with all LR(1) item set closure and state nub
-    indexes translated according to [index_map], where keys are the original indexes, and values are
-    the reindexed indexes. State nubs without mappings are omitted from the result. *)
+val reindex: StateIndexMap.t -> t -> t
+(** [reindex state_index_map t] creates a derivative of [t] with all LR(1) item set closure and
+    state nub indexes translated according to [state_index_map]. State nubs without mappings are
+    omitted from the result. *)
 
 val isocores_length: t -> uns
 (** [isocores_length t] returns the number of isocore sets in [t]. *)

--- a/bootstrap/bin/hocc/kernelAttribs.ml
+++ b/bootstrap/bin/hocc/kernelAttribs.ml
@@ -47,9 +47,9 @@ let remerge1 remergeable_index_map t =
     Attribs.remerge1 remergeable_index_map attribs
   ) t
 
-let reindex index_map t =
+let reindex state_index_map t =
   Ordmap.map ~f:(fun (_lr1item, attribs) ->
-    Attribs.reindex index_map attribs
+    Attribs.reindex state_index_map attribs
   ) t
 
 let is_empty = Ordmap.is_empty

--- a/bootstrap/bin/hocc/kernelAttribs.mli
+++ b/bootstrap/bin/hocc/kernelAttribs.mli
@@ -38,10 +38,9 @@ val remerge1: (StateIndex.t, StateIndex.t, StateIndex.cmper_witness) Ordmap.t ->
     closure and state nub indexes translated according to [index_map], where keys are the original
     indexes, and values are the reindexed indexes. *)
 
-val reindex: (StateIndex.t, StateIndex.t, StateIndex.cmper_witness) Ordmap.t -> t -> t
-(** [reindex index_map t] creates kernel attribs with all LR(1) item set closure and state nub
-    indexes translated according to [index_map], where keys are the original indexes, and values are
-    the reindexed indexes. *)
+val reindex: StateIndexMap.t -> t -> t
+(** [reindex state_index_map t] creates kernel attribs with all LR(1) item set closure and state nub
+    indexes translated according to [state_index_map]. *)
 
 val is_empty: t -> bool
 (** [is_empty t] returns true if there are no kernel items in [t]. *)

--- a/bootstrap/bin/hocc/lr1ItemsetClosure.ml
+++ b/bootstrap/bin/hocc/lr1ItemsetClosure.ml
@@ -423,8 +423,8 @@ let remerge symbols remergeable_index_map {index=i0; kernel=k0; _} ({index=i1; _
   assert Index.(index = min i0 i1);
   match merge symbols k0 {t1 with index} with _, t1' -> t1'
 
-let reindex index_map ({index; _} as t) =
-  {t with index=Ordmap.get_hlt index index_map}
+let reindex state_index_map ({index; _} as t) =
+  {t with index=StateIndexMap.reindexed_state_index index state_index_map}
 
 let init symbols ~index lr1itemset =
   match merge symbols lr1itemset {

--- a/bootstrap/bin/hocc/lr1ItemsetClosure.mli
+++ b/bootstrap/bin/hocc/lr1ItemsetClosure.mli
@@ -40,10 +40,9 @@ val remerge: Symbols.t -> (Index.t, Index.t, Index.cmper_witness) Ordmap.t -> t 
 (** [remerge symbols remergeable_index_map t0 t1] re-merges the kernels of [t0] and [t1] creates the
     closure of the merged kernel. *)
 
-val reindex: (Index.t, Index.t, Index.cmper_witness) Ordmap.t -> t -> t
-(** [reindex index_map t] creates an LR(1) item set closure with all LR(1) item set closure indexes
-    translated according to [index_map], where keys are the original indexes, and values are the
-    reindexed indexes. *)
+val reindex: StateIndexMap.t -> t -> t
+(** [reindex state_index_map t] creates an LR(1) item set closure with all LR(1) item set closure
+    indexes translated according to [state_index_map]. *)
 
 val merge: Symbols.t -> Lr1Itemset.t -> t -> bool * t
 (** [merge symbols lr1itemset t] merges the kernel represented by [lr1itemset] into [t]'s kernel and

--- a/bootstrap/bin/hocc/remergeables.mli
+++ b/bootstrap/bin/hocc/remergeables.mli
@@ -18,4 +18,6 @@ val insert: StateNub.t -> StateNub.t -> t -> t
     prior to calling this function. *)
 
 val index_map: t -> (StateNub.Index.t, StateNub.Index.t, StateNub.Index.cmper_witness) Ordmap.t
-(** [index_map t] returns a map of remergeable statenub indexes in canonical form. *)
+(** [index_map t] returns a map of remergeable statenub indexes in canonical form.
+
+     Example: Given remergeable set {1, 2, 3}, the map contains [(2, 1); [3, 1)]. *)

--- a/bootstrap/bin/hocc/state.mli
+++ b/bootstrap/bin/hocc/state.mli
@@ -48,10 +48,9 @@ val remerge: Symbols.t -> (Index.t, Index.t, Index.cmper_witness) Ordmap.t-> t -
 (** [remerge symbols index_map t0 t1] creates a merged state comprising remergeable states
     [t0] and [t1]. *)
 
-val reindex: (Index.t, Index.t, Index.cmper_witness) Ordmap.t -> t -> t
-(** [reindex index_map t] creates a state with all LR(1) item set closure, state nub, and state
-    indexes translated according to [index_map], where keys are the original indexes, and values are
-    the reindexed indexes. *)
+val reindex: StateIndexMap.t -> t -> t
+(** [reindex state_index_map t] creates a state with all LR(1) item set closure, state nub, and
+    state indexes translated according to [state_index_map]. *)
 
 val index: t -> Index.t
 (** [index t] returns the index of the contained unique LR(1) item set closure. *)

--- a/bootstrap/bin/hocc/stateIndexMap.ml
+++ b/bootstrap/bin/hocc/stateIndexMap.ml
@@ -1,0 +1,50 @@
+open Basis
+open! Basis.Rudiments
+
+type v = {
+  (* Reindexed state index. *)
+  reindexed_state_index: StateIndex.t;
+  (* Reindexed isocore set serial number. *)
+  reindexed_isocore_set_sn: uns;
+}
+
+type t = (StateIndex.t, v, StateIndex.cmper_witness) Map.t
+
+let init ~remaining_state_indexes:remaining_state_indexes ~remergeable_index_map
+    ~isocores_sn_of_state_index =
+  let isocore_set_sizes = Map.empty (module Uns) in
+  let t = Map.empty (module StateIndex) in
+  let _, t = Ordset.fold ~init:(isocore_set_sizes, t) ~f:(fun (isocore_set_sizes, t) state_index ->
+    let isocores_sn = isocores_sn_of_state_index state_index in
+    let isocore_set_sizes = Map.amend isocores_sn ~f:(fun set_size_opt ->
+      match set_size_opt with
+      | None -> Some 1L
+      | Some set_size -> Some (succ set_size)
+    ) isocore_set_sizes in
+    let reindexed_state_index = Map.length t in
+    let reindexed_isocore_set_sn = pred (Map.get_hlt isocores_sn isocore_set_sizes) in
+    let t = Map.insert_hlt ~k:state_index ~v:{reindexed_state_index; reindexed_isocore_set_sn} t in
+    isocore_set_sizes, t
+  ) remaining_state_indexes in
+  Ordmap.fold ~init:t ~f:(fun t (state_index_alias, state_index) ->
+    let v = Map.get_hlt state_index t in
+    Map.insert_hlt ~k:state_index_alias ~v t
+  ) remergeable_index_map
+
+let reindexed_state_index state_index t =
+  let {reindexed_state_index; _} = Map.get_hlt state_index t in
+  assert (reindexed_state_index <= state_index);
+  reindexed_state_index
+
+let reindexed_state_index_opt state_index t =
+  match Map.get state_index t with
+  | None -> None
+  | Some {reindexed_state_index; _} -> begin
+      assert (reindexed_state_index <= state_index);
+      Some reindexed_state_index
+    end
+
+let reindexed_isocore_set_sn state_index t =
+  let {reindexed_state_index; reindexed_isocore_set_sn} = Map.get_hlt state_index t in
+  assert (reindexed_state_index <= state_index);
+  reindexed_isocore_set_sn

--- a/bootstrap/bin/hocc/stateIndexMap.mli
+++ b/bootstrap/bin/hocc/stateIndexMap.mli
@@ -1,0 +1,31 @@
+(** States can become unreachable due to conflict resolution and/or remerging. The state index map
+    enables recompression of state indices and isocore set sequence numbers to contiguous integer
+    sequences. *)
+
+open! Basis
+open! Basis.Rudiments
+
+type t
+
+val init: remaining_state_indexes:(StateIndex.t, StateIndex.cmper_witness) Ordset.t
+  -> remergeable_index_map:(StateIndex.t, StateIndex.t, StateIndex.cmper_witness) Ordmap.t
+  -> isocores_sn_of_state_index:(StateIndex.t -> uns) -> t
+(** [init ~remaining_state_indexes ~remergeable_index_map ~isocores_sn_of_state_index] constructs a
+    contiguously numbered mapping of state indices and isocore set sequence numbers, including only
+    remaining states and their remergeable aliases (if any). [isocores_sn_of_state_index] returns
+    the corresponding state's sequence number within its containing isocore set. *)
+
+val reindexed_state_index: StateIndex.t -> t -> StateIndex.t
+(** [reindexed_state_index state_index t] returns the reindexed state index for the original
+    [state_index]. The resulting index is always less than or equal to the state's original
+     index. *)
+
+val reindexed_state_index_opt: StateIndex.t -> t -> StateIndex.t option
+(** [reindexed_state_index state_index t] returns the reindexed state index for the original
+    [state_index] if present in the map, [None] otherwise. The resulting index is always less than
+    or equal to the state's original index. *)
+
+val reindexed_isocore_set_sn: StateIndex.t -> t -> uns
+(** [reindexed_isocore_set_sn state_index t] returns the reindexed isocore set sequence number for
+    the original [state_index]. The resulting sequence number is always less than or equal to the
+    state's original isocore set sequence number. *)

--- a/bootstrap/bin/hocc/stateNub.ml
+++ b/bootstrap/bin/hocc/stateNub.ml
@@ -230,11 +230,13 @@ let remerge symbols remergeable_index_map
     attribs=Attribs.remerge remergeable_index_map a0 a1
   }
 
-let reindex index_map
-    {lr1itemsetclosure; isocores_sn; isocore_set_sn; kernel_attribs; attribs} =
-  let lr1itemsetclosure = Lr1ItemsetClosure.reindex index_map lr1itemsetclosure in
-  let kernel_attribs = KernelAttribs.reindex index_map kernel_attribs in
-  let attribs = Attribs.reindex index_map attribs in
+let reindex state_index_map
+    {lr1itemsetclosure={index; _} as lr1itemsetclosure; isocores_sn; isocore_set_sn=_;
+      kernel_attribs; attribs} =
+  let lr1itemsetclosure = Lr1ItemsetClosure.reindex state_index_map lr1itemsetclosure in
+  let isocore_set_sn = StateIndexMap.reindexed_isocore_set_sn index state_index_map in
+  let kernel_attribs = KernelAttribs.reindex state_index_map kernel_attribs in
+  let attribs = Attribs.reindex state_index_map attribs in
   {lr1itemsetclosure; isocores_sn; isocore_set_sn; kernel_attribs; attribs}
 
 let index {lr1itemsetclosure; _} =

--- a/bootstrap/bin/hocc/stateNub.mli
+++ b/bootstrap/bin/hocc/stateNub.mli
@@ -65,10 +65,9 @@ val remerge: Symbols.t -> (Index.t, Index.t, Index.cmper_witness) Ordmap.t -> t 
 (** [remerge symbols remergeable_index_map t0 t1] creates a merged state nub comprising remergeable
     state nubs [t0] and [t1]. *)
 
-val reindex: (Index.t, Index.t, Index.cmper_witness) Ordmap.t -> t -> t
-(** [reindex index_map t] creates a state nub with all LR(1) item set closure and state nub indexes
-    translated according to [index_map], where keys are the original indexes, and values are the
-    reindexed indexes. *)
+val reindex: StateIndexMap.t -> t -> t
+(** [reindex state_index_map t] creates a state nub with all LR(1) item set closure indexes, state
+    nub indexes, and isocore set sequence numbers translated according to [state_index_map]. *)
 
 val merge: Symbols.t -> GotoNub.t -> t -> bool * t
 (** [merge symbols gotonub t] merges the kernel represented by [gotonub] into [t]'s kernel and

--- a/bootstrap/test/hocc/G2.expected.txt
+++ b/bootstrap/test/hocc/G2.expected.txt
@@ -231,7 +231,7 @@ PGM(1) States
             At : ShiftPrefix 25
             Dt : Reduce Yn ::= Ut Xn
             Et : Reduce Yn ::= Ut Xn
-    State 18 [6.1]
+    State 18 [6.0]
         Kernel
             [Yn ::= Ut · Xn, {Dt, Et}]
             [Tn ::= Ut · Xn At, {At, Dt, Et, EOI}]


### PR DESCRIPTION
State GC and remerging can leave states with noncontiguous isocore set sequence numbers, e.g. {16.0, 16.2}. This causes no correctness issues, but it makes automoton descriptions more difficult to understand. Refactor reindexing into the `StateIndexMap` module and add enhancements to reindex isocore set sequence numbers.