### PR TITLE
Properly document mysterious conflicts

### DIFF
--- a/bootstrap/bin/hocc/state.ml
+++ b/bootstrap/bin/hocc/state.ml
@@ -290,6 +290,8 @@ let conflicts_alist ~resolve symbols prods {actions; _} =
     match resolve with
     | false -> (symbol_index, conflict) :: symbol_index_conflict
     | true -> begin
+        (* Conflicts which resolve to a shift action can be ignored because state merging cannot
+         * affect resolutions, but all others must be traced. *)
         let resolved = Contrib.resolve symbols prods symbol_index conflict in
         match Contrib.mem_shift resolved && (Uns.(=) (Contrib.length resolved) 1L) with
         | true -> symbol_index_conflict


### PR DESCRIPTION
Update the IELR(1) report to document all three classes of mysterious conflicts (new, invasive, mutated) rather than just mysterious new conflicts. LR(1)-inadequate parsers can exist even with no reduce-reduce conflicts, as is the case for the mysterious invasive conflicts in the OCaml grammar. (NB: The LALR(1) parser may behave as intended, but its behavior differs from one generated by LR(1) or IELR(1).)