### PR TITLE
Enhance lane context merging to reenable pointless tracing termination

### DIFF
--- a/bootstrap/bin/hocc/kernelAttribs.ml
+++ b/bootstrap/bin/hocc/kernelAttribs.ml
@@ -64,6 +64,7 @@ let union t0 t1 =
     Attribs.union attribs0 attribs1
   ) t0 t1
 
+(* Not used. *)
 let merge t0 t1 =
   (* Manually compute the union of `t0` and `t1` such that `strict_superset` is false if the union
    * equals `t1`. The conceptually simpler approach of computing the union via `union` and checking

--- a/bootstrap/bin/hocc/laneCtx.mli
+++ b/bootstrap/bin/hocc/laneCtx.mli
@@ -71,6 +71,10 @@ val of_ipred_state: State.t -> Lr1ItemsetClosure.LeftmostCache.t -> t
 val union: t -> t -> t
 (** [union t0 t1] returns a lane context containing the union of traces in [t0] and [t1]. *)
 
+val merge: t -> t -> bool * t
+(** [merge t0 t1] computes the union of [t0] and [t1], and returns the result along with a boolean
+    indicating whether the union is a strict superset of [t1]. *)
+
 val diff: t -> t -> t
 (** [diff t0 t1] returns a lane context containing traces present in [t0] but absent in [t1]. *)
 

--- a/bootstrap/bin/hocc/lr1Itemset.mli
+++ b/bootstrap/bin/hocc/lr1Itemset.mli
@@ -69,6 +69,10 @@ val remove: Lr1Item.t -> t -> t
 val union: t -> t -> t
 (** [union t0 t1] creates an LR(1) item set containing all the items in [t0] or [t1]. *)
 
+val merge: t -> t -> bool * t
+(** [merge t0 t1] computes the union of [t0] and [t1], and returns the result along with a boolean
+    indicating whether the union is a strict superset of [t1]. *)
+
 val inter: t -> t -> t
 (** [inter t0 t1] creates an LR(1) item set containing all the items in [t0] and [t1]. *)
 


### PR DESCRIPTION
The (no longer existing) `close_annotations` used `KernelAttribs.merge` to detect when lane tracing became pointless. This capability was not preserved in the initial implementation of `close_lanectxs`. Add `LaneCtx.merge` and its transitive dependencies, and use it to reimplement pointless tracing termination.