### PR TITLE
Reformat conflict contribution reporting

### DIFF
--- a/bootstrap/bin/hocc/description.ml
+++ b/bootstrap/bin/hocc/description.ml
@@ -428,17 +428,37 @@ let generate_txt conf io Spec.{algorithm; precs; symbols; prods; states; _} =
                   |> Fmt.fmt "            " |> pp_lr0item kernel_lr0item
                   |> Fmt.fmt "\n"
                   |> (fun formatter ->
-                    Attribs.fold ~init:formatter
-                      ~f:(fun formatter Attrib.{conflict_state_index; symbol_index; contrib; _} ->
-                        formatter
-                        |> Fmt.fmt "                "
-                        |> pp_state_index conflict_state_index
-                        |> Fmt.fmt " : "
-                        |> pp_symbol_index symbol_index
-                        |> Fmt.fmt " : "
-                        |> pp_contrib contrib
-                        |> Fmt.fmt "\n"
+                    Attribs.fold ~init:(Ordmap.empty (module Symbol.Index))
+                      ~f:(fun sym_attribs (Attrib.{symbol_index; _} as attrib) ->
+                        Ordmap.amend symbol_index ~f:(fun attribs_opt ->
+                          match attribs_opt with
+                          | None -> Some (Attribs.singleton attrib)
+                          | Some attribs -> Some (Attribs.insert attrib attribs)
+                        ) sym_attribs
                       ) attribs
+                    |> Ordmap.fold ~init:formatter ~f:(fun formatter (symbol_index, attribs) ->
+                      let sep, pad = match Attribs.length attribs with
+                        | 0L -> not_reached ()
+                        | 1L -> " ", ""
+                        | _ -> "\n", "                    "
+                      in
+                      formatter
+                      |> Fmt.fmt "                "
+                      |> pp_symbol_index symbol_index
+                      |> Fmt.fmt " :"
+                      |> Fmt.fmt sep
+                      |> (fun formatter ->
+                        Attribs.fold ~init:formatter
+                          ~f:(fun formatter Attrib.{conflict_state_index; contrib; _} ->
+                            formatter
+                            |> Fmt.fmt pad
+                            |> pp_state_index conflict_state_index
+                            |> Fmt.fmt " : "
+                            |> pp_contrib contrib
+                            |> Fmt.fmt "\n"
+                          ) attribs
+                      )
+                    )
                   )
                 ) statenub.kernel_attribs
               )

--- a/bootstrap/test/hocc/IelrFig1.expected.txt
+++ b/bootstrap/test/hocc/IelrFig1.expected.txt
@@ -78,7 +78,7 @@ IELR(1) States
             Ta : Reduce A ::= Ta prec p
         Conflict contributions
             A ::= Ta ·
-                4 : Ta : Reduce A ::= Ta
+                Ta : 4 : Reduce A ::= Ta
     State 5 [5.0]
         Kernel
             [S ::= Ta A · Ta, {"⊥"}] prec p

--- a/bootstrap/test/hocc/IelrFig1_rno.expected.txt
+++ b/bootstrap/test/hocc/IelrFig1_rno.expected.txt
@@ -80,7 +80,7 @@ CONFLICT        ShiftPrefix 9 prec p
 CONFLICT        Reduce A ::= Ta prec p
         Conflict contributions
             A ::= Ta ·
-                4 : Ta : Reduce A ::= Ta
+                Ta : 4 : Reduce A ::= Ta
     State 5 [5.0]
         Kernel
             [S ::= Ta A · Ta, {"⊥"}] prec p

--- a/bootstrap/test/hocc/IelrFig2.expected.txt
+++ b/bootstrap/test/hocc/IelrFig2.expected.txt
@@ -109,9 +109,9 @@ IELR(1) States
             Ta : ShiftPrefix 12
         Conflict contributions
             A ::= Ta · Ta
-                12 : Ta : Reduce A ::= Ta Ta
+                Ta : 12 : Reduce A ::= Ta Ta
             B ::= Ta · Ta
-                12 : Tb : Reduce B ::= Ta Ta
+                Tb : 12 : Reduce B ::= Ta Ta
     State 5 [5.0]
         Kernel
             [S ::= Ta A · Ta, {"⊥"}]
@@ -136,11 +136,11 @@ IELR(1) States
             Ta : ShiftPrefix 16
         Conflict contributions
             A ::= Ta · Ta
-                12 : Tb : Reduce A ::= Ta Ta
+                Tb : 12 : Reduce A ::= Ta Ta
             B ::= Ta · Ta
-                12 : Ta : Reduce B ::= Ta Ta
+                Ta : 12 : Reduce B ::= Ta Ta
             C ::= Ta · Ta
-                12 : Ta : Reduce C ::= Ta Ta
+                Ta : 12 : Reduce C ::= Ta Ta
     State 9 [8.0]
         Kernel
             [S ::= Tb A · Tb, {"⊥"}]
@@ -167,9 +167,9 @@ IELR(1) States
             Tc : Reduce C ::= Ta Ta prec p2
         Conflict contributions
             A ::= Ta Ta ·
-                12 : Ta : Reduce A ::= Ta Ta
+                Ta : 12 : Reduce A ::= Ta Ta
             B ::= Ta Ta ·
-                12 : Tb : Reduce B ::= Ta Ta
+                Tb : 12 : Reduce B ::= Ta Ta
     State 13 [13.0]
         Kernel
             [S ::= Ta A Ta ·, {"⊥"}]
@@ -195,11 +195,11 @@ IELR(1) States
             Tb : Reduce A ::= Ta Ta
         Conflict contributions
             A ::= Ta Ta ·
-                12 : Tb : Reduce A ::= Ta Ta
+                Tb : 12 : Reduce A ::= Ta Ta
             B ::= Ta Ta ·
-                12 : Ta : Reduce B ::= Ta Ta
+                Ta : 12 : Reduce B ::= Ta Ta
             C ::= Ta Ta ·
-                12 : Ta : Reduce C ::= Ta Ta
+                Ta : 12 : Reduce C ::= Ta Ta
     State 17 [16.0]
         Kernel
             [S ::= Tb A Tb ·, {"⊥"}]

--- a/bootstrap/test/hocc/IelrFig2_rno.expected.txt
+++ b/bootstrap/test/hocc/IelrFig2_rno.expected.txt
@@ -110,9 +110,9 @@ IELR(1) States
             Ta : ShiftPrefix 13
         Conflict contributions
             A ::= Ta · Ta
-                12 : Ta : Reduce A ::= Ta Ta
+                Ta : 12 : Reduce A ::= Ta Ta
             B ::= Ta · Ta
-                12 : Tb : Reduce B ::= Ta Ta
+                Tb : 12 : Reduce B ::= Ta Ta
     State 5 [5.0]
         Kernel
             [S ::= Ta A · Ta, {"⊥"}]
@@ -137,11 +137,11 @@ IELR(1) States
             Ta : ShiftPrefix 17
         Conflict contributions
             A ::= Ta · Ta
-                12 : Tb : Reduce A ::= Ta Ta
+                Tb : 12 : Reduce A ::= Ta Ta
             B ::= Ta · Ta
-                12 : Ta : Reduce B ::= Ta Ta
+                Ta : 12 : Reduce B ::= Ta Ta
             C ::= Ta · Ta
-                12 : Ta : Reduce C ::= Ta Ta
+                Ta : 12 : Reduce C ::= Ta Ta
     State 9 [8.0]
         Kernel
             [S ::= Tb A · Tb, {"⊥"}]
@@ -173,9 +173,9 @@ IELR(1) States
             Tc : Reduce C ::= Ta Ta prec p2
         Conflict contributions
             A ::= Ta Ta ·
-                12 : Ta : Reduce A ::= Ta Ta
+                Ta : 12 : Reduce A ::= Ta Ta
             B ::= Ta Ta ·
-                12 : Tb : Reduce B ::= Ta Ta
+                Tb : 12 : Reduce B ::= Ta Ta
     State 14 [13.0]
         Kernel
             [S ::= Ta A Ta ·, {"⊥"}]
@@ -203,11 +203,11 @@ CONFLICT        Reduce C ::= Ta Ta prec p2
             Tb : Reduce A ::= Ta Ta
         Conflict contributions
             A ::= Ta Ta ·
-                12 : Tb : Reduce A ::= Ta Ta
+                Tb : 12 : Reduce A ::= Ta Ta
             B ::= Ta Ta ·
-                12 : Ta : Reduce B ::= Ta Ta
+                Ta : 12 : Reduce B ::= Ta Ta
             C ::= Ta Ta ·
-                12 : Ta : Reduce C ::= Ta Ta
+                Ta : 12 : Reduce C ::= Ta Ta
     State 18 [16.0]
         Kernel
             [S ::= Tb A Tb ·, {"⊥"}]

--- a/bootstrap/test/hocc/IelrFig3.expected.txt
+++ b/bootstrap/test/hocc/IelrFig3.expected.txt
@@ -105,11 +105,11 @@ IELR(1) States
             Ta : ShiftPrefix 10
         Conflict contributions
             A ::= Ta · Ta
-                12 : Ta : Reduce A ::= Ta Ta
+                Ta : 12 : Reduce A ::= Ta Ta
             B ::= Ta · Ta
-                12 : Ta : Reduce B ::= Ta Ta
+                Ta : 12 : Reduce B ::= Ta Ta
             C ::= Ta · Ta
-                12 : Ta : Reduce C ::= Ta Ta
+                Ta : 12 : Reduce C ::= Ta Ta
     State 5 [5.0]
         Kernel
             [S ::= Ta A · Ta, {"⊥"}]
@@ -124,9 +124,9 @@ IELR(1) States
             Ta : ShiftPrefix 12
         Conflict contributions
             B ::= Ta · Ta
-                12 : Ta : Reduce B ::= Ta Ta
+                Ta : 12 : Reduce B ::= Ta Ta
             C ::= Ta · Ta
-                12 : Ta : Reduce C ::= Ta Ta
+                Ta : 12 : Reduce C ::= Ta Ta
     State 7 [8.0]
         Kernel
             [S ::= Tb A · Tb, {"⊥"}]
@@ -151,11 +151,11 @@ IELR(1) States
             Ta : Reduce A ::= Ta Ta prec p1
         Conflict contributions
             A ::= Ta Ta ·
-                12 : Ta : Reduce A ::= Ta Ta
+                Ta : 12 : Reduce A ::= Ta Ta
             B ::= Ta Ta ·
-                12 : Ta : Reduce B ::= Ta Ta
+                Ta : 12 : Reduce B ::= Ta Ta
             C ::= Ta Ta ·
-                12 : Ta : Reduce C ::= Ta Ta
+                Ta : 12 : Reduce C ::= Ta Ta
     State 11 [13.0]
         Kernel
             [S ::= Ta A Ta ·, {"⊥"}]
@@ -171,9 +171,9 @@ IELR(1) States
             Tb : Reduce A ::= Ta Ta prec p1
         Conflict contributions
             B ::= Ta Ta ·
-                12 : Ta : Reduce B ::= Ta Ta
+                Ta : 12 : Reduce B ::= Ta Ta
             C ::= Ta Ta ·
-                12 : Ta : Reduce C ::= Ta Ta
+                Ta : 12 : Reduce C ::= Ta Ta
     State 13 [16.0]
         Kernel
             [S ::= Tb A Tb ·, {"⊥"}]

--- a/bootstrap/test/hocc/IelrFig3_rno.expected.txt
+++ b/bootstrap/test/hocc/IelrFig3_rno.expected.txt
@@ -108,11 +108,11 @@ IELR(1) States
             Ta : ShiftPrefix 13
         Conflict contributions
             A ::= Ta · Ta
-                12 : Ta : Reduce A ::= Ta Ta
+                Ta : 12 : Reduce A ::= Ta Ta
             B ::= Ta · Ta
-                12 : Ta : Reduce B ::= Ta Ta
+                Ta : 12 : Reduce B ::= Ta Ta
             C ::= Ta · Ta
-                12 : Ta : Reduce C ::= Ta Ta
+                Ta : 12 : Reduce C ::= Ta Ta
     State 5 [5.0]
         Kernel
             [S ::= Ta A · Ta, {"⊥"}]
@@ -137,9 +137,9 @@ IELR(1) States
             Ta : ShiftPrefix 17
         Conflict contributions
             B ::= Ta · Ta
-                12 : Ta : Reduce B ::= Ta Ta
+                Ta : 12 : Reduce B ::= Ta Ta
             C ::= Ta · Ta
-                12 : Ta : Reduce C ::= Ta Ta
+                Ta : 12 : Reduce C ::= Ta Ta
     State 9 [8.0]
         Kernel
             [S ::= Tb A · Tb, {"⊥"}]
@@ -172,11 +172,11 @@ CONFLICT        Reduce B ::= Ta Ta prec p2
 CONFLICT        Reduce C ::= Ta Ta prec p3
         Conflict contributions
             A ::= Ta Ta ·
-                12 : Ta : Reduce A ::= Ta Ta
+                Ta : 12 : Reduce A ::= Ta Ta
             B ::= Ta Ta ·
-                12 : Ta : Reduce B ::= Ta Ta
+                Ta : 12 : Reduce B ::= Ta Ta
             C ::= Ta Ta ·
-                12 : Ta : Reduce C ::= Ta Ta
+                Ta : 12 : Reduce C ::= Ta Ta
     State 14 [13.0]
         Kernel
             [S ::= Ta A Ta ·, {"⊥"}]
@@ -204,9 +204,9 @@ CONFLICT        Reduce C ::= Ta Ta prec p3
             Tb : Reduce A ::= Ta Ta prec p1
         Conflict contributions
             B ::= Ta Ta ·
-                12 : Ta : Reduce B ::= Ta Ta
+                Ta : 12 : Reduce B ::= Ta Ta
             C ::= Ta Ta ·
-                12 : Ta : Reduce C ::= Ta Ta
+                Ta : 12 : Reduce C ::= Ta Ta
     State 18 [16.0]
         Kernel
             [S ::= Tb A Tb ·, {"⊥"}]

--- a/bootstrap/test/hocc/IelrFig4_rno.expected.txt
+++ b/bootstrap/test/hocc/IelrFig4_rno.expected.txt
@@ -94,10 +94,10 @@ CONFLICT        Reduce B ::= Ta
             Tb : Reduce A ::= Ta
         Conflict contributions
             A ::= Ta ·
-                4 : Ta : Reduce A ::= Ta
-                4 : Tb : Reduce A ::= Ta
+                Ta : 4 : Reduce A ::= Ta
+                Tb : 4 : Reduce A ::= Ta
             B ::= Ta ·
-                4 : Ta : Reduce B ::= Ta
+                Ta : 4 : Reduce B ::= Ta
     State 5 [5.0]
         Kernel
             [Sn ::= Ta A · Ta, {"⊥"}]
@@ -119,9 +119,9 @@ CONFLICT        Reduce B ::= Ta
             Tb : Reduce B ::= Ta
         Conflict contributions
             A ::= Ta ·
-                4 : Ta : Reduce A ::= Ta
+                Ta : 4 : Reduce A ::= Ta
             B ::= Ta ·
-                4 : Tb : Reduce B ::= Ta
+                Tb : 4 : Reduce B ::= Ta
     State 8 [7.0]
         Kernel
             [Sn ::= Tb A · Ta, {"⊥"}]

--- a/bootstrap/test/hocc/IelrFig5.expected.txt
+++ b/bootstrap/test/hocc/IelrFig5.expected.txt
@@ -106,7 +106,7 @@ IELR(1) States
             D : 11
         Conflict contributions
             A ::= Ta · C D E
-                14 : Ta : Reduce E ::= epsilon
+                Ta : 14 : Reduce E ::= epsilon
     State 5 [5.0]
         Kernel
             [S ::= Ta A · B Ta, {"⊥"}]
@@ -163,7 +163,7 @@ IELR(1) States
             D : 16
         Conflict contributions
             A ::= Ta C · D E
-                14 : Ta : Reduce E ::= epsilon
+                Ta : 14 : Reduce E ::= epsilon
     State 11 [10.0]
         Kernel
             [C ::= D ·, {Ta}]
@@ -207,7 +207,7 @@ IELR(1) States
             E : 21
         Conflict contributions
             A ::= Ta C D · E
-                14 : Ta : Reduce E ::= epsilon
+                Ta : 14 : Reduce E ::= epsilon
     State 17 [15.0]
         Kernel
             [S ::= Ta A B Ta ·, {"⊥"}]

--- a/bootstrap/test/hocc/IelrFig5Diamond.expected.txt
+++ b/bootstrap/test/hocc/IelrFig5Diamond.expected.txt
@@ -120,7 +120,7 @@ IELR(1) States
             A : 12
         Conflict contributions
             Z ::= Tz · A B
-                20 : Ta : Reduce E ::= epsilon
+                Ta : 20 : Reduce E ::= epsilon
     State 5 [5.0]
         Kernel
             [Z ::= Ty · A B, {Ta}]
@@ -132,7 +132,7 @@ IELR(1) States
             A : 13
         Conflict contributions
             Z ::= Ty · A B
-                20 : Ta : Reduce E ::= epsilon
+                Ta : 20 : Reduce E ::= epsilon
     State 6 [6.0]
         Kernel
             [S ::= Ta Z · Ta, {"⊥"}]
@@ -179,7 +179,7 @@ IELR(1) States
             D : 19
         Conflict contributions
             A ::= Ta · C D E
-                20 : Ta : Reduce E ::= epsilon
+                Ta : 20 : Reduce E ::= epsilon
     State 12 [10.0]
         Kernel
             [Z ::= Tz A · B, {Ta, Tb}]
@@ -243,7 +243,7 @@ IELR(1) States
             D : 24
         Conflict contributions
             A ::= Ta C · D E
-                20 : Ta : Reduce E ::= epsilon
+                Ta : 20 : Reduce E ::= epsilon
     State 19 [16.0]
         Kernel
             [C ::= D ·, {Ta}]
@@ -289,7 +289,7 @@ IELR(1) States
             E : 27
         Conflict contributions
             A ::= Ta C D · E
-                20 : Ta : Reduce E ::= epsilon
+                Ta : 20 : Reduce E ::= epsilon
     State 25 [20.1]
         Kernel
             [A ::= Ta C D · E, {Tb, Tc}]

--- a/bootstrap/test/hocc/IelrFig5Diamonds.expected.txt
+++ b/bootstrap/test/hocc/IelrFig5Diamonds.expected.txt
@@ -134,7 +134,7 @@ IELR(1) States
             Z : 13
         Conflict contributions
             Y ::= Ty0 · Z
-                24 : Ta : Reduce E ::= epsilon
+                Ta : 24 : Reduce E ::= epsilon
     State 5 [5.0]
         Kernel
             [Y ::= Ty1 · Z, {Ta}]
@@ -148,7 +148,7 @@ IELR(1) States
             Z : 14
         Conflict contributions
             Y ::= Ty1 · Z
-                24 : Ta : Reduce E ::= epsilon
+                Ta : 24 : Reduce E ::= epsilon
     State 6 [6.0]
         Kernel
             [S ::= Ta Y · Ta, {"⊥"}]
@@ -197,7 +197,7 @@ IELR(1) States
             A : 20
         Conflict contributions
             Z ::= Tz0 · A B
-                24 : Ta : Reduce E ::= epsilon
+                Ta : 24 : Reduce E ::= epsilon
     State 12 [10.0]
         Kernel
             [Z ::= Tz1 · A B, {Ta}]
@@ -209,7 +209,7 @@ IELR(1) States
             A : 21
         Conflict contributions
             Z ::= Tz1 · A B
-                24 : Ta : Reduce E ::= epsilon
+                Ta : 24 : Reduce E ::= epsilon
     State 13 [11.0]
         Kernel
             [Y ::= Ty0 Z ·, {Ta, Tb}]
@@ -263,7 +263,7 @@ IELR(1) States
             D : 25
         Conflict contributions
             A ::= Ta · C D E
-                24 : Ta : Reduce E ::= epsilon
+                Ta : 24 : Reduce E ::= epsilon
     State 20 [16.0]
         Kernel
             [Z ::= Tz0 A · B, {Ta, Tb}]
@@ -317,7 +317,7 @@ IELR(1) States
             D : 30
         Conflict contributions
             A ::= Ta C · D E
-                24 : Ta : Reduce E ::= epsilon
+                Ta : 24 : Reduce E ::= epsilon
     State 25 [20.0]
         Kernel
             [C ::= D ·, {Ta}]
@@ -363,7 +363,7 @@ IELR(1) States
             E : 33
         Conflict contributions
             A ::= Ta C D · E
-                24 : Ta : Reduce E ::= epsilon
+                Ta : 24 : Reduce E ::= epsilon
     State 31 [24.1]
         Kernel
             [A ::= Ta C D · E, {Tb, Tc}]

--- a/bootstrap/test/hocc/IelrFig5_rno.expected.txt
+++ b/bootstrap/test/hocc/IelrFig5_rno.expected.txt
@@ -106,7 +106,7 @@ IELR(1) States
             D : 11
         Conflict contributions
             A ::= Ta · C D E
-                14 : Ta : Reduce E ::= epsilon
+                Ta : 14 : Reduce E ::= epsilon
     State 5 [5.0]
         Kernel
             [S ::= Ta A · B Ta, {"⊥"}]
@@ -163,7 +163,7 @@ IELR(1) States
             D : 16
         Conflict contributions
             A ::= Ta C · D E
-                14 : Ta : Reduce E ::= epsilon
+                Ta : 14 : Reduce E ::= epsilon
     State 11 [10.0]
         Kernel
             [C ::= D ·, {Ta}]
@@ -209,7 +209,7 @@ CONFLICT        Reduce E ::= epsilon prec p1
             E : 21
         Conflict contributions
             A ::= Ta C D · E
-                14 : Ta : Reduce E ::= epsilon
+                Ta : 14 : Reduce E ::= epsilon
     State 17 [15.0]
         Kernel
             [S ::= Ta A B Ta ·, {"⊥"}]

--- a/bootstrap/test/hocc/IelrRemergeable_aielr_gno.expected.txt
+++ b/bootstrap/test/hocc/IelrRemergeable_aielr_gno.expected.txt
@@ -151,10 +151,11 @@ IELR(1) States
             E : 9
         Conflict contributions
             E ::= "(" · E ")"
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 3 [3.0]
         Kernel
             [S' ::= S · "⊥", {"ε"}]
@@ -196,18 +197,21 @@ IELR(1) States
             "," : ShiftPrefix 18 prec p4
         Conflict contributions
             E ::= E · "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 7 [7.0]
         Kernel
             [Pos ::= Pos · "+" EPair, {"+", "-", ","}]
@@ -244,18 +248,21 @@ IELR(1) States
             "," : ShiftPrefix 18 prec p4
         Conflict contributions
             E ::= E · "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 10 [10.0]
         Kernel
             [S' ::= S "⊥" ·, {"ε"}]
@@ -316,10 +323,11 @@ IELR(1) States
             E : 27
         Conflict contributions
             E ::= E "+" · E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 15 [15.0]
         Kernel
             [Pos ::= E "min" · Pos "max" Pos, {")", "+", "-", "max", ",", EOI}] prec p1
@@ -371,10 +379,11 @@ IELR(1) States
             E : 30
         Conflict contributions
             E ::= E "<" · E
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 17 [17.0]
         Kernel
             [E ::= E ">" · E, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p3
@@ -391,10 +400,11 @@ IELR(1) States
             E : 31
         Conflict contributions
             E ::= E ">" · E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 18 [18.0]
         Kernel
             [EPair ::= E "," · E, {")", "+", "-", "max", ",", EOI}] prec p4
@@ -411,7 +421,7 @@ IELR(1) States
             E : 32
         Conflict contributions
             EPair ::= E "," · E
-                27 : "+" : Reduce E ::= E "+" E
+                "+" : 27 : Reduce E ::= E "+" E
     State 19 [19.0]
         Kernel
             [Pos ::= "(" Pos "," · Pos ")", {")", "+", "-", "max", ">", ",", EOI}]
@@ -480,9 +490,10 @@ IELR(1) States
             E : 35
         Conflict contributions
             E ::= "(" · E ")"
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 23 [23.0]
         Kernel
             [Pos ::= Pos "+" EPair ·, {")", "+", "-", "max", ">", ",", EOI}]
@@ -507,17 +518,20 @@ IELR(1) States
             "," : ShiftPrefix 18 prec p4
         Conflict contributions
             E ::= E · "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 25 [25.0]
         Kernel
             [Pos ::= Pos "-" EPair ·, {")", "+", "-", "max", ">", ",", EOI}]
@@ -545,10 +559,11 @@ IELR(1) States
             E : 37
         Conflict contributions
             E ::= "(" · E ")"
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 27 [27.0]
         Kernel
             [E ::= E · "+" E, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p0
@@ -567,23 +582,26 @@ IELR(1) States
             EOI : Reduce E ::= E "+" E prec p0
         Conflict contributions
             E ::= E · "+" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E "+" E ·
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" : 27 : Reduce E ::= E "+" E
             E ::= E · "<" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 28 [28.0]
         Kernel
             [Pos ::= Pos · "+" EPair, {"+", "-", "max"}]
@@ -620,20 +638,23 @@ IELR(1) States
             "," : Reduce E ::= E "<" E prec p3
         Conflict contributions
             E ::= E · "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E "<" E ·
-                30 : ">" : Reduce E ::= E "<" E
+                ">" : 30 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 31 [31.0]
         Kernel
             [E ::= E · "+" E, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p0
@@ -652,22 +673,25 @@ IELR(1) States
             EOI : Reduce E ::= E ">" E prec p3
         Conflict contributions
             E ::= E · "+" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E ">" E ·
-                31 : ">" : Reduce E ::= E ">" E
+                ">" : 31 : Reduce E ::= E ">" E
     State 32 [32.0]
         Kernel
             [EPair ::= E "," E ·, {")", "+", "-", "max", ">", ",", EOI}] prec p4
@@ -685,20 +709,23 @@ IELR(1) States
             EOI : Reduce EPair ::= E "," E prec p4
         Conflict contributions
             E ::= E · "+" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 33 [33.0]
         Kernel
             [Pos ::= Pos · "+" EPair, {")", "+", "-"}]
@@ -728,17 +755,20 @@ IELR(1) States
             "," : ShiftPrefix 41 prec p4
         Conflict contributions
             E ::= E · "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 36 [36.0]
         Kernel
             [E ::= E "<" · E, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p3
@@ -755,10 +785,11 @@ IELR(1) States
             E : 42
         Conflict contributions
             E ::= E "<" · E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 37 [37.0]
         Kernel
             [E ::= E · "+" E, {")", "+", "<", ">"}] prec p0
@@ -772,20 +803,23 @@ IELR(1) States
             ">" : ShiftPrefix 17 prec p3
         Conflict contributions
             E ::= E · "+" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 38 [38.0]
         Kernel
             [Pos ::= E "min" Pos "max" · Pos, {")", "+", "-", "max", ",", EOI}] prec p1
@@ -877,22 +911,25 @@ IELR(1) States
             EOI : Reduce E ::= E "<" E prec p3
         Conflict contributions
             E ::= E · "+" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E "<" E ·
-                41 : ">" : Reduce E ::= E "<" E
+                ">" : 41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 43 [42.0]
         Kernel
             [Pos ::= Pos · "+" EPair, {")", "+", "-", "max", ",", EOI}]
@@ -916,13 +953,15 @@ IELR(1) States
             ">" : ShiftPrefix 48 prec p3
         Conflict contributions
             Pos ::= Pos · "+" EPair
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             Pos ::= Pos · "-" EPair
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 45 [6.1]
         Kernel
             [Pos ::= E · "min" Pos "max" Pos, {"+", "-", ">"}] prec p1
@@ -939,32 +978,38 @@ IELR(1) States
             "," : ShiftPrefix 51 prec p4
         Conflict contributions
             Pos ::= E · "min" Pos "max" Pos
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             Pos ::= E · "<" Pos "," Pos ">"
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             EPair ::= E · "," E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 46 [11.1]
         Kernel
             [Pos ::= Pos "+" · EPair, {"+", "-", ">"}]
@@ -984,9 +1029,10 @@ IELR(1) States
             E : 52
         Conflict contributions
             Pos ::= Pos "+" · EPair
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 47 [12.1]
         Kernel
             [Pos ::= Pos "-" · EPair, {"+", "-", ">"}]
@@ -1006,9 +1052,10 @@ IELR(1) States
             E : 52
         Conflict contributions
             Pos ::= Pos "-" · EPair
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 48 [44.0]
         Kernel
             [Pos ::= E "<" Pos "," Pos ">" ·, {")", "+", "-", "max", ">", ",", EOI}]
@@ -1046,10 +1093,11 @@ IELR(1) States
             E : 6
         Conflict contributions
             Pos ::= E "min" · Pos "max" Pos
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 50 [16.1]
         Kernel
             [Pos ::= E "<" · Pos "," Pos ">", {"+", "-", ">"}]
@@ -1077,15 +1125,17 @@ IELR(1) States
             E : 30
         Conflict contributions
             Pos ::= E "<" · Pos "," Pos ">"
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E "<" · E
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 51 [18.2]
         Kernel
             [EPair ::= E "," · E, {"+", "-", ">"}] prec p4
@@ -1102,10 +1152,11 @@ IELR(1) States
             E : 32
         Conflict contributions
             EPair ::= E "," · E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 52 [24.1]
         Kernel
             [EPair ::= E · "," E, {"+", "-", ">"}] prec p4
@@ -1119,21 +1170,25 @@ IELR(1) States
             "," : ShiftPrefix 51 prec p4
         Conflict contributions
             EPair ::= E · "," E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 53 [28.1]
         Kernel
             [Pos ::= Pos · "+" EPair, {"+", "-", "max"}]
@@ -1145,10 +1200,11 @@ IELR(1) States
             "max" : ShiftPrefix 55 prec p1
         Conflict contributions
             Pos ::= E "min" Pos · "max" Pos
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 54 [29.1]
         Kernel
             [Pos ::= Pos · "+" EPair, {"+", "-", ","}]
@@ -1160,10 +1216,11 @@ IELR(1) States
             "," : ShiftPrefix 56 prec p4
         Conflict contributions
             Pos ::= E "<" Pos · "," Pos ">"
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 55 [38.1]
         Kernel
             [Pos ::= E "min" Pos "max" · Pos, {"+", "-", ">"}] prec p1
@@ -1190,10 +1247,11 @@ IELR(1) States
             E : 45
         Conflict contributions
             Pos ::= E "min" Pos "max" · Pos
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 56 [39.1]
         Kernel
             [Pos ::= E "<" Pos "," · Pos ">", {"+", "-", ">"}]
@@ -1220,10 +1278,11 @@ IELR(1) States
             E : 45
         Conflict contributions
             Pos ::= E "<" Pos "," · Pos ">"
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 57 [42.1]
         Kernel
             [Pos ::= Pos · "+" EPair, {"+", "-", ">"}]
@@ -1235,10 +1294,12 @@ IELR(1) States
             ">" : Reduce Pos ::= E "min" Pos "max" Pos prec p1
         Conflict contributions
             Pos ::= Pos · "+" EPair
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             Pos ::= Pos · "-" EPair
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E

--- a/bootstrap/test/hocc/IelrRemergeable_aielr_myes.expected.txt
+++ b/bootstrap/test/hocc/IelrRemergeable_aielr_myes.expected.txt
@@ -151,10 +151,11 @@ IELR(1) States
             E : 9
         Conflict contributions
             E ::= "(" · E ")"
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 3 [3.0]
         Kernel
             [S' ::= S · "⊥", {"ε"}]
@@ -196,32 +197,38 @@ IELR(1) States
             "," : ShiftPrefix 18 prec p4
         Conflict contributions
             Pos ::= E · "min" Pos "max" Pos
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             Pos ::= E · "<" Pos "," Pos ">"
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             EPair ::= E · "," E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 7 [7.0]
         Kernel
             [Pos ::= Pos · "+" EPair, {"+", "-", ","}]
@@ -258,18 +265,21 @@ IELR(1) States
             "," : ShiftPrefix 18 prec p4
         Conflict contributions
             E ::= E · "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 10 [10.0]
         Kernel
             [S' ::= S "⊥" ·, {"ε"}]
@@ -294,9 +304,10 @@ IELR(1) States
             E : 24
         Conflict contributions
             Pos ::= Pos "+" · EPair
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 12 [12.0]
         Kernel
             [Pos ::= Pos "-" · EPair, {")", "+", "-", "max", ">", ",", EOI}]
@@ -316,9 +327,10 @@ IELR(1) States
             E : 24
         Conflict contributions
             Pos ::= Pos "-" · EPair
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 13 [13.0]
         Kernel
             [S ::= Pos EOI ·, {"⊥"}]
@@ -340,10 +352,11 @@ IELR(1) States
             E : 27
         Conflict contributions
             E ::= E "+" · E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 15 [15.0]
         Kernel
             [Pos ::= E "min" · Pos "max" Pos, {")", "+", "-", "max", ">", ",", EOI}] prec p1
@@ -370,10 +383,11 @@ IELR(1) States
             E : 6
         Conflict contributions
             Pos ::= E "min" · Pos "max" Pos
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 16 [16.0]
         Kernel
             [Pos ::= E "<" · Pos "," Pos ">", {")", "+", "-", "max", ">", ",", EOI}]
@@ -401,15 +415,17 @@ IELR(1) States
             E : 30
         Conflict contributions
             Pos ::= E "<" · Pos "," Pos ">"
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E "<" · E
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 17 [17.0]
         Kernel
             [E ::= E ">" · E, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p3
@@ -426,10 +442,11 @@ IELR(1) States
             E : 31
         Conflict contributions
             E ::= E ">" · E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 18 [18.0]
         Kernel
             [EPair ::= E "," · E, {")", "+", "-", "max", ">", ",", EOI}] prec p4
@@ -446,10 +463,11 @@ IELR(1) States
             E : 32
         Conflict contributions
             EPair ::= E "," · E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 19 [19.0]
         Kernel
             [Pos ::= "(" Pos "," · Pos ")", {")", "+", "-", "max", ">", ",", EOI}]
@@ -518,9 +536,10 @@ IELR(1) States
             E : 35
         Conflict contributions
             E ::= "(" · E ")"
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 23 [23.0]
         Kernel
             [Pos ::= Pos "+" EPair ·, {")", "+", "-", "max", ">", ",", EOI}]
@@ -545,21 +564,25 @@ IELR(1) States
             "," : ShiftPrefix 18 prec p4
         Conflict contributions
             EPair ::= E · "," E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 25 [25.0]
         Kernel
             [Pos ::= Pos "-" EPair ·, {")", "+", "-", "max", ">", ",", EOI}]
@@ -587,10 +610,11 @@ IELR(1) States
             E : 37
         Conflict contributions
             E ::= "(" · E ")"
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 27 [27.0]
         Kernel
             [E ::= E · "+" E, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p0
@@ -609,23 +633,26 @@ IELR(1) States
             EOI : Reduce E ::= E "+" E prec p0
         Conflict contributions
             E ::= E · "+" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E "+" E ·
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" : 27 : Reduce E ::= E "+" E
             E ::= E · "<" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 28 [28.0]
         Kernel
             [Pos ::= Pos · "+" EPair, {"+", "-", "max"}]
@@ -637,10 +664,11 @@ IELR(1) States
             "max" : ShiftPrefix 38 prec p1
         Conflict contributions
             Pos ::= E "min" Pos · "max" Pos
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 29 [29.0]
         Kernel
             [Pos ::= Pos · "+" EPair, {"+", "-", ","}]
@@ -652,10 +680,11 @@ IELR(1) States
             "," : ShiftPrefix 39 prec p4
         Conflict contributions
             Pos ::= E "<" Pos · "," Pos ">"
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 30 [30.0]
         Kernel
             [Pos ::= E · "min" Pos "max" Pos, {"+", "-", ","}] prec p1
@@ -674,20 +703,23 @@ IELR(1) States
             "," : Reduce E ::= E "<" E prec p3
         Conflict contributions
             E ::= E · "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E "<" E ·
-                30 : ">" : Reduce E ::= E "<" E
+                ">" : 30 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 31 [31.0]
         Kernel
             [E ::= E · "+" E, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p0
@@ -706,22 +738,25 @@ IELR(1) States
             EOI : Reduce E ::= E ">" E prec p3
         Conflict contributions
             E ::= E · "+" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E ">" E ·
-                31 : ">" : Reduce E ::= E ">" E
+                ">" : 31 : Reduce E ::= E ">" E
     State 32 [32.0]
         Kernel
             [EPair ::= E "," E ·, {")", "+", "-", "max", ">", ",", EOI}] prec p4
@@ -739,20 +774,23 @@ IELR(1) States
             EOI : Reduce EPair ::= E "," E prec p4
         Conflict contributions
             E ::= E · "+" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 33 [33.0]
         Kernel
             [Pos ::= Pos · "+" EPair, {")", "+", "-"}]
@@ -782,17 +820,20 @@ IELR(1) States
             "," : ShiftPrefix 18 prec p4
         Conflict contributions
             E ::= E · "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 36 [36.0]
         Kernel
             [E ::= E "<" · E, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p3
@@ -809,10 +850,11 @@ IELR(1) States
             E : 41
         Conflict contributions
             E ::= E "<" · E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 37 [37.0]
         Kernel
             [E ::= E · "+" E, {")", "+", "<", ">"}] prec p0
@@ -826,20 +868,23 @@ IELR(1) States
             ">" : ShiftPrefix 17 prec p3
         Conflict contributions
             E ::= E · "+" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 38 [38.0]
         Kernel
             [Pos ::= E "min" Pos "max" · Pos, {")", "+", "-", "max", ">", ",", EOI}] prec p1
@@ -866,10 +911,11 @@ IELR(1) States
             E : 6
         Conflict contributions
             Pos ::= E "min" Pos "max" · Pos
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 39 [39.0]
         Kernel
             [Pos ::= E "<" Pos "," · Pos ">", {")", "+", "-", "max", ">", ",", EOI}]
@@ -896,10 +942,11 @@ IELR(1) States
             E : 6
         Conflict contributions
             Pos ::= E "<" Pos "," · Pos ">"
-                27 : ">" : Reduce E ::= E "+" E
-                30 : ">" : Reduce E ::= E "<" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    30 : Reduce E ::= E "<" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 40 [40.0]
         Kernel
             [Pos ::= "(" Pos "," Pos ")" ·, {")", "+", "-", "max", ">", ",", EOI}]
@@ -929,22 +976,25 @@ IELR(1) States
             EOI : Reduce E ::= E "<" E prec p3
         Conflict contributions
             E ::= E · "+" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E · "<" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             E ::= E "<" E ·
-                41 : ">" : Reduce E ::= E "<" E
+                ">" : 41 : Reduce E ::= E "<" E
             E ::= E · ">" E
-                27 : "+" : Reduce E ::= E "+" E
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                "+" : 27 : Reduce E ::= E "+" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 42 [42.0]
         Kernel
             [Pos ::= Pos · "+" EPair, {")", "+", "-", "max", ">", ",", EOI}]
@@ -960,13 +1010,15 @@ IELR(1) States
             EOI : Reduce Pos ::= E "min" Pos "max" Pos prec p1
         Conflict contributions
             Pos ::= Pos · "+" EPair
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             Pos ::= Pos · "-" EPair
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 43 [43.0]
         Kernel
             [Pos ::= Pos · "+" EPair, {"+", "-", ">"}]
@@ -978,13 +1030,15 @@ IELR(1) States
             ">" : ShiftPrefix 44 prec p3
         Conflict contributions
             Pos ::= Pos · "+" EPair
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
             Pos ::= Pos · "-" EPair
-                27 : ">" : Reduce E ::= E "+" E
-                31 : ">" : Reduce E ::= E ">" E
-                41 : ">" : Reduce E ::= E "<" E
+                ">" :
+                    27 : Reduce E ::= E "+" E
+                    31 : Reduce E ::= E ">" E
+                    41 : Reduce E ::= E "<" E
     State 44 [44.0]
         Kernel
             [Pos ::= E "<" Pos "," Pos ">" ·, {")", "+", "-", "max", ">", ",", EOI}]

--- a/bootstrap/test/hocc/PagerG2_aielr.expected.txt
+++ b/bootstrap/test/hocc/PagerG2_aielr.expected.txt
@@ -152,7 +152,7 @@ IELR(1) States
             Wn : 17
         Conflict contributions
             Yn ::= Tt · Wn
-                15 : Dt : Reduce Vn ::= epsilon
+                Dt : 15 : Reduce Vn ::= epsilon
     State 6 [6.0]
         Kernel
             [Yn ::= Ut · Xn, {Dt, Et}]
@@ -199,7 +199,7 @@ IELR(1) States
             Wn : 17
         Conflict contributions
             Zn ::= Tt · Ut
-                15 : Dt : Reduce Zn ::= Tt Ut
+                Dt : 15 : Reduce Zn ::= Tt Ut
     State 11 [10.0]
         Kernel
             [Xn ::= Bt Yn · Et, {At, Dt, Et, EOI}]
@@ -241,7 +241,7 @@ IELR(1) States
             Vn : 24
         Conflict contributions
             Wn ::= Ut · Vn
-                15 : Dt : Reduce Vn ::= epsilon
+                Dt : 15 : Reduce Vn ::= epsilon
     State 17 [16.0]
         Kernel
             [Yn ::= Tt Wn ·, {Dt, Et}]
@@ -285,7 +285,7 @@ IELR(1) States
             Vn : 24
         Conflict contributions
             Zn ::= Tt Ut ·
-                15 : Dt : Reduce Zn ::= Tt Ut
+                Dt : 15 : Reduce Zn ::= Tt Ut
     State 22 [20.0]
         Kernel
             [Xn ::= Bt Yn Et ·, {At, Dt, Et, EOI}]

--- a/doc/reports/ielr1/G2_ielr1.txt
+++ b/doc/reports/ielr1/G2_ielr1.txt
@@ -152,7 +152,7 @@ IELR(1) States
             Wn : 17
         Conflict contributions
             Yn ::= Tt · Wn
-                15 : Dt : Reduce Vn ::= epsilon
+                Dt : 15 : Reduce Vn ::= epsilon
     State 6 [6.0]
         Kernel
             [Yn ::= Ut · Xn, {Dt, Et}]
@@ -199,7 +199,7 @@ IELR(1) States
             Wn : 17
         Conflict contributions
             Zn ::= Tt · Ut
-                15 : Dt : Reduce Zn ::= Tt Ut
+                Dt : 15 : Reduce Zn ::= Tt Ut
     State 11 [10.0]
         Kernel
             [Xn ::= Bt Yn · Et, {At, Dt, Et, EOI}]
@@ -241,7 +241,7 @@ IELR(1) States
             Vn : 24
         Conflict contributions
             Wn ::= Ut · Vn
-                15 : Dt : Reduce Vn ::= epsilon
+                Dt : 15 : Reduce Vn ::= epsilon
     State 17 [16.0]
         Kernel
             [Yn ::= Tt Wn ·, {Dt, Et}]
@@ -285,7 +285,7 @@ IELR(1) States
             Vn : 24
         Conflict contributions
             Zn ::= Tt Ut ·
-                15 : Dt : Reduce Zn ::= Tt Ut
+                Dt : 15 : Reduce Zn ::= Tt Ut
     State 22 [20.0]
         Kernel
             [Xn ::= Bt Yn Et ·, {At, Dt, Et, EOI}]

--- a/doc/reports/ielr1/ielr1.md
+++ b/doc/reports/ielr1/ielr1.md
@@ -454,7 +454,7 @@ inadequacies. Following are lightly edited excerpts from [LALR(1)](G2_lalr1.txt)
 |     Wn : 16₀                            |   |     Wn : 16₀                          |
 | Conflict contributions                  |   | Conflict contributions                |
 |     Yn ::= Tt · Wn                      |   |     Zn ::= Tt · Ut                    |
-|         15 : Dt : Reduce Vn ::= epsilon |   |         15 : Dt : Reduce Zn ::= Tt Ut |
+|         Dt : 15 : Reduce Vn ::= epsilon |   |         Dt : 15 : Reduce Zn ::= Tt Ut |
 |_________________________________________|   |_______________________________________|
                     |                                             |
                     |                                             |
@@ -472,7 +472,7 @@ inadequacies. Following are lightly edited excerpts from [LALR(1)](G2_lalr1.txt)
 |     Vn : 22₀                            |   |     Vn : 22₀                          |
 | Conflict contributions                  |   | Conflict contributions                |
 |     [Wn ::= Ut · Vn, {Dt}]              |   |     [Zn ::= Tt Ut ·, {Dt}]            |
-|         15 : Dt : Reduce Vn ::= epsilon |   |         15 : Dt : Reduce Zn ::= Tt Ut |
+|         Dt : 15 : Reduce Vn ::= epsilon |   |         Dt : 15 : Reduce Zn ::= Tt Ut |
 |_________________________________________|   |_______________________________________|
 ```
 

--- a/doc/tools/hocc.md
+++ b/doc/tools/hocc.md
@@ -931,22 +931,26 @@ IELR(1) States
             AddOp : 10
         Conflict contributions
             Expr ::= Expr · MulOp Expr
-                12 : "*" : Reduce Expr ::= Expr MulOp Expr
-                12 : "/" : Reduce Expr ::= Expr MulOp Expr
-                12 : "+" : Reduce Expr ::= Expr MulOp Expr
-                12 : "-" : Reduce Expr ::= Expr MulOp Expr
-                13 : "+" : Reduce Expr ::= Expr AddOp Expr
-                13 : "-" : Reduce Expr ::= Expr AddOp Expr
+                "*" : 12 : Reduce Expr ::= Expr MulOp Expr
+                "/" : 12 : Reduce Expr ::= Expr MulOp Expr
+                "+" :
+                    12 : Reduce Expr ::= Expr MulOp Expr
+                    13 : Reduce Expr ::= Expr AddOp Expr
+                "-" :
+                    12 : Reduce Expr ::= Expr MulOp Expr
+                    13 : Reduce Expr ::= Expr AddOp Expr
             Expr ::= Expr · AddOp Expr
-                12 : "*" : Reduce Expr ::= Expr MulOp Expr
-                12 : "/" : Reduce Expr ::= Expr MulOp Expr
-                12 : "+" : Reduce Expr ::= Expr MulOp Expr
-                12 : "-" : Reduce Expr ::= Expr MulOp Expr
-                13 : "+" : Reduce Expr ::= Expr AddOp Expr
-                13 : "-" : Reduce Expr ::= Expr AddOp Expr
+                "*" : 12 : Reduce Expr ::= Expr MulOp Expr
+                "/" : 12 : Reduce Expr ::= Expr MulOp Expr
+                "+" :
+                    12 : Reduce Expr ::= Expr MulOp Expr
+                    13 : Reduce Expr ::= Expr AddOp Expr
+                "-" :
+                    12 : Reduce Expr ::= Expr MulOp Expr
+                    13 : Reduce Expr ::= Expr AddOp Expr
             Expr ::= Expr AddOp Expr ·
-                13 : "+" : Reduce Expr ::= Expr AddOp Expr
-                13 : "-" : Reduce Expr ::= Expr AddOp Expr
+                "+" : 13 : Reduce Expr ::= Expr AddOp Expr
+                "-" : 13 : Reduce Expr ::= Expr AddOp Expr
 ```
 
 Of note:


### PR DESCRIPTION
Group per kernel conflict contributions by symbol, since that is the most common needed ordering when evaluating conflicts.