### PR TITLE
Trace/GC pre-remerging by default

### DIFF
--- a/bootstrap/bin/hocc/conf.ml
+++ b/bootstrap/bin/hocc/conf.ml
@@ -17,9 +17,21 @@ let pp_algorithm algorithm formatter =
     | Lalr -> "Lalr"
   )
 
+type gc =
+  | PreRemerge
+  | PostRemerge
+  | No
+
+let pp_gc gc formatter =
+  formatter |> Fmt.fmt (match gc with
+    | PreRemerge -> "PreRemerge"
+    | PostRemerge -> "PostRemerge"
+    | No -> "No"
+  )
+
 type remerge =
-  | Default of bool (** Default; no remerge parameter specified. *)
-  | Explicit of bool (** Explicit remerge parameter specified. *)
+  | Default of bool
+  | Explicit of bool
 
 type t = {
   verbose: bool;
@@ -28,7 +40,7 @@ type t = {
   algorithm: algorithm;
   resolve_opt: bool option;
   remerge_opt: bool option;
-  gc: bool;
+  gc: gc;
   hemlock: bool;
   ocaml: bool;
   srcdir_opt: Path.t option;
@@ -45,7 +57,7 @@ let pp {verbose; text; hocc; algorithm; resolve_opt; remerge_opt; gc; hemlock; o
   |> Fmt.fmt "; algorithm=" |> pp_algorithm algorithm
   |> Fmt.fmt "; resolve_opt=" |> Option.pp Bool.pp resolve_opt
   |> Fmt.fmt "; remerge_opt=" |> Option.pp Bool.pp remerge_opt
-  |> Fmt.fmt "; gc=" |> Bool.pp gc
+  |> Fmt.fmt "; gc=" |> pp_gc gc
   |> Fmt.fmt "; hemlock=" |> Bool.pp hemlock
   |> Fmt.fmt "; ocaml=" |> Bool.pp ocaml
   |> Fmt.fmt "; srcdir_opt=" |> (Option.pp Path.pp) srcdir_opt
@@ -60,7 +72,7 @@ let default = {
   algorithm=Aplr;
   resolve_opt=None;
   remerge_opt=None;
-  gc=true;
+  gc=PreRemerge;
   hemlock=false;
   ocaml=false;
   srcdir_opt=None;
@@ -112,8 +124,9 @@ Parameters:
                         for aplr/ielr/lr algorithms, no for pgm/lalr algorithms.
 -[re]m[erge] (yes|no) : Control compatible state subgraph remerging enablement.
                         Defaults to yes for aplr algorithm, no otherwise.
-  -g[c] (yes|no)      : Control unreachable state garbage collection enablement.
-                        Defaults to yes.
+  -g[c] (pre|post|no) : Control unreachable state garbage collection enablement
+                        and ordering relative to remerging. Defaults to
+                        pre-remerging.
        -hm | -hemlock : Generate a Hemlock-based parser implementation and write
                         it to "<dstdir>/<module>.hm[i]".
          -ml | -ocaml : Generate an OCaml-based parser implementation and write
@@ -236,8 +249,9 @@ let of_argv argv =
           end
         | "-g" | "-gc" -> begin
             let gc = match Bytes.to_string_replace (arg_arg argv i) with
-              | "yes" -> true
-              | "no" -> false
+              | "pre" -> PreRemerge
+              | "post" -> PostRemerge
+              | "no" -> No
               | s -> begin
                   File.Fmt.stderr |> Fmt.fmt "hocc: Invalid gc parameter: "
                   |> Fmt.fmt s |> Fmt.fmt "\n" |> ignore;

--- a/bootstrap/bin/hocc/conf.mli
+++ b/bootstrap/bin/hocc/conf.mli
@@ -9,6 +9,11 @@ type algorithm =
   | Pgm (** PGM LR(1) algorithm. *)
   | Lalr (** LALR(1) algorithm. *)
 
+type gc =
+  | PreRemerge (** Perform unreachable state garbage collection before potentially remerging. *)
+  | PostRemerge (** Perform unreachable state garbage collection after potentially remerging. *)
+  | No (** Do not perform unreachable state garbage collection. *)
+
 type remerge =
   | Default of bool (** Default; no remerge parameter specified. *)
   | Explicit of bool (** Explicit remerge parameter specified. *)
@@ -39,8 +44,8 @@ val algorithm: t -> algorithm
 val resolve: t -> bool
 (** [resolve t] returns true if conflict resolution is enabled. *)
 
-val gc: t -> bool
-(** [gc t] returns true if unreachable state garbage collection is enabled. *)
+val gc: t -> gc
+(** [gc t] returns whether/when to perform unreachable state garbage collection. *)
 
 val remerge: t -> remerge
 (** [remerge t] returns a [Default]/[Explicit] remerging parameter, true if remerging of equivalent

--- a/bootstrap/bin/hocc/spec.ml
+++ b/bootstrap/bin/hocc/spec.ml
@@ -1292,6 +1292,11 @@ and init algorithm ~resolve ~gc ~remerge io hmh =
   in
   let io, precs, symbols, prods, callbacks = hmh_extract io hmh in
   let io, isocores, states = init_inner algorithm ~resolve io precs symbols prods callbacks in
+  let io, isocores, states = match gc with
+    | Conf.PreRemerge -> Trace.gc_states io prods isocores states
+    | PostRemerge
+    | No -> io, isocores, states
+  in
   let io, isocores, states = match remerge with
     | Conf.Default true
     | Explicit true -> begin
@@ -1319,8 +1324,9 @@ and init algorithm ~resolve ~gc ~remerge io hmh =
     | Explicit false -> io, isocores, states
   in
   let io, _isocores, states = match gc with
-    | true -> Trace.gc_states io prods isocores states
-    | false -> io, isocores, states
+    | PostRemerge -> Trace.gc_states io prods isocores states
+    | PreRemerge
+    | No -> io, isocores, states
   in
   let io = log_conflicts io ~resolve states in
   let io = log_unused io precs symbols prods states in

--- a/bootstrap/bin/hocc/spec.mli
+++ b/bootstrap/bin/hocc/spec.mli
@@ -27,7 +27,7 @@ val synthetic_name_of_start_name: string -> string
 (** [synthetic_name_of_start_name start_name] returns a synthetic symbol name based on [start_name],
     e.g. "Start" -> "Start'". *)
 
-val init: Conf.algorithm -> resolve:bool -> gc:bool -> remerge:Conf.remerge -> Io.t
+val init: Conf.algorithm -> resolve:bool -> gc:Conf.gc -> remerge:Conf.remerge -> Io.t
   -> Parse.nonterm_hmh -> Io.t * t
 (** [init algorithm ~resolve ~gc ~remerge io hmh] creates a specification using the specified
     [algorithm] on [hmh], with conflicts optionally resolved, unreachable states optionally

--- a/bootstrap/test/hocc/Conflict.expected
+++ b/bootstrap/test/hocc/Conflict.expected
@@ -4,10 +4,10 @@ hocc: 0 precedences, 3 tokens, 2 non-terminals (1 start), 3 productions
 hocc: LR(1) item set compatibility: lr
 hocc: Generating LR(1) item set closures (workq/total) 0/4
 hocc: Generating 4 LR(1) states
-hocc: State subgraph remerging disabled due to unresolvable conflicts
-hocc: Explicitly enable remerging (-remerge yes) to override
 hocc: Tracing automaton (.+=actions[+gotos])+.+.+
 hocc: 0 unreachable states
+hocc: State subgraph remerging disabled due to unresolvable conflicts
+hocc: Explicitly enable remerging (-remerge yes) to override
 hocc: 1 unresolvable conflict in 1 state (0 ⊥, 0 shift-reduce, 1 reduce-reduce)
 hocc: Searching for unused precedences/tokens/non-terminals/productions
 hocc: Hemlock code not generated due to conflict

--- a/bootstrap/test/hocc/Example.expected
+++ b/bootstrap/test/hocc/Example.expected
@@ -5,10 +5,10 @@ hocc: 2 precedences, 8 tokens, 5 non-terminals (1 start), 9 productions
 hocc: LR(1) item set compatibility: lr
 hocc: Generating LR(1) item set closures (workq/total) 0/14
 hocc: Generating 14 LR(1) states
-hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/0[0]
-hocc: 0 remergeable states
 hocc: Tracing automaton (.+=actions[+gotos])+.+.+.++
 hocc: 0 unreachable states
+hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/0[0]
+hocc: 0 remergeable states
 hocc: 0 unresolvable conflicts in 0 states
 hocc: Searching for unused precedences/tokens/non-terminals/productions
 hocc: Generating text report

--- a/bootstrap/test/hocc/Example_b.expected
+++ b/bootstrap/test/hocc/Example_b.expected
@@ -5,10 +5,10 @@ hocc: 2 precedences, 8 tokens, 5 non-terminals (1 start), 9 productions
 hocc: LR(1) item set compatibility: lr
 hocc: Generating LR(1) item set closures (workq/total) 0/14
 hocc: Generating 14 LR(1) states
-hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/0[0]
-hocc: 0 remergeable states
 hocc: Tracing automaton (.+=actions[+gotos])+.+.+.++
 hocc: 0 unreachable states
+hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/0[0]
+hocc: 0 remergeable states
 hocc: 0 unresolvable conflicts in 0 states
 hocc: Searching for unused precedences/tokens/non-terminals/productions
 hocc: Writing "./Example_b.hmi"

--- a/bootstrap/test/hocc/Example_c.expected
+++ b/bootstrap/test/hocc/Example_c.expected
@@ -5,10 +5,10 @@ hocc: 2 precedences, 8 tokens, 5 non-terminals (1 start), 9 productions
 hocc: LR(1) item set compatibility: lr
 hocc: Generating LR(1) item set closures (workq/total) 0/14
 hocc: Generating 14 LR(1) states
-hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/0[0]
-hocc: 0 remergeable states
 hocc: Tracing automaton (.+=actions[+gotos])+.+.+.++
 hocc: 0 unreachable states
+hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/0[0]
+hocc: 0 remergeable states
 hocc: 0 unresolvable conflicts in 0 states
 hocc: Searching for unused precedences/tokens/non-terminals/productions
 hocc: Writing "./Example_c.hmi"

--- a/bootstrap/test/hocc/Example_rno.expected
+++ b/bootstrap/test/hocc/Example_rno.expected
@@ -4,10 +4,10 @@ hocc: 2 precedences, 8 tokens, 5 non-terminals (1 start), 9 productions
 hocc: LR(1) item set compatibility: lr
 hocc: Generating LR(1) item set closures (workq/total) 0/14
 hocc: Generating 14 LR(1) states
-hocc: State subgraph remerging disabled due to unresolvable conflicts
-hocc: Explicitly enable remerging (-remerge yes) to override
 hocc: Tracing automaton (.+=actions[+gotos])+.+.+.++
 hocc: 0 unreachable states
+hocc: State subgraph remerging disabled due to unresolvable conflicts
+hocc: Explicitly enable remerging (-remerge yes) to override
 hocc: 8 conflicts in 2 states (0 ⊥, 8 shift-reduce, 0 reduce-reduce) (conflict resolution disabled)
 hocc: Searching for unused precedences/tokens/non-terminals/productions
 hocc: Generating text report

--- a/bootstrap/test/hocc/Gawk_aaplr.expected
+++ b/bootstrap/test/hocc/Gawk_aaplr.expected
@@ -4,10 +4,10 @@ hocc: 19 precedences, 60 tokens, 46 non-terminals (1 start), 164 productions
 hocc: LR(1) item set compatibility: lr
 hocc: Generating LR(1) item set closures (workq/total) 486/1_000 245/2_000 0/2_467
 hocc: Generating 2_467 LR(1) states
-hocc: State subgraph remerging disabled due to unresolvable conflicts
-hocc: Explicitly enable remerging (-remerge yes) to override
 hocc: Tracing automaton (.+=actions[+gotos])+.+......+..+......+.....+..+.....+......+..+..+..+.+++++++
 hocc: 108 unreachable states
 hocc: Reindexing 2_359 LR(1) states
+hocc: State subgraph remerging disabled due to unresolvable conflicts
+hocc: Explicitly enable remerging (-remerge yes) to override
 hocc: 308 unresolvable conflicts in 210 states (43 ⊥, 265 shift-reduce, 0 reduce-reduce)
 hocc: Searching for unused precedences/tokens/non-terminals/productions

--- a/bootstrap/test/hocc/Gawk_aielr_myes.expected
+++ b/bootstrap/test/hocc/Gawk_aielr_myes.expected
@@ -10,10 +10,11 @@ hocc: Gathering IELR(1) conflict state attributions (/=none/some)
 hocc: LR(1) item set compatibility: ielr
 hocc: Generating LR(1) item set closures (workq/total) 0/616
 hocc: Generating 616 LR(1) states
-hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/296[427] 249/296[0]
-hocc: Remerging 249 LR(1) states
+hocc: Tracing automaton (.+=actions[+gotos])+.+....+..+.....+.....+.+.....+.....+.++.+.++++++
+hocc: 4 unreachable states
+hocc: Reindexing 612 LR(1) states
+hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/292[423] 245/292[0]
+hocc: Remerging 245 LR(1) states
 hocc: Reindexing 367 LR(1) states
-hocc: Tracing automaton (.+=actions[+gotos])+.+...+..+.....+..+.+.....+.+++.++++++
-hocc: 0 unreachable states
 hocc: 104 unresolvable conflicts in 66 states (38 ⊥, 66 shift-reduce, 0 reduce-reduce)
 hocc: Searching for unused precedences/tokens/non-terminals/productions

--- a/bootstrap/test/hocc/Gpic_aaplr.expected
+++ b/bootstrap/test/hocc/Gpic_aaplr.expected
@@ -4,11 +4,11 @@ hocc: 25 precedences, 140 tokens, 46 non-terminals (1 start), 248 productions
 hocc: LR(1) item set compatibility: lr
 hocc: Generating LR(1) item set closures (workq/total) 539/1_000 825/2_000 880/3_000 685/4_000 0/4_871
 hocc: Generating 4_871 LR(1) states
-hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/4_445[4_847] 3_459/4_445[4_000] 3_966/4_445[3_000] 4_290/4_445[2_000] 4_432/4_445[1_000] 4_440/4_445[0]
-hocc: Remerging 4_440 LR(1) states
-hocc: Reindexing 431 LR(1) states
-hocc: Tracing automaton (.+=actions[+gotos])+.+....+....+..+.+.+.+++
-hocc: 3 unreachable states
+hocc: Tracing automaton (.+=actions[+gotos])+.+......+....+.....+....+..+..+..+.+++
+hocc: 37 unreachable states
+hocc: Reindexing 4_834 LR(1) states
+hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/4_411[4_810] 3_411/4_411[4_000] 3_954/4_411[3_000] 4_262/4_411[2_000] 4_404/4_411[1_000] 4_406/4_411[0]
+hocc: Remerging 4_406 LR(1) states
 hocc: Reindexing 428 LR(1) states
 hocc: 239 unresolvable conflicts in 239 states (239 ⊥, 0 shift-reduce, 0 reduce-reduce)
 hocc: Searching for unused precedences/tokens/non-terminals/productions

--- a/bootstrap/test/hocc/Gpic_aielr_myes.expected
+++ b/bootstrap/test/hocc/Gpic_aielr_myes.expected
@@ -10,11 +10,11 @@ hocc: Gathering IELR(1) conflict state attributions (/=none/some)
 hocc: LR(1) item set compatibility: ielr
 hocc: Generating LR(1) item set closures (workq/total) 0/450
 hocc: Generating 450 LR(1) states
-hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/24[38] 19/24[0]
-hocc: Remerging 19 LR(1) states
-hocc: Reindexing 431 LR(1) states
 hocc: Tracing automaton (.+=actions[+gotos])+.+....+....+..+.+.+.+++
 hocc: 3 unreachable states
+hocc: Reindexing 447 LR(1) states
+hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/24[38] 19/24[0]
+hocc: Remerging 19 LR(1) states
 hocc: Reindexing 428 LR(1) states
 hocc: 239 unresolvable conflicts in 239 states (239 ⊥, 0 shift-reduce, 0 reduce-reduce)
 hocc: Searching for unused precedences/tokens/non-terminals/productions

--- a/bootstrap/test/hocc/Hocc.expected
+++ b/bootstrap/test/hocc/Hocc.expected
@@ -4,11 +4,11 @@ hocc: 5 precedences, 42 tokens, 48 non-terminals (2 starts), 158 productions
 hocc: LR(1) item set compatibility: lr
 hocc: Generating LR(1) item set closures (workq/total) 0/860
 hocc: Generating 860 LR(1) states
+hocc: Tracing automaton (.+=actions[+gotos])+.+.....+...+....+..+..+....+..+..+..+.+...+.++.+.+.++
+hocc: 1 unreachable state
+hocc: Reindexing 859 LR(1) states
 hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/601[785] 601/601[0]
 hocc: Remerging 601 LR(1) states
-hocc: Reindexing 259 LR(1) states
-hocc: Tracing automaton (.+=actions[+gotos])+.+.....+...+....+..+..+.+..+..+.+.+.+.+.++
-hocc: 1 unreachable state
 hocc: Reindexing 258 LR(1) states
 hocc: 0 unresolvable conflicts in 0 states
 hocc: Searching for unused precedences/tokens/non-terminals/productions

--- a/bootstrap/test/hocc/IelrRemergeable_aaplr_post.expected
+++ b/bootstrap/test/hocc/IelrRemergeable_aaplr_post.expected
@@ -1,16 +1,15 @@
-hocc: Parsing "./IelrRemergeable_aaplr.hmh"
+hocc: Parsing "./IelrRemergeable_aaplr_gpost.hmh"
 hocc: Generating APLR(1) specification
 hocc: 6 precedences, 13 tokens, 5 non-terminals (1 start), 15 productions
 hocc: LR(1) item set compatibility: lr
 hocc: Generating LR(1) item set closures (workq/total) 0/268
 hocc: Generating 268 LR(1) states
-hocc: Tracing automaton (.+=actions[+gotos])+..+...+..+.+...+..+..+..+..+.+.+
-hocc: 4 unreachable states
-hocc: Reindexing 264 LR(1) states
-hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/219[259] 219/219[0]
-hocc: Remerging 219 LR(1) states
+hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/223[263] 223/223[0]
+hocc: Remerging 223 LR(1) states
 hocc: Reindexing 45 LR(1) states
+hocc: Tracing automaton (.+=actions[+gotos])+.+..+.+.+..+.+.+.+
+hocc: 0 unreachable states
 hocc: 0 unresolvable conflicts in 0 states
 hocc: Searching for unused precedences/tokens/non-terminals/productions
 hocc: Generating text report
-hocc: Writing "./hocc/IelrRemergeable_aaplr.txt"
+hocc: Writing "./hocc/IelrRemergeable_aaplr_gpost.txt"

--- a/bootstrap/test/hocc/IelrRemergeable_aaplr_post.expected.txt
+++ b/bootstrap/test/hocc/IelrRemergeable_aaplr_post.expected.txt
@@ -1,4 +1,4 @@
-IelrRemergeable_aaplr grammar
+IelrRemergeable_aaplr_gpost grammar
 
 Precedences
     left p0
@@ -580,13 +580,13 @@ APLR(1) States
             "," : ShiftPrefix 18 prec p4
     State 36 [36.0]
         Kernel
-            [E ::= E "<" · E, {")", "+", "-", "max", "<", ">", ",", EOI}] prec p3
+            [E ::= E "<" · E, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p3
         Added
-            [E ::= · "var", {")", "+", "-", "max", "<", ">", ",", EOI}]
-            [E ::= · E "+" E, {")", "+", "-", "max", "<", ">", ",", EOI}] prec p0
-            [E ::= · "(" E ")", {")", "+", "-", "max", "<", ">", ",", EOI}]
-            [E ::= · E "<" E, {")", "+", "-", "max", "<", ">", ",", EOI}] prec p3
-            [E ::= · E ">" E, {")", "+", "-", "max", "<", ">", ",", EOI}] prec p3
+            [E ::= · "var", {")", "+", "-", "max", "min", "<", ">", ",", EOI}]
+            [E ::= · E "+" E, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p0
+            [E ::= · "(" E ")", {")", "+", "-", "max", "min", "<", ">", ",", EOI}]
+            [E ::= · E "<" E, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p3
+            [E ::= · E ">" E, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p3
         Actions
             "var" : ShiftPrefix 1 prec p5
             "(" : ShiftPrefix 26 prec p5
@@ -664,15 +664,16 @@ APLR(1) States
             EOI : Reduce Pos ::= "(" Pos "," Pos ")"
     State 41 [41.0]
         Kernel
-            [E ::= E · "+" E, {")", "+", "-", "max", "<", ">", ",", EOI}] prec p0
-            [E ::= E · "<" E, {")", "+", "-", "max", "<", ">", ",", EOI}] prec p3
-            [E ::= E "<" E ·, {")", "+", "-", "max", "<", ">", ",", EOI}] prec p3
-            [E ::= E · ">" E, {")", "+", "-", "max", "<", ">", ",", EOI}] prec p3
+            [E ::= E · "+" E, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p0
+            [E ::= E · "<" E, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p3
+            [E ::= E "<" E ·, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p3
+            [E ::= E · ">" E, {")", "+", "-", "max", "min", "<", ">", ",", EOI}] prec p3
         Actions
             ")" : Reduce E ::= E "<" E prec p3
             "+" : ShiftPrefix 14 prec p0
             "-" : Reduce E ::= E "<" E prec p3
             "max" : Reduce E ::= E "<" E prec p3
+            "min" : Reduce E ::= E "<" E prec p3
             "<" : Reduce E ::= E "<" E prec p3
             ">" : Reduce E ::= E "<" E prec p3
             "," : Reduce E ::= E "<" E prec p3

--- a/bootstrap/test/hocc/IelrRemergeable_aielr_myes.expected
+++ b/bootstrap/test/hocc/IelrRemergeable_aielr_myes.expected
@@ -10,11 +10,11 @@ hocc: Gathering IELR(1) conflict state attributions (/=none/some)
 hocc: LR(1) item set compatibility: ielr
 hocc: Generating LR(1) item set closures (workq/total) 0/58
 hocc: Generating 58 LR(1) states
+hocc: Tracing automaton (.+=actions[+gotos])+.+..+.+.+..+.+.+.++
+hocc: 0 unreachable states
 hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/13[25] 13/13[0]
 hocc: Remerging 13 LR(1) states
 hocc: Reindexing 45 LR(1) states
-hocc: Tracing automaton (.+=actions[+gotos])+.+..+.+.+..+.+.+.+
-hocc: 0 unreachable states
 hocc: 0 unresolvable conflicts in 0 states
 hocc: Searching for unused precedences/tokens/non-terminals/productions
 hocc: Generating text report

--- a/bootstrap/test/hocc/MulAddParenPrec.expected
+++ b/bootstrap/test/hocc/MulAddParenPrec.expected
@@ -4,11 +4,11 @@ hocc: 2 precedences, 8 tokens, 5 non-terminals (1 start), 8 productions
 hocc: LR(1) item set compatibility: lr
 hocc: Generating LR(1) item set closures (workq/total) 0/25
 hocc: Generating 25 LR(1) states
+hocc: Tracing automaton (.+=actions[+gotos])+..++.+.+.+
+hocc: 0 unreachable states
 hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/10[20] 10/10[0]
 hocc: Remerging 10 LR(1) states
 hocc: Reindexing 15 LR(1) states
-hocc: Tracing automaton (.+=actions[+gotos])+.++.+.+.+
-hocc: 0 unreachable states
 hocc: 0 unresolvable conflicts in 0 states
 hocc: Searching for unused precedences/tokens/non-terminals/productions
 hocc: Generating text report

--- a/bootstrap/test/hocc/NestedEpsilon.expected
+++ b/bootstrap/test/hocc/NestedEpsilon.expected
@@ -4,10 +4,10 @@ hocc: 0 precedences, 4 tokens, 6 non-terminals (1 start), 7 productions
 hocc: LR(1) item set compatibility: lr
 hocc: Generating LR(1) item set closures (workq/total) 0/9
 hocc: Generating 9 LR(1) states
-hocc: State subgraph remerging disabled due to unresolvable conflicts
-hocc: Explicitly enable remerging (-remerge yes) to override
 hocc: Tracing automaton (.+=actions[+gotos])+.+++.+.+
 hocc: 0 unreachable states
+hocc: State subgraph remerging disabled due to unresolvable conflicts
+hocc: Explicitly enable remerging (-remerge yes) to override
 hocc: 1 unresolvable conflict in 1 state (0 ⊥, 0 shift-reduce, 1 reduce-reduce)
 hocc: Searching for unused precedences/tokens/non-terminals/productions
 hocc: Generating text report

--- a/bootstrap/test/hocc/PSEUDO_END_conflict.expected
+++ b/bootstrap/test/hocc/PSEUDO_END_conflict.expected
@@ -4,10 +4,10 @@ hocc: 2 precedences, 7 tokens, 4 non-terminals (1 start), 8 productions
 hocc: LR(1) item set compatibility: lr
 hocc: Generating LR(1) item set closures (workq/total) 0/12
 hocc: Generating 12 LR(1) states
-hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/0[0]
-hocc: 0 remergeable states
 hocc: Tracing automaton (.+=actions[+gotos])+.+.+++
 hocc: 0 unreachable states
+hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/0[0]
+hocc: 0 remergeable states
 hocc: 4 unresolvable conflicts in 4 states (4 ⊥, 0 shift-reduce, 0 reduce-reduce)
 hocc: Searching for unused precedences/tokens/non-terminals/productions
 hocc: Generating text report

--- a/bootstrap/test/hocc/TokenCoverage.expected
+++ b/bootstrap/test/hocc/TokenCoverage.expected
@@ -5,10 +5,10 @@ hocc: 8 precedences, 8 tokens, 10 non-terminals (2 starts), 15 productions
 hocc: LR(1) item set compatibility: lr
 hocc: Generating LR(1) item set closures (workq/total) 0/6
 hocc: Generating 6 LR(1) states
-hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/0[0]
-hocc: 0 remergeable states
 hocc: Tracing automaton (.+=actions[+gotos])++.+
 hocc: 0 unreachable states
+hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/0[0]
+hocc: 0 remergeable states
 hocc: 0 unresolvable conflicts in 0 states
 hocc: Searching for unused precedences/tokens/non-terminals/productions
 hocc: 6 unused precedences:

--- a/bootstrap/test/hocc/Unused.expected
+++ b/bootstrap/test/hocc/Unused.expected
@@ -4,10 +4,10 @@ hocc: 2 precedences, 5 tokens, 5 non-terminals (1 start), 7 productions
 hocc: LR(1) item set compatibility: lr
 hocc: Generating LR(1) item set closures (workq/total) 0/5
 hocc: Generating 5 LR(1) states
-hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/0[0]
-hocc: 0 remergeable states
 hocc: Tracing automaton (.+=actions[+gotos])+.+.+
 hocc: 0 unreachable states
+hocc: Searching for remergeable state subgraphs (mergeable/max[worklst]) 0/0[0]
+hocc: 0 remergeable states
 hocc: 1 unresolvable conflict in 1 state (1 ⊥, 0 shift-reduce, 0 reduce-reduce)
 hocc: Searching for unused precedences/tokens/non-terminals/productions
 hocc: 2 unused precedences:

--- a/bootstrap/test/hocc/dune
+++ b/bootstrap/test/hocc/dune
@@ -466,6 +466,21 @@
  (deps
   (glob_files IelrRemergeable.hmh*)
   %{bin:hocc})
+ (targets IelrRemergeable_aaplr_gpost.out.txt)
+ (action
+  (with-accepted-exit-codes 0
+   (with-outputs-to IelrRemergeable_aaplr_gpost.out (run ./hocc_test %{bin:hocc} IelrRemergeable -algorithm aplr -gc post -v -txt)))))
+(rule
+ (alias runtest)
+ (action
+  (progn
+   (diff IelrRemergeable_aaplr_post.expected IelrRemergeable_aaplr_gpost.out)
+   (diff IelrRemergeable_aaplr_post.expected.txt IelrRemergeable_aaplr_gpost.out.txt))))
+
+(rule
+ (deps
+  (glob_files IelrRemergeable.hmh*)
+  %{bin:hocc})
  (targets IelrRemergeable_aielr_gno.out.txt)
  (action
   (with-accepted-exit-codes 0

--- a/bootstrap/test/hocc/help_a.expected
+++ b/bootstrap/test/hocc/help_a.expected
@@ -19,8 +19,9 @@ Parameters:
                         for aplr/ielr/lr algorithms, no for pgm/lalr algorithms.
 -[re]m[erge] (yes|no) : Control compatible state subgraph remerging enablement.
                         Defaults to yes for aplr algorithm, no otherwise.
-  -g[c] (yes|no)      : Control unreachable state garbage collection enablement.
-                        Defaults to yes.
+  -g[c] (pre|post|no) : Control unreachable state garbage collection enablement
+                        and ordering relative to remerging. Defaults to
+                        pre-remerging.
        -hm | -hemlock : Generate a Hemlock-based parser implementation and write
                         it to "<dstdir>/<module>.hm[i]".
          -ml | -ocaml : Generate an OCaml-based parser implementation and write

--- a/bootstrap/test/hocc/help_b.expected
+++ b/bootstrap/test/hocc/help_b.expected
@@ -20,8 +20,9 @@ Parameters:
                         for aplr/ielr/lr algorithms, no for pgm/lalr algorithms.
 -[re]m[erge] (yes|no) : Control compatible state subgraph remerging enablement.
                         Defaults to yes for aplr algorithm, no otherwise.
-  -g[c] (yes|no)      : Control unreachable state garbage collection enablement.
-                        Defaults to yes.
+  -g[c] (pre|post|no) : Control unreachable state garbage collection enablement
+                        and ordering relative to remerging. Defaults to
+                        pre-remerging.
        -hm | -hemlock : Generate a Hemlock-based parser implementation and write
                         it to "<dstdir>/<module>.hm[i]".
          -ml | -ocaml : Generate an OCaml-based parser implementation and write

--- a/bootstrap/test/hocc/hocc_test
+++ b/bootstrap/test/hocc/hocc_test
@@ -49,7 +49,7 @@ case "$1" in
         shift 2
         ;;
     *)
-        gc="yes"
+        gc="pre"
 esac
 
 if [ "x${mangled_src}" != "x${src}" ] ; then

--- a/doc/tools/hocc.md
+++ b/doc/tools/hocc.md
@@ -55,7 +55,9 @@ Parameters:
   `aplr`/`ielr`/`lr` algorithms, `no` for `pgm`/`lalr` algorithms.
 - `-[re]m[erge] (yes|no)`: Control compatible state subgraph remerging enablement. Defaults to `yes`
   for `aplr` algorithm, `no` otherwise.
-- `-g[c] (yes|no)`: Control unreachable state garbage collection enablement. Defaults to `yes`.
+- `-g[c] (pre|post|no)`: Control unreachable state garbage collection enablement and ordering
+  relative to remerging. Defaults to `pre`-remerging, which is more thorough than `post`-remerging
+  but slower due to operating on a larger automaton.
 - `-hm` | `-hemlock`: Generate a Hemlock-based parser implementation and write it to
   `<dstdir>/<module>.hm[i]`.
 - `-ml` | `-ocaml`: Generate an OCaml-based parser implementation and write it to


### PR DESCRIPTION
Trace before remerging, because it is slightly more effective; reduce actions present in only one remerged lane can make previously unreachable gotos reachable. This change can result in APLR automata omitting actions that LR also omits, whereas IELR still contains these actions that can cause longer reduce cascades prior to syntax error detection.