### PR TITLE
Remove attrib reindexing

### DIFF
--- a/bootstrap/bin/hocc/attrib.ml
+++ b/bootstrap/bin/hocc/attrib.ml
@@ -100,11 +100,6 @@ module T = struct
     in
     {t with conflict_state_index=conflict_state_index'}
 
-  let reindex state_index_map ({conflict_state_index; _} as t) =
-    match StateIndexMap.reindexed_state_index_opt conflict_state_index state_index_map with
-    | None -> None
-    | Some conflict_state_index' -> Some {t with conflict_state_index=conflict_state_index'}
-
   let is_empty {isucc_lr1itemset; contrib; _} =
     Lr1Itemset.is_empty isucc_lr1itemset &&
     Contrib.is_empty contrib

--- a/bootstrap/bin/hocc/attrib.mli
+++ b/bootstrap/bin/hocc/attrib.mli
@@ -52,11 +52,6 @@ val remerge1: (StateIndex.t, StateIndex.t, StateIndex.cmper_witness) Ordmap.t ->
     translated according to [remergeable_index_map], where keys are the original indexes, and values
     are the reindexed indexes. *)
 
-val reindex: StateIndexMap.t -> t -> t option
-(** [reindex state_index_map t] creates an attrib with all state indexes translated according to
-    [state_index_map]. If no translation exists, returns [None] to indicate that the attrib is
-    obsolete. *)
-
 val is_empty: t -> bool
 (** [is_empty t] returns true if there are no attributions in [t]. *)
 

--- a/bootstrap/bin/hocc/attribs.ml
+++ b/bootstrap/bin/hocc/attribs.ml
@@ -187,14 +187,6 @@ let remerge1 remergeable_index_map t =
 let remerge remergeable_index_map t0 t1 =
   remerge1 remergeable_index_map (union t0 t1)
 
-let reindex state_index_map t =
-  Ordmap.fold ~init:empty
-    ~f:(fun reindexed_t (_symbol_index, attrib) ->
-      match Attrib.reindex state_index_map attrib with
-      | None -> reindexed_t
-      | Some attrib' -> insert_remerged attrib' reindexed_t
-    ) t
-
 let fold_until ~init ~f t =
   Ordmap.fold_until ~init ~f:(fun accum (_symbol_index, attrib) -> f accum attrib) t
 

--- a/bootstrap/bin/hocc/attribs.mli
+++ b/bootstrap/bin/hocc/attribs.mli
@@ -83,10 +83,6 @@ val remerge: (StateIndex.t, StateIndex.t, StateIndex.cmper_witness) Ordmap.t -> 
     remergeable attribs [t0] and [t1], translated according to [remergeable_index_map], where keys
     are the original indexes, and values are the reindexed indexes. *)
 
-val reindex: StateIndexMap.t -> t -> t
-(** [reindex state_index_map t] creates attribs with all state indexes translated according to
-    [state_index_map]. *)
-
 val fold_until: init:'accum -> f:('accum -> Attrib.t -> 'accum * bool) -> t -> 'accum
 (** [fold ~init ~f t] folds over the attribs in [t], using [init] as the initial accumulator value,
     continuing until [f] returns [accum, true], or until folding is complete if [f] always returns

--- a/bootstrap/bin/hocc/kernelAttribs.ml
+++ b/bootstrap/bin/hocc/kernelAttribs.ml
@@ -47,11 +47,6 @@ let remerge1 remergeable_index_map t =
     Attribs.remerge1 remergeable_index_map attribs
   ) t
 
-let reindex state_index_map t =
-  Ordmap.map ~f:(fun (_lr1item, attribs) ->
-    Attribs.reindex state_index_map attribs
-  ) t
-
 let is_empty = Ordmap.is_empty
 
 let get = Ordmap.get

--- a/bootstrap/bin/hocc/kernelAttribs.mli
+++ b/bootstrap/bin/hocc/kernelAttribs.mli
@@ -38,10 +38,6 @@ val remerge1: (StateIndex.t, StateIndex.t, StateIndex.cmper_witness) Ordmap.t ->
     closure and state nub indexes translated according to [index_map], where keys are the original
     indexes, and values are the reindexed indexes. *)
 
-val reindex: StateIndexMap.t -> t -> t
-(** [reindex state_index_map t] creates kernel attribs with all LR(1) item set closure and state nub
-    indexes translated according to [state_index_map]. *)
-
 val is_empty: t -> bool
 (** [is_empty t] returns true if there are no kernel items in [t]. *)
 

--- a/bootstrap/bin/hocc/stateNub.ml
+++ b/bootstrap/bin/hocc/stateNub.ml
@@ -231,13 +231,11 @@ let remerge symbols remergeable_index_map
   }
 
 let reindex state_index_map
-    {lr1itemsetclosure={index; _} as lr1itemsetclosure; isocores_sn; isocore_set_sn=_;
-      kernel_attribs; attribs} =
+    ({lr1itemsetclosure={index; _} as lr1itemsetclosure; isocores_sn; isocore_set_sn=_;
+        kernel_attribs=_; attribs=_} as t) =
   let lr1itemsetclosure = Lr1ItemsetClosure.reindex state_index_map lr1itemsetclosure in
   let isocore_set_sn = StateIndexMap.reindexed_isocore_set_sn index state_index_map in
-  let kernel_attribs = KernelAttribs.reindex state_index_map kernel_attribs in
-  let attribs = Attribs.reindex state_index_map attribs in
-  {lr1itemsetclosure; isocores_sn; isocore_set_sn; kernel_attribs; attribs}
+  {t with lr1itemsetclosure; isocores_sn; isocore_set_sn}
 
 let index {lr1itemsetclosure; _} =
   lr1itemsetclosure.index

--- a/doc/tools/hocc.md
+++ b/doc/tools/hocc.md
@@ -972,7 +972,11 @@ Of note:
   + `Actions`: Map of per token actions, with conflicts prefixed by `CONFLICT`
   + `Gotos`: Map of per non-terminal gotos
   + `Conflict contributions`: Per {kernel item, follow symbol, conflict state} IELR(1) conflict
-    contributions that inform isocore (in)compatibility
+    contributions that inform isocore (in)compatibility (NB: conflict state is an LALR(1) state
+    index)
+- Conflict contributions are best interpreted in combination with a corresponding LALR(1) automaton
+  report generated with conflict resolution disabled (e.g. `hocc -txt -algorithm lalr1 -resolve no
+  -src Example`). This enables inspection of the conflicts which compel IELR(1) state splitting.
 
 ## Grammar
 


### PR DESCRIPTION
The conflict state indexes that Attribs operate on are LALR(1) state indexes, and therefore they should not be reindexed. Transitively remove the errant code.