### PR TITLE
Remove html report output feature from hocc

### DIFF
--- a/bootstrap/bin/hocc/conf.ml
+++ b/bootstrap/bin/hocc/conf.ml
@@ -18,7 +18,6 @@ let pp_algorithm algorithm formatter =
 type t = {
   verbose: bool;
   text: bool;
-  html: bool;
   hocc: bool;
   algorithm: algorithm;
   resolve: bool;
@@ -30,12 +29,11 @@ type t = {
   dstdir_opt: Path.t option;
 }
 
-let pp {verbose; text; html; hocc; algorithm; resolve; remerge; hemlock; ocaml; srcdir_opt;
-  module_opt; dstdir_opt} formatter =
+let pp {verbose; text; hocc; algorithm; resolve; remerge; hemlock; ocaml; srcdir_opt; module_opt;
+  dstdir_opt} formatter =
   formatter
   |> Fmt.fmt "{verbose=" |> Bool.pp verbose
   |> Fmt.fmt "; text=" |> Bool.pp text
-  |> Fmt.fmt "; html=" |> Bool.pp html
   |> Fmt.fmt "; hocc=" |> Bool.pp hocc
   |> Fmt.fmt "; algorithm=" |> pp_algorithm algorithm
   |> Fmt.fmt "; resolve=" |> Bool.pp resolve
@@ -50,7 +48,6 @@ let pp {verbose; text; html; hocc; algorithm; resolve; remerge; hemlock; ocaml; 
 let default = {
   verbose=false;
   text=false;
-  html=false;
   hocc=false;
   algorithm=Lr1;
   resolve=true;
@@ -75,9 +72,6 @@ Parameters:
            -v[erbose] : Print progress information during parser generation.
          -txt | -text : Write a detailed automaton description in plain text
                         format to "<dstdir>/hocc/<module>.txt".
-                -html : Write a detailed automaton description in internally
-                        hyperlinked HTML format to
-                        "<dstdir>/hocc/<module>.html".
          -hmh | -hocc : Write a complete grammar specification in hocc format to
                         "<dstdir>/hocc/<module>.hmh", but with all non-terminal
                         types and reduction code omitted.
@@ -168,7 +162,6 @@ let of_argv argv =
         | "-help" | "-h" -> usage false
         | "-verbose" | "-v" -> f {t with verbose=true} argv (succ i)
         | "-txt" | "-text" -> f {t with text=true} argv (succ i)
-        | "-html" -> f {t with html=true} argv (succ i)
         | "-hmh" | "-hocc" -> f {t with hocc=true} argv (succ i)
         | "-algorithm" | "-a" -> begin
             let algorithm = match Bytes.to_string_replace (arg_arg argv i) with
@@ -265,9 +258,6 @@ let verbose {verbose; _} =
 
 let text {text; _} =
   text
-
-let html {html; _} =
-  html
 
 let hocc {hocc; _} =
   hocc

--- a/bootstrap/bin/hocc/conf.mli
+++ b/bootstrap/bin/hocc/conf.mli
@@ -25,9 +25,6 @@ val verbose: t -> bool
 val text: t -> bool
 (** [text t] returns true if a plain-text automaton description is to be generated. *)
 
-val html: t -> bool
-(** [html t] returns true if an html automaton description is to be generated. *)
-
 val hocc: t -> bool
 (** [hocc t] returns true if a hocc-format grammar specification is to be generated. *)
 

--- a/bootstrap/bin/hocc/description.ml
+++ b/bootstrap/bin/hocc/description.ml
@@ -1,34 +1,20 @@
 open Basis
 open! Basis.Rudiments
 
-type description =
-  | DescriptionTxt
-  | DescriptionHtml
-
-let generate_description conf io description Spec.{algorithm; precs; symbols; prods; states; _} =
-  let sink _ formatter = formatter in
-  let passthrough s formatter = formatter |> Fmt.fmt s in
-  let txt = match description with
-    | DescriptionTxt -> passthrough
-    | DescriptionHtml -> sink
-  in
-  let html = match description with
-    | DescriptionTxt -> sink
-    | DescriptionHtml -> passthrough
-  in
+let generate_txt conf io Spec.{algorithm; precs; symbols; prods; states; _} =
   let pp_symbol_index symbol_index formatter = begin
     let symbol = Symbols.symbol_of_symbol_index symbol_index symbols in
     let pretty_name = match symbol.alias with
       | None -> symbol.name
       | Some alias ->
         String.Fmt.empty
-        |> txt "\"" |> html "“"
+        |> Fmt.fmt "\""
         |> Fmt.fmt alias
-        |> txt "\"" |> html "”"
+        |> Fmt.fmt "\""
         |> Fmt.to_string
     in
-    formatter |> html "<a href=\"#symbol-" |> html symbol.name |> html "\">"
-    |> Fmt.fmt pretty_name |> html "</a>"
+    formatter
+    |> Fmt.fmt pretty_name
   end in
   let pp_symbol_set symbol_set formatter = begin
     formatter
@@ -44,27 +30,22 @@ let generate_description conf io description Spec.{algorithm; precs; symbols; pr
   end in
   let pp_prec name formatter = begin
     formatter
-    |> Fmt.fmt "prec " |> html "<a href=\"#prec-" |> html name |> html "\">"
+    |> Fmt.fmt "prec "
     |> Fmt.fmt name
-    |> html "</a>"
   end in
   let pp_prod ?(do_pp_prec=true) Prod.{lhs_index; rhs_indexes; prec; _} formatter = begin
     let lhs_name = Symbol.name (Symbols.symbol_of_symbol_index lhs_index symbols) in
     formatter
-    |> html "<a href=\"#symbol-" |> html lhs_name |> html "\">"
     |> Fmt.fmt lhs_name
-    |> html "</a>" |> Fmt.fmt " ::="
+    |> Fmt.fmt " ::="
     |> (fun formatter ->
       match Array.length rhs_indexes with
       | 0L -> formatter |> Fmt.fmt " epsilon"
       | _ -> begin
           Array.fold ~init:formatter ~f:(fun formatter rhs_index ->
-            let rhs_name = Symbol.name (Symbols.symbol_of_symbol_index rhs_index symbols) in
             formatter
             |> Fmt.fmt " "
-            |> html "<a href=\"#symbol-" |> html rhs_name |> html "\">"
             |> pp_symbol_index rhs_index
-            |> html "</a>"
           ) rhs_indexes
         end
     )
@@ -127,9 +108,7 @@ let generate_description conf io description Spec.{algorithm; precs; symbols; pr
   let pp_state_index state_index formatter = begin
     let state_index_string = String.Fmt.empty |> State.Index.pp state_index |> Fmt.to_string in
     formatter
-    |> html "<a href=\"#state-" |> html state_index_string |> html "\">"
     |> Fmt.fmt state_index_string
-    |> html "</a>"
   end in
   let pp_action symbol_index action formatter = begin
     let pp_symbol_prec symbol_index formatter = begin
@@ -171,25 +150,22 @@ let generate_description conf io description Spec.{algorithm; precs; symbols; pr
       end
     | _ as ncontribs -> begin
         formatter
-        |> html "<ul type=none>" |> Fmt.fmt "\n"
+        |> Fmt.fmt "\n"
         |> (fun formatter ->
           Ordset.foldi ~init:formatter ~f:(fun i formatter prod_index ->
             let prod = Prods.prod_of_prod_index prod_index prods in
             formatter
-            |> Fmt.fmt "                    " |> html "<li>"
+            |> Fmt.fmt "                    "
             |> Fmt.fmt "Reduce "
             |> pp_prod ~do_pp_prec:false prod
-            |> html "</li>" |> Fmt.fmt (match (succ i) < ncontribs with true -> "\n" | false -> "")
+            |> Fmt.fmt (match (succ i) < ncontribs with true -> "\n" | false -> "")
           ) (Contrib.reduces contrib)
         )
-        |> html "</ul>"
       end
   end in
   let io =
     io.log
-    |> Fmt.fmt "hocc: Generating "
-    |> txt "text" |> html "html"
-    |> Fmt.fmt " report\n"
+    |> Fmt.fmt "hocc: Generating text report\n"
     |> Io.with_log io
   in
   let nprecs = Precs.length precs in
@@ -199,42 +175,28 @@ let generate_description conf io description Spec.{algorithm; precs; symbols; pr
     | Pgm1 -> "PGM(1)"
     | Lalr1 -> "LALR(1)"
   in
-  (match description with
-    | DescriptionTxt -> io.txt
-    | DescriptionHtml -> io.html
-  )
-  |> html "<html>\n"
-  |> html "<body>\n"
-  |> html "<h1>" |> Fmt.fmt (Path.Segment.to_string_hlt (Conf.module_ conf))
-  |> Fmt.fmt " grammar" |> html "</h1>" |> Fmt.fmt "\n"
+  io.txt
+  |> Fmt.fmt (Path.Segment.to_string_hlt (Conf.module_ conf))
+  |> Fmt.fmt " grammar" |> Fmt.fmt "\n"
   |> Fmt.fmt "\n"
-  |> html "<h2>Sections</h2>\n"
-  |> html "    <ul type=none>\n"
   |> (fun formatter -> match nprecs with
     | 0L -> formatter
-    | _ -> formatter |> html "    <li><a href=\"#precedences\">Precedences</a></li>\n"
+    | _ -> formatter
   )
-  |> html "    <li><a href=\"#tokens\">Tokens</a></li>\n"
-  |> html "    <li><a href=\"#nonterms\">Non-terminals</a></li>\n"
-  |> html "    <li><a href=\"#states\">" |> html states_algorithm |> html " States</a></li>\n"
-  |> html "    </ul>\n"
-  |> html "<hr>\n"
   |> (fun formatter -> match nprecs with
     | 0L -> formatter
     | _ ->
-      formatter |> html "<h2 id=\"precedences\">" |> Fmt.fmt "Precedences"
+      formatter |> Fmt.fmt "Precedences"
       |> (fun formatter -> match (Conf.resolve conf) with
         | true -> formatter
         | false -> formatter |> Fmt.fmt " (conflict resolution disabled)"
       )
-      |> html "</h2>"
       |> Fmt.fmt"\n"
   )
-  |> html "    <ul>\n"
   |> (fun formatter ->
     Precs.fold_prec_sets ~init:formatter ~f:(fun formatter PrecSet.{names; assoc; doms; _} ->
       formatter
-      |> Fmt.fmt "    " |> html "<li>"
+      |> Fmt.fmt "    "
       |> Fmt.fmt (match assoc with
         | None -> "neutral"
         | Some Left -> "left"
@@ -244,9 +206,8 @@ let generate_description conf io description Spec.{algorithm; precs; symbols; pr
       |> (fun formatter ->
         Array.fold ~init:formatter ~f:(fun formatter name ->
           formatter
-          |> Fmt.fmt " " |> html "<a id=\"prec-" |> html name |> html "\">"
+          |> Fmt.fmt " "
           |> Fmt.fmt name
-          |> html "</a>"
         ) names
       )
       |> (fun formatter ->
@@ -262,9 +223,7 @@ let generate_description conf io description Spec.{algorithm; precs; symbols; pr
                       | true -> " < "
                       | false -> ", "
                     )
-                    |> html "<a href=\"#prec-" |> html name |> html "\">"
                     |> Fmt.fmt name
-                    |> html "</a>"
                   in
                   (false, formatter)
                 ) (Precs.prec_set_of_prec_index prec_ind precs).names
@@ -273,12 +232,10 @@ let generate_description conf io description Spec.{algorithm; precs; symbols; pr
             formatter
           end
       )
-      |> html "</li>" |> Fmt.fmt "\n"
+      |> Fmt.fmt "\n"
     ) precs
   )
-  |> html "    </ul>\n"
-  |> html "<h2 id=\"tokens\">" |> Fmt.fmt "Tokens" |> html "</h2>" |> Fmt.fmt "\n"
-  |> html "    <ul>\n"
+  |> Fmt.fmt "Tokens" |> Fmt.fmt "\n"
   |> (fun formatter ->
     Symbols.symbols_fold ~init:formatter
       ~f:(fun formatter (Symbol.{name; alias; stype; prec; first; follow; _} as symbol) ->
@@ -286,10 +243,8 @@ let generate_description conf io description Spec.{algorithm; precs; symbols; pr
         | false -> formatter
         | true -> begin
             formatter
-            |> Fmt.fmt "    " |> html "<li>" |> Fmt.fmt "token "
-            |> html "<a id=\"symbol-" |> html name |> html "\">"
+            |> Fmt.fmt "    " |> Fmt.fmt "token "
             |> Fmt.fmt name
-            |> html "</a>"
             |> (fun formatter ->
               match alias with
               | None -> formatter
@@ -307,21 +262,16 @@ let generate_description conf io description Spec.{algorithm; precs; symbols; pr
               | Some prec -> formatter |> Fmt.fmt " " |> pp_prec (Prec.name prec)
             )
             |> Fmt.fmt "\n"
-            |> html "        <ul type=none>\n"
-            |> Fmt.fmt "        " |> html "<li>" |> Fmt.fmt "First: "
+            |> Fmt.fmt "        First: "
             |> pp_symbol_set first
-            |> html "</li>" |> Fmt.fmt "\n"
-            |> Fmt.fmt "        " |> html "<li>" |> Fmt.fmt "Follow: "
+            |> Fmt.fmt "\n"
+            |> Fmt.fmt "        Follow: "
             |> pp_symbol_set follow
-            |> html "</li>" |> Fmt.fmt "\n"
-            |> html "        </ul>\n"
-            |> html "    </li>\n"
+            |> Fmt.fmt "\n"
           end
       ) symbols
   )
-  |> html "    </ul>\n"
-  |> html "<h2 id=\"nonterms\">" |> Fmt.fmt "Non-terminals" |> html "</h2>" |> Fmt.fmt "\n"
-  |> html "    <ul>\n"
+  |> Fmt.fmt "Non-terminals" |> Fmt.fmt "\n"
   |> (fun formatter ->
     Symbols.symbols_fold ~init:formatter
       ~f:(fun formatter (Symbol.{name; start; stype; prods; first; follow; _} as symbol) ->
@@ -329,14 +279,12 @@ let generate_description conf io description Spec.{algorithm; precs; symbols; pr
         | false -> formatter
         | true -> begin
             formatter
-            |> Fmt.fmt "    " |> html "<li>"
+            |> Fmt.fmt "    "
             |> Fmt.fmt (match start with
               | true -> "start "
               | false -> "nonterm "
             )
-            |> html "<a id=\"symbol-" |> html name |> html "\">"
             |> Fmt.fmt name
-            |> html "</a>"
             |> (fun formatter ->
               match SymbolType.is_explicit stype with
               | false -> formatter
@@ -344,35 +292,27 @@ let generate_description conf io description Spec.{algorithm; precs; symbols; pr
                 formatter |> Fmt.fmt " of " |> Fmt.fmt (SymbolType.to_string stype)
             )
             |> Fmt.fmt "\n"
-            |> html "            <ul type=none>\n"
-            |> Fmt.fmt "        " |> html "<li>" |> Fmt.fmt "First: "
+            |> Fmt.fmt "        First: "
             |> pp_symbol_set first
-            |> html "</li>" |> Fmt.fmt "\n"
-            |> Fmt.fmt "        " |> html "<li>" |> Fmt.fmt "Follow: "
+            |> Fmt.fmt "\n"
+            |> Fmt.fmt "        Follow: "
             |> pp_symbol_set follow
-            |> html "</li>" |> Fmt.fmt "\n"
-            |> Fmt.fmt "        " |> html "<li>" |> Fmt.fmt "Productions\n"
-            |> html "            <ul type=none>\n"
+            |> Fmt.fmt "\n"
+            |> Fmt.fmt "        Productions\n"
             |> (fun formatter ->
               Ordset.fold ~init:formatter
                 ~f:(fun formatter prod ->
                   formatter
-                  |> Fmt.fmt "            " |> html "<li>"
+                  |> Fmt.fmt "            "
                   |> pp_prod prod
-                  |> html "</li>" |> Fmt.fmt "\n"
+                  |> Fmt.fmt "\n"
                 ) prods
-              |> html "            </ul>\n"
-              |> html "        </li>\n"
             )
-            |> html "        </ul>\n"
-            |> html "    </li>\n"
           end
       ) symbols
   )
-  |> html "    </ul>\n"
-  |> html "<h2 id=\"states\">" |> Fmt.fmt states_algorithm |> Fmt.fmt " States" |> html "</h2>"
+  |> Fmt.fmt states_algorithm |> Fmt.fmt " States"
   |> Fmt.fmt "\n"
-  |> html "    <ul>\n"
   |> (fun formatter ->
     Array.fold ~init:formatter
       ~f:(fun formatter (State.{statenub; actions; gotos; _} as state) ->
@@ -380,8 +320,7 @@ let generate_description conf io description Spec.{algorithm; precs; symbols; pr
           String.Fmt.empty |> StateNub.Index.pp (StateNub.index statenub)
           |> Fmt.to_string in
         formatter
-        |> Fmt.fmt "    " |> html "<li>" |> Fmt.fmt "State "
-        |> html "<a id=\"state-" |> html state_index_string |> html "\">"
+        |> Fmt.fmt "    State "
         |> Fmt.fmt state_index_string
         |> (fun formatter ->
           match algorithm with
@@ -397,50 +336,42 @@ let generate_description conf io description Spec.{algorithm; precs; symbols; pr
             end
           | Lalr1 -> formatter
         )
-        |> html "</a>" |> Fmt.fmt "\n"
-        |> html "        <ul type=none>\n"
-        |> Fmt.fmt "        " |> html "<li>" |> Fmt.fmt "Kernel\n"
-        |> html "            <ul type=none>\n"
+        |> Fmt.fmt "\n"
+        |> Fmt.fmt "        Kernel\n"
         |> (fun formatter ->
           Lr1Itemset.fold ~init:formatter ~f:(fun formatter lr1itemset ->
             formatter
-            |> Fmt.fmt "            " |> html "<li>"
+            |> Fmt.fmt "            "
             |> pp_lr1item lr1itemset
-            |> html "</li>" |> Fmt.fmt "\n"
+            |> Fmt.fmt "\n"
           ) statenub.lr1itemsetclosure.kernel
         )
-        |> html "            </ul>\n"
-        |> html "        </li>\n"
         |> (fun formatter ->
           match Lr1Itemset.is_empty statenub.lr1itemsetclosure.added with
           | true -> formatter
           | false -> begin
               formatter
-              |> Fmt.fmt "        " |> html "<li>" |> Fmt.fmt "Added\n"
-              |> html "            <ul type=none>\n"
+              |> Fmt.fmt "        Added\n"
               |> (fun formatter ->
                 Lr1Itemset.fold ~init:formatter ~f:(fun formatter lr1itemset ->
-                  formatter |> Fmt.fmt "            " |> html "<li>"
+                  formatter |> Fmt.fmt "            "
                   |> pp_lr1item lr1itemset
-                  |> html "</li>" |> Fmt.fmt "\n"
+                  |> Fmt.fmt "\n"
                 ) statenub.lr1itemsetclosure.added
               )
-              |> html "            </ul>\n"
-              |> html "        </li>\n"
             end
         )
         |> (fun formatter ->
           let has_pseudo_end_conflict = State.has_pseudo_end_conflict state in
           formatter
-          |> Fmt.fmt "        " |> html "<li>" |> Fmt.fmt "Actions\n"
-          |> html "            <ul type=none>\n"
+          |> Fmt.fmt "        Actions\n"
           |> (fun formatter ->
             Ordmap.fold ~init:formatter ~f:(fun formatter (symbol_index, action_set) ->
               formatter
               |> (fun formatter ->
                 match has_pseudo_end_conflict && symbol_index = Symbol.pseudo_end.index with
-                | false -> formatter |> Fmt.fmt "            " |> html "<li>"
-                | true -> formatter |> txt "CONFLICT    " |> html "            <li>CONFLICT "
+                | false -> formatter |> Fmt.fmt "            "
+                | true -> formatter |> Fmt.fmt "CONFLICT    "
               )
               |> pp_symbol_index symbol_index |> Fmt.fmt " :"
               |> (fun formatter ->
@@ -449,45 +380,38 @@ let generate_description conf io description Spec.{algorithm; precs; symbols; pr
                     formatter
                     |> Fmt.fmt " "
                     |> pp_action symbol_index (Ordset.choose_hlt action_set)
-                    |> html "</li>" |> Fmt.fmt "\n"
+                    |> Fmt.fmt "\n"
                   end
                 | _ -> begin
                     formatter
-                    |> html " CONFLICT" |> Fmt.fmt "\n"
-                    |> html "                <ul type=none>\n"
+                    |> Fmt.fmt "\n"
                     |> (fun formatter ->
                       Ordset.fold ~init:formatter ~f:(fun formatter action ->
                         formatter
-                        |> txt "CONFLICT        " |> html "                <li>"
+                        |> Fmt.fmt "CONFLICT        "
                         |> pp_action symbol_index action
-                        |> html "</li>" |> Fmt.fmt "\n"
+                        |> Fmt.fmt "\n"
                       ) action_set
                     )
-                    |> html "                </ul>\n"
                   end
               )
             ) actions
           )
-          |> html "            </ul>\n"
-          |> html "        </li>\n"
         )
         |> (fun formatter ->
           match Ordmap.is_empty gotos with
           | true -> formatter
           | false -> begin
               formatter
-              |> Fmt.fmt "        " |> html "<li>" |> Fmt.fmt "Gotos\n"
-              |> html "            <ul type=none>\n"
+              |> Fmt.fmt "        Gotos\n"
               |> (fun formatter ->
                 Ordmap.fold ~init:formatter ~f:(fun formatter (symbol_index, state_index) ->
                   formatter
-                  |> Fmt.fmt "            " |> html "<li>"
+                  |> Fmt.fmt "            "
                   |> pp_symbol_index symbol_index |> Fmt.fmt " : " |> State.Index.pp state_index
-                  |> html "</li>" |> Fmt.fmt "\n"
+                  |> Fmt.fmt "\n"
                 ) gotos
               )
-              |> html "            </ul>\n"
-              |> html "        </li>\n"
             end
         )
         |> (fun formatter ->
@@ -497,46 +421,27 @@ let generate_description conf io description Spec.{algorithm; precs; symbols; pr
           | _ -> begin
               let kernel_attribs = StateNub.filtered_kernel_attribs statenub in
               formatter
-              |> Fmt.fmt "        " |> html "<li>" |> Fmt.fmt "Conflict contributions\n"
-              |> html "            <ul type=none>\n"
+              |> Fmt.fmt "        Conflict contributions\n"
               |> (fun formatter ->
                 KernelAttribs.fold ~init:formatter ~f:(fun formatter (kernel_item, attribs) ->
                   formatter
                   |> Fmt.fmt "            " |> pp_lr1item ~do_pp_prec:false kernel_item
                   |> Fmt.fmt "\n"
-                  |> html "                <ul type=none>\n"
                   |> (fun formatter ->
                     Attribs.fold ~init:formatter
                       ~f:(fun formatter Attrib.{conflict_state_index; contrib; _} ->
                         formatter
-                        |> Fmt.fmt "                " |> html "<li>"
+                        |> Fmt.fmt "                "
                         |> pp_state_index conflict_state_index
                         |> Fmt.fmt " : "
                         |> pp_contrib contrib
-                        |> html "</li>" |> Fmt.fmt "\n"
+                        |> Fmt.fmt "\n"
                       ) attribs
                   )
-                  |> html "                </ul>\n"
                 ) kernel_attribs
               )
-              |> html "            </ul>\n"
-              |> html "        </li>\n"
             end
         )
-        |> html "        </ul>\n"
-        |> html "    </li>\n"
       ) states
   )
-  |> html "    </ul>\n"
-  |> html "</body>\n"
-  |> html "</html>\n"
-  |> (match description with
-    | DescriptionTxt -> Io.with_txt io
-    | DescriptionHtml -> Io.with_html io
-  )
-
-let generate_txt conf io spec =
-  generate_description conf io DescriptionTxt spec
-
-let generate_html conf io spec =
-  generate_description conf io DescriptionHtml spec
+  |> Io.with_txt io

--- a/bootstrap/bin/hocc/description.mli
+++ b/bootstrap/bin/hocc/description.mli
@@ -1,7 +1,4 @@
-(** Text/html description generation. *)
+(** Text description generation. *)
 
 val generate_txt: Conf.t -> Io.t -> Spec.t -> Io.t
 (** [generate_txt conf io spec] integrates a text representation of [spec] into [io]. *)
-
-val generate_html: Conf.t -> Io.t -> Spec.t -> Io.t
-(** [generate_html conf io spec] integrates an html representation of [spec] into [io]. *)

--- a/bootstrap/bin/hocc/hocc.ml
+++ b/bootstrap/bin/hocc/hocc.ml
@@ -48,10 +48,6 @@ let _ =
     | false -> io
     | true -> Description.generate_txt conf io spec
   in
-  let io = match Conf.html conf with
-    | false -> io
-    | true -> Description.generate_html conf io spec
-  in
   let io = match Conf.hocc conf with
     | false -> io
     | true -> Grammar.generate_hocc io spec

--- a/bootstrap/bin/hocc/io.ml
+++ b/bootstrap/bin/hocc/io.ml
@@ -7,7 +7,6 @@ type t = {
   hmh: Text.t;
   log: (module Fmt.Formatter);
   txt: (module Fmt.Formatter);
-  html: (module Fmt.Formatter);
   hocc: (module Fmt.Formatter);
   hmi: (module Fmt.Formatter);
   hm: (module Fmt.Formatter);
@@ -70,11 +69,6 @@ let init_txt conf =
   | false -> File.Fmt.sink
   | true -> String.Fmt.empty
 
-let init_html conf =
-  match Conf.html conf with
-  | false -> File.Fmt.sink
-  | true -> String.Fmt.empty
-
 let init_hocc conf =
   match Conf.hocc conf with
   | false -> File.Fmt.sink
@@ -108,14 +102,13 @@ let init conf =
   let hmh = init_hmh conf ~err in
   let log = init_log conf in
   let txt = init_txt conf in
-  let html = init_html conf in
   let hocc = init_hocc conf in
   let hmi = init_hmi conf hmhi in
   let hm = init_hm conf in
   let mli = init_mli conf hmhi in
   let ml = init_ml conf in
 
-  {err; hmhi; hmh; log; txt; html; hocc; hmi; hm; mli; ml}
+  {err; hmhi; hmh; log; txt; hocc; hmi; hm; mli; ml}
 
 let open_outfile_as_formatter ~is_report ~err path =
   let _ = match is_report with
@@ -141,9 +134,8 @@ let fini_formatter ?(is_report=false) conf conflicts ~err ~log formatter suffix 
     end
   | false -> log, formatter
 
-let fini conf conflicts ({err; log; txt; html; hocc; hmi; hm; mli; ml; _} as t) =
+let fini conf conflicts ({err; log; txt; hocc; hmi; hm; mli; ml; _} as t) =
   let log, txt = fini_formatter ~is_report:true conf conflicts ~err ~log txt ".txt" in
-  let log, html = fini_formatter ~is_report:true conf conflicts ~err ~log html ".html" in
   let log, hocc = fini_formatter ~is_report:true conf conflicts ~err ~log hocc ".hmh" in
 
   let log, hmi = fini_formatter conf conflicts ~err ~log hmi ".hmi" in
@@ -151,7 +143,7 @@ let fini conf conflicts ({err; log; txt; html; hocc; hmi; hm; mli; ml; _} as t) 
   let log, mli = fini_formatter conf conflicts ~err ~log mli ".mli" in
   let log, ml = fini_formatter conf conflicts ~err ~log ml ".ml" in
   let log = Fmt.flush log in
-  {t with log; txt; html; hocc; hmi; hm; mli; ml}
+  {t with log; txt; hocc; hmi; hm; mli; ml}
 
 let fatal {err; _} =
   let _err = Fmt.flush err in
@@ -166,9 +158,6 @@ let with_log t log =
 
 let with_txt t txt =
   {t with txt}
-
-let with_html t html =
-  {t with html}
 
 let with_hocc t hocc =
   {t with hocc}

--- a/bootstrap/bin/hocc/io.mli
+++ b/bootstrap/bin/hocc/io.mli
@@ -14,7 +14,6 @@ type t = {
   hmh: Text.t;
   log: (module Fmt.Formatter);
   txt: (module Fmt.Formatter);
-  html: (module Fmt.Formatter);
   hocc: (module Fmt.Formatter);
   hmi: (module Fmt.Formatter);
   hm: (module Fmt.Formatter);
@@ -40,9 +39,6 @@ val with_log: t -> (module Fmt.Formatter) -> t
 
 val with_txt: t -> (module Fmt.Formatter) -> t
 (** [with_txt t txt] is equivalent to [{t with txt}]. *)
-
-val with_html: t -> (module Fmt.Formatter) -> t
-(** [with_html t html] is equivalent to [{t with html}]. *)
 
 val with_hocc: t -> (module Fmt.Formatter) -> t
 (** [with_hocc t hocc] is equivalent to [{t with hocc}]. *)

--- a/bootstrap/test/hocc/dune
+++ b/bootstrap/test/hocc/dune
@@ -177,7 +177,7 @@
  (action
   (with-accepted-exit-codes
    (or 0 1)
-   (with-outputs-to help_a.out (run %{bin:hocc} -v -verbose -txt -text -html -hmh -hocc -c -canonical -hm -hemlock -ml -ocaml -s Foo -src Foo -d bar -dstdir bar -h)))))
+   (with-outputs-to help_a.out (run %{bin:hocc} -v -verbose -txt -text -hmh -hocc -c -canonical -hm -hemlock -ml -ocaml -s Foo -src Foo -d bar -dstdir bar -h)))))
 (rule
  (alias runtest)
  (action (diff help_a.expected help_a.out)))
@@ -188,7 +188,7 @@
  (action
   (with-accepted-exit-codes
    (or 0 1)
-   (with-outputs-to help_b.out (run %{bin:hocc} -v -verbose -txt -text -html -hmh -hocc -c -canonical -hm -hemlock -ml -ocaml -s Foo -src Foo -d bar -dstdir bar -no-such-option)))))
+   (with-outputs-to help_b.out (run %{bin:hocc} -v -verbose -txt -text -hmh -hocc -c -canonical -hm -hemlock -ml -ocaml -s Foo -src Foo -d bar -dstdir bar -no-such-option)))))
 (rule
  (alias runtest)
  (action (diff help_b.expected help_b.out)))

--- a/bootstrap/test/hocc/help_a.expected
+++ b/bootstrap/test/hocc/help_a.expected
@@ -6,9 +6,6 @@ Parameters:
            -v[erbose] : Print progress information during parser generation.
          -txt | -text : Write a detailed automaton description in plain text
                         format to "<dstdir>/hocc/<module>.txt".
-                -html : Write a detailed automaton description in internally
-                        hyperlinked HTML format to
-                        "<dstdir>/hocc/<module>.html".
          -hmh | -hocc : Write a complete grammar specification in hocc format to
                         "<dstdir>/hocc/<module>.hmh", but with all non-terminal
                         types and reduction code omitted.

--- a/bootstrap/test/hocc/help_b.expected
+++ b/bootstrap/test/hocc/help_b.expected
@@ -6,9 +6,6 @@ Parameters:
            -v[erbose] : Print progress information during parser generation.
          -txt | -text : Write a detailed automaton description in plain text
                         format to "<dstdir>/hocc/<module>.txt".
-                -html : Write a detailed automaton description in internally
-                        hyperlinked HTML format to
-                        "<dstdir>/hocc/<module>.html".
          -hmh | -hocc : Write a complete grammar specification in hocc format to
                         "<dstdir>/hocc/<module>.hmh", but with all non-terminal
                         types and reduction code omitted.

--- a/bootstrap/test/hocc/hocc_test
+++ b/bootstrap/test/hocc/hocc_test
@@ -51,5 +51,4 @@ mv_report() {
     fi
 }
 mv_report txt
-mv_report html
 mv_report hmh

--- a/doc/tools/hocc.md
+++ b/doc/tools/hocc.md
@@ -34,8 +34,6 @@ Parameters:
 - `-v[erbose]`: Print progress information during parser generation.
 - `-txt` | `-text`: Write a detailed automaton description in plain text format to
   `<dstdir>/hocc/<module>.txt`.
-- `-html`: Write a detailed automaton description in internally hyperlinked HTML format to
-  `<dstdir>/hocc/<module>.html`.
 - `-hmh` | `-hocc`: Write a complete grammar specification in `hocc` format to
   `<dstdir>/hocc/<module>.hmh`, but with all non-terminal types and reduction code omitted.
 - `-a[lgorithm] <alg>`: Use the specified `<alg>`orithm for generating an automaton. Defaults to


### PR DESCRIPTION
This feature proved to be of limited usefulness because large, extremely interlinked html documents bring modern web browsers to their knees.

Resolves #256