### PR TITLE
Fix added set computation to be memoized

### DIFF
--- a/bootstrap/bin/hocc/Parse.ml
+++ b/bootstrap/bin/hocc/Parse.ml
@@ -1578,6 +1578,7 @@ include struct
                 type t = {
                     index: uns;
                     kernel: Lr1Itemset.t;
+                    added: Lr1Itemset.t lazy_t;
                   }
 
                 let hash_fold {index; _} state =
@@ -1586,7 +1587,7 @@ include struct
                 let cmp {index=i0; _} {index=i1; _} =
                     Uns.cmp i0 i1
 
-                let pp {index; kernel} formatter =
+                let pp {index; kernel; _} formatter =
                     formatter
                       |> Fmt.fmt "{index=" |> Uns.pp index
                       |> Fmt.fmt "; kernel=" |> Lr1Itemset.pp kernel
@@ -1595,10 +1596,7 @@ include struct
             include T
             include Identifiable.Make(T)
 
-            let init ~index ~kernel =
-                {index; kernel}
-
-            let added_impl symbols {kernel; _} =
+            let added_impl symbols kernel =
                 let rec f symbols lr1itemset added = begin
                     match Ordmap.choose lr1itemset with
                       | None -> added
@@ -1643,9 +1641,11 @@ include struct
                   end in
                 f symbols kernel Lr1Itemset.empty
 
-            let added t =
-                lazy (added_impl symbols t)
-                  |> Lazy.force
+            let added {added; _} =
+                Lazy.force added
+
+            let init ~index ~kernel =
+                {index; kernel; added=lazy (added_impl symbols kernel)}
           end
 
         module Action = struct

--- a/bootstrap/bin/hocc/code.ml
+++ b/bootstrap/bin/hocc/code.ml
@@ -212,6 +212,7 @@ let hmi_template = {|{
             type t: t = {
                 index: uns # Index of corresponding `State.t` in `states` array.
                 kernel: Lr1Itemset.t
+                added: lazy_t Lr1Itemset.t
               }
 
             include IdentifiableIntf.S with type t := t
@@ -830,6 +831,7 @@ let hm_template = {|{
                 type t: t = {
                     index: uns
                     kernel: Lr1Itemset.t
+                    added: lazy_t Lr1Itemset.t
                   }
 
                 hash_fold {index; _} state =
@@ -848,10 +850,7 @@ let hm_template = {|{
             include T
             include Identifiable.Make(T)
 
-            init ~index ~kernel =
-                {index; kernel}
-
-            added_impl symbols {kernel; _} =
+            added_impl symbols kernel =
                 let rec f symbols lr1itemset added =
                     match Ordmap.choose lr1itemset with
                       | None -> added
@@ -889,9 +888,11 @@ let hm_template = {|{
                                 f symbols lr1itemset' added'
                 f symbols kernel Lr1Itemset.empty
 
-            let added t =
-                lazy (added_impl symbols t)
-                  |> Lazy.force
+            let added {added; _} =
+                Lazy.force added
+
+            init ~index ~kernel =
+                {index; kernel; added=lazy (added_impl symbols kernel)}
           }
 
         Action = {
@@ -2120,6 +2121,7 @@ let mli_template = {|sig
             type t = {
                 index: uns; (* Index of corresponding `State.t` in `states` array. *)
                 kernel: Lr1Itemset.t;
+                added: Lr1Itemset.t lazy_t;
               }
 
             include IdentifiableIntf.S with type t := t
@@ -2746,6 +2748,7 @@ let ml_template = {|struct
                 type t = {
                     index: uns;
                     kernel: Lr1Itemset.t;
+                    added: Lr1Itemset.t lazy_t;
                   }
 
                 let hash_fold {index; _} state =
@@ -2754,7 +2757,7 @@ let ml_template = {|struct
                 let cmp {index=i0; _} {index=i1; _} =
                     Uns.cmp i0 i1
 
-                let pp {index; kernel} formatter =
+                let pp {index; kernel; _} formatter =
                     formatter
                       |> Fmt.fmt "{index=" |> Uns.pp index
                       |> Fmt.fmt "; kernel=" |> Lr1Itemset.pp kernel
@@ -2763,10 +2766,7 @@ let ml_template = {|struct
             include T
             include Identifiable.Make(T)
 
-            let init ~index ~kernel =
-                {index; kernel}
-
-            let added_impl symbols {kernel; _} =
+            let added_impl symbols kernel =
                 let rec f symbols lr1itemset added = begin
                     match Ordmap.choose lr1itemset with
                       | None -> added
@@ -2811,9 +2811,11 @@ let ml_template = {|struct
                   end in
                 f symbols kernel Lr1Itemset.empty
 
-            let added t =
-                lazy (added_impl symbols t)
-                  |> Lazy.force
+            let added {added; _} =
+                Lazy.force added
+
+            let init ~index ~kernel =
+                {index; kernel; added=lazy (added_impl symbols kernel)}
           end
 
         module Action = struct

--- a/bootstrap/test/hocc/Example.expected.hm
+++ b/bootstrap/test/hocc/Example.expected.hm
@@ -447,6 +447,7 @@ include [:]{
                 type t: t = {
                     index: uns
                     kernel: Lr1Itemset.t
+                    added: lazy_t Lr1Itemset.t
                   }
 
                 hash_fold {index; _} state =
@@ -465,10 +466,7 @@ include [:]{
             include T
             include Identifiable.Make(T)
 
-            init ~index ~kernel =
-                {index; kernel}
-
-            added_impl symbols {kernel; _} =
+            added_impl symbols kernel =
                 let rec f symbols lr1itemset added =
                     match Ordmap.choose lr1itemset with
                       | None -> added
@@ -506,9 +504,11 @@ include [:]{
                                 f symbols lr1itemset' added'
                 f symbols kernel Lr1Itemset.empty
 
-            let added t =
-                lazy (added_impl symbols t)
-                  |> Lazy.force
+            let added {added; _} =
+                Lazy.force added
+
+            init ~index ~kernel =
+                {index; kernel; added=lazy (added_impl symbols kernel)}
           }
 
         Action = {

--- a/bootstrap/test/hocc/Example.expected.hmi
+++ b/bootstrap/test/hocc/Example.expected.hmi
@@ -114,6 +114,7 @@ include [:]{
             type t: t = {
                 index: uns # Index of corresponding `State.t` in `states` array.
                 kernel: Lr1Itemset.t
+                added: lazy_t Lr1Itemset.t
               }
 
             include IdentifiableIntf.S with type t := t

--- a/bootstrap/test/hocc/Example_b.expected.hm
+++ b/bootstrap/test/hocc/Example_b.expected.hm
@@ -448,6 +448,7 @@ include
                 type t: t = {
                     index: uns
                     kernel: Lr1Itemset.t
+                    added: lazy_t Lr1Itemset.t
                   }
 
                 hash_fold {index; _} state =
@@ -466,10 +467,7 @@ include
             include T
             include Identifiable.Make(T)
 
-            init ~index ~kernel =
-                {index; kernel}
-
-            added_impl symbols {kernel; _} =
+            added_impl symbols kernel =
                 let rec f symbols lr1itemset added =
                     match Ordmap.choose lr1itemset with
                       | None -> added
@@ -507,9 +505,11 @@ include
                                 f symbols lr1itemset' added'
                 f symbols kernel Lr1Itemset.empty
 
-            let added t =
-                lazy (added_impl symbols t)
-                  |> Lazy.force
+            let added {added; _} =
+                Lazy.force added
+
+            init ~index ~kernel =
+                {index; kernel; added=lazy (added_impl symbols kernel)}
           }
 
         Action = {

--- a/bootstrap/test/hocc/Example_b.expected.hmi
+++ b/bootstrap/test/hocc/Example_b.expected.hmi
@@ -114,6 +114,7 @@ include
             type t: t = {
                 index: uns # Index of corresponding `State.t` in `states` array.
                 kernel: Lr1Itemset.t
+                added: lazy_t Lr1Itemset.t
               }
 
             include IdentifiableIntf.S with type t := t

--- a/bootstrap/test/hocc/Example_c.expected.hm
+++ b/bootstrap/test/hocc/Example_c.expected.hm
@@ -448,6 +448,7 @@ Parser = {
                     type t: t = {
                         index: uns
                         kernel: Lr1Itemset.t
+                        added: lazy_t Lr1Itemset.t
                       }
 
                     hash_fold {index; _} state =
@@ -466,10 +467,7 @@ Parser = {
                 include T
                 include Identifiable.Make(T)
 
-                init ~index ~kernel =
-                    {index; kernel}
-
-                added_impl symbols {kernel; _} =
+                added_impl symbols kernel =
                     let rec f symbols lr1itemset added =
                         match Ordmap.choose lr1itemset with
                           | None -> added
@@ -507,9 +505,11 @@ Parser = {
                                     f symbols lr1itemset' added'
                     f symbols kernel Lr1Itemset.empty
 
-                let added t =
-                    lazy (added_impl symbols t)
-                      |> Lazy.force
+                let added {added; _} =
+                    Lazy.force added
+
+                init ~index ~kernel =
+                    {index; kernel; added=lazy (added_impl symbols kernel)}
               }
 
             Action = {

--- a/bootstrap/test/hocc/Example_c.expected.hmi
+++ b/bootstrap/test/hocc/Example_c.expected.hmi
@@ -114,6 +114,7 @@ Parser = {
                 type t: t = {
                     index: uns # Index of corresponding `State.t` in `states` array.
                     kernel: Lr1Itemset.t
+                    added: lazy_t Lr1Itemset.t
                   }
 
                 include IdentifiableIntf.S with type t := t

--- a/bootstrap/test/hocc/Example_introspect.expected.ml
+++ b/bootstrap/test/hocc/Example_introspect.expected.ml
@@ -458,6 +458,7 @@ include struct
                 type t = {
                     index: uns;
                     kernel: Lr1Itemset.t;
+                    added: Lr1Itemset.t lazy_t;
                   }
 
                 let hash_fold {index; _} state =
@@ -466,7 +467,7 @@ include struct
                 let cmp {index=i0; _} {index=i1; _} =
                     Uns.cmp i0 i1
 
-                let pp {index; kernel} formatter =
+                let pp {index; kernel; _} formatter =
                     formatter
                       |> Fmt.fmt "{index=" |> Uns.pp index
                       |> Fmt.fmt "; kernel=" |> Lr1Itemset.pp kernel
@@ -475,10 +476,7 @@ include struct
             include T
             include Identifiable.Make(T)
 
-            let init ~index ~kernel =
-                {index; kernel}
-
-            let added_impl symbols {kernel; _} =
+            let added_impl symbols kernel =
                 let rec f symbols lr1itemset added = begin
                     match Ordmap.choose lr1itemset with
                       | None -> added
@@ -523,9 +521,11 @@ include struct
                   end in
                 f symbols kernel Lr1Itemset.empty
 
-            let added t =
-                lazy (added_impl symbols t)
-                  |> Lazy.force
+            let added {added; _} =
+                Lazy.force added
+
+            let init ~index ~kernel =
+                {index; kernel; added=lazy (added_impl symbols kernel)}
           end
 
         module Action = struct

--- a/bootstrap/test/hocc/Example_introspect.expected.mli
+++ b/bootstrap/test/hocc/Example_introspect.expected.mli
@@ -113,6 +113,7 @@ include sig
             type t = {
                 index: uns; (* Index of corresponding `State.t` in `states` array. *)
                 kernel: Lr1Itemset.t;
+                added: Lr1Itemset.t lazy_t;
               }
 
             include IdentifiableIntf.S with type t := t

--- a/bootstrap/test/hocc/Example_ml.expected.ml
+++ b/bootstrap/test/hocc/Example_ml.expected.ml
@@ -459,6 +459,7 @@ include struct
                 type t = {
                     index: uns;
                     kernel: Lr1Itemset.t;
+                    added: Lr1Itemset.t lazy_t;
                   }
 
                 let hash_fold {index; _} state =
@@ -467,7 +468,7 @@ include struct
                 let cmp {index=i0; _} {index=i1; _} =
                     Uns.cmp i0 i1
 
-                let pp {index; kernel} formatter =
+                let pp {index; kernel; _} formatter =
                     formatter
                       |> Fmt.fmt "{index=" |> Uns.pp index
                       |> Fmt.fmt "; kernel=" |> Lr1Itemset.pp kernel
@@ -476,10 +477,7 @@ include struct
             include T
             include Identifiable.Make(T)
 
-            let init ~index ~kernel =
-                {index; kernel}
-
-            let added_impl symbols {kernel; _} =
+            let added_impl symbols kernel =
                 let rec f symbols lr1itemset added = begin
                     match Ordmap.choose lr1itemset with
                       | None -> added
@@ -524,9 +522,11 @@ include struct
                   end in
                 f symbols kernel Lr1Itemset.empty
 
-            let added t =
-                lazy (added_impl symbols t)
-                  |> Lazy.force
+            let added {added; _} =
+                Lazy.force added
+
+            let init ~index ~kernel =
+                {index; kernel; added=lazy (added_impl symbols kernel)}
           end
 
         module Action = struct

--- a/bootstrap/test/hocc/Example_ml.expected.mli
+++ b/bootstrap/test/hocc/Example_ml.expected.mli
@@ -115,6 +115,7 @@ include sig
             type t = {
                 index: uns; (* Index of corresponding `State.t` in `states` array. *)
                 kernel: Lr1Itemset.t;
+                added: Lr1Itemset.t lazy_t;
               }
 
             include IdentifiableIntf.S with type t := t


### PR DESCRIPTION
Capture a lazy value in each LR(1) itemset during initialization such that each itemset's added set is memoized when the lazy value is forced.