### PR TITLE
Enhance `next` function to restore stack on `Reject`, implement `expect`

### DIFF
--- a/bootstrap/bin/hocc/Parse.hmh
+++ b/bootstrap/bin/hocc/Parse.hmh
@@ -1,9 +1,9 @@
 (* To bootstrap the `hocc` parser, run one of the following commands:
  *
  * - Compilable (trivial update):
- *   dune exec -- hocc -v -ml -s Parse
+ *   dune exec -- hocc -v -w -ml -s Parse
  * - Not compilable (use external `hocc`):
- *   hocc -v -ml -s Parse
+ *   hocc -v -w -ml -s Parse
  *)
 open Basis
 open! Basis.Rudiments
@@ -156,18 +156,18 @@ type nonterm_uident =
   | SymbolTypeQualifierEpsilon
   and nonterm_symbol_type =
   | SymbolType of {symbol_type_qualifier: nonterm_symbol_type_qualifier; symbol_type: Scan.Token.t}
-  and nonterm_symbol_type0 =
-  | SymbolType0SymbolType of {symbol_type: nonterm_symbol_type}
-  | SymbolType0Epsilon
   and nonterm_prec_ref =
   | PrecRefUident of {uident: Scan.Token.t}
   | PrecRefEpsilon
-  and nonterm_token_alias =
-  | TokenAlias of {alias: token_istring}
-  | TokenAliasEpsilon
+  and nonterm_alias =
+  | Alias of {alias: token_istring}
+  | AliasEpsilon
+  and nonterm_token_type =
+  | TokenType of {symbol_type: nonterm_symbol_type; proto: nonterm_code}
+  | TokenTypeEpsilon
   and nonterm_token =
-  | Token of {cident: token_cident; token_alias: nonterm_token_alias;
-  symbol_type0: nonterm_symbol_type0; prec_ref: nonterm_prec_ref}
+  | Token of {cident: token_cident; alias: nonterm_alias; token_type: nonterm_token_type;
+  prec_ref: nonterm_prec_ref}
   and nonterm_sep =
   | SepLineDelim of {line_delim: token_line_delim}
   | SepSemi of {semi: token_semi}
@@ -274,65 +274,123 @@ type nonterm_uident =
   and nonterm_hmhi =
   | Hmhi of {prelude: nonterm_matter; hocc_: token_hocc; postlude: nonterm_matter; eoi: token_eoi}
 
+(* Fake prototype token payload. *)
+let fake_token =
+    let source =
+      ""
+      |> String.C.Slice.of_string
+      |> Text.of_string_slice
+      |> Hmc.Source.init
+      in
+    let base = Hmc.Source.Cursor.hd source in
+    let past = Hmc.Source.Cursor.tl source in
+    let slice = Hmc.Source.Slice.of_cursors ~base ~past in
+    Scan.Token.HmcToken (Hmc.Scan.Token.Tok_error {source=slice; error=[]})
+
+(* Prototype tokens. *)
+let proto_hocc = HOCC {token=fake_token}
+let proto_nonterm = NONTERM {token=fake_token}
+let proto_epsilon = EPSILON {token=fake_token}
+let proto_start = START {token=fake_token}
+let proto_token = TOKEN {token=fake_token}
+let proto_neutral = NEUTRAL {token=fake_token}
+let proto_left = LEFT {token=fake_token}
+let proto_right = RIGHT {token=fake_token}
+let proto_nonassoc = NONASSOC {token=fake_token}
+let proto_prec = PREC {token=fake_token}
+let proto_uident = UIDENT {token=fake_token}
+let proto_cident = CIDENT {token=fake_token}
+let proto_uscore = USCORE {token=fake_token}
+let proto_istring = ISTRING {token=fake_token}
+let proto_colon_colon_eq = COLON_COLON_EQ {token=fake_token}
+let proto_of = OF {token=fake_token}
+let proto_colon = COLON {token=fake_token}
+let proto_dot = DOT {token=fake_token}
+let proto_arrow = ARROW {token=fake_token}
+let proto_bar = BAR {token=fake_token}
+let proto_lt = LT {token=fake_token}
+let proto_eq = EQ {token=fake_token}
+let proto_comma = COMMA {token=fake_token}
+let proto_semi = SEMI {token=fake_token}
+let proto_as = AS {token=fake_token}
+let proto_line_delim = LINE_DELIM {token=fake_token}
+let proto_indent = INDENT {token=fake_token}
+let proto_dedent = DEDENT {token=fake_token}
+let proto_lparen = LPAREN {token=fake_token}
+let proto_rparen = RPAREN {token=fake_token}
+let proto_lcapture = LCAPTURE {token=fake_token}
+let proto_rcapture = RCAPTURE {token=fake_token}
+let proto_lbrack = LBRACK {token=fake_token}
+let proto_rbrack = RBRACK {token=fake_token}
+let proto_larray = LARRAY {token=fake_token}
+let proto_rarray = RARRAY {token=fake_token}
+let proto_lcurly = LCURLY {token=fake_token}
+let proto_rcurly = RCURLY {token=fake_token}
+let proto_other_token = OTHER_TOKEN {token=fake_token}
+let proto_eoi = EOI {token=fake_token}
+
 include hocc
+    neutral pCodeTlEpsilon
+    neutral pPrec < pCodeTlEpsilon
+
     (* hocc-specific keywords *)
-    token HOCC "hocc" of token_hocc
-    token NONTERM "nonterm" of token_nonterm
-    token EPSILON_ "epsilon" of token_epsilon
-    token START "start" of token_start
-    token TOKEN "token" of token_token
-    token NEUTRAL "neutral" of token_neutral
-    token LEFT "left" of token_left
-    token RIGHT "right" of token_right
-    token NONASSOC "nonassoc" of token_nonassoc
-    token PREC "prec" of token_prec
+    token HOCC "hocc" of token_hocc proto_hocc
+    token NONTERM "nonterm" of token_nonterm proto_nonterm
+    token EPSILON_ "epsilon" of token_epsilon proto_epsilon
+    token START "start" of token_start proto_start
+    token TOKEN "token" of token_token proto_token
+    token NEUTRAL "neutral" of token_neutral proto_neutral
+    token LEFT "left" of token_left proto_left
+    token RIGHT "right" of token_right proto_right
+    token NONASSOC "nonassoc" of token_nonassoc proto_nonassoc
+    token PREC "prec" of token_prec proto_prec prec pPrec
 
     (* Identifiers *)
-    token UIDENT of token_uident # Uncapitalized
+    token UIDENT of token_uident proto_uident # Uncapitalized
     neutral pCIDENT
-    token CIDENT of token_cident # Capitalized
-    token USCORE "_" of token_uscore
+    token CIDENT of token_cident proto_cident # Capitalized
+    token USCORE "_" of token_uscore proto_uscore
 
     (* Token alias *)
-    token ISTRING of token_istring
+    token ISTRING of token_istring proto_istring
 
     (* Punctuation/separators *)
-    token COLON_COLON_EQ "::=" of token_colon_colon_eq
-    token OF "of" of token_of
-    token COLON ":" of token_colon
+    token COLON_COLON_EQ "::=" of token_colon_colon_eq proto_colon_colon_eq
+    token OF "of" of token_of proto_of
+    token COLON ":" of token_colon proto_colon
     left pDOT
-    token DOT "." of token_dot prec pDOT
-    token ARROW "->" of token_arrow
-    token BAR "|" of token_bar
-    token LT "<" of token_lt
-    token EQ "=" of token_eq
+    token DOT "." of token_dot proto_dot prec pDOT
+    token ARROW "->" of token_arrow proto_arrow
+    token BAR "|" of token_bar proto_bar
+    token LT "<" of token_lt proto_lt
+    token EQ "=" of token_eq proto_eq
     left pCOMMA < pCIDENT
-    token COMMA "," of token_comma prec pCOMMA
+    token COMMA "," of token_comma proto_comma prec pCOMMA
     right pSEMI
-    token SEMI ";" of token_semi prec pSEMI
+    token SEMI ";" of token_semi proto_semi prec pSEMI
     neutral pAS < pCOMMA
-    token AS "as" of token_as prec pAS
-    token LINE_DELIM of token_line_delim
+    token AS "as" of token_as proto_as prec pAS
+    token LINE_DELIM of token_line_delim proto_line_delim
 
     (* Left-right paired delimiters *)
-    token INDENT of token_indent
-    token DEDENT of token_dedent
-    token LPAREN "(" of token_lparen
-    token RPAREN ")" of token_rparen
-    token LCAPTURE "(|" of token_lcapture
-    token RCAPTURE "|)" of token_rcapture
-    token LBRACK "[" of token_lbrack
-    token RBRACK "]" of token_rbrack
-    token LARRAY "[|" of token_larray
-    token RARRAY "|]" of token_rarray
-    token LCURLY "{" of token_lcurly
-    token RCURLY "}" of token_rcurly
+    token INDENT of token_indent proto_indent
+    token DEDENT of token_dedent proto_dedent
+    token LPAREN "(" of token_lparen proto_lparen
+    token RPAREN ")" of token_rparen proto_rparen
+    token LCAPTURE "(|" of token_lcapture proto_lcapture
+    token RCAPTURE "|)" of token_rcapture proto_rcapture
+    token LBRACK "[" of token_lbrack proto_lbrack
+    token RBRACK "]" of token_rbrack proto_rbrack
+    token LARRAY "[|" of token_larray proto_larray
+    token RARRAY "|]" of token_rarray proto_rarray
+    token LCURLY "{" of token_lcurly proto_lcurly
+    token RCURLY "}" of token_rcurly proto_rcurly
 
     (* Miscellaneous Hemlock token in embedded code *)
-    token OTHER_TOKEN of token_other_token
+    token OTHER_TOKEN of token_other_token proto_other_token
 
     (* End of input, used to terminate start symbols *)
-    token EOI of token_eoi
+    token EOI of token_eoi proto_eoi
 
     nonterm Uident of nonterm_uident ::=
       | (HOCC {token}):"hocc"
@@ -378,21 +436,21 @@ include hocc
       | "of" symbol_type_qualifier:SymbolTypeQualifier (Uident {token}):Uident ->
         SymbolType {symbol_type_qualifier; symbol_type=token}
 
-    nonterm SymbolType0 of nonterm_symbol_type0 ::=
-      | symbol_type:SymbolType -> SymbolType0SymbolType {symbol_type}
-      | epsilon -> SymbolType0Epsilon
-
     nonterm PrecRef of nonterm_prec_ref ::=
       | "prec" (Uident {token}):Uident -> PrecRefUident {uident=token}
       | epsilon -> PrecRefEpsilon
 
-    nonterm TokenAlias of nonterm_token_alias ::=
-      | alias:ISTRING -> TokenAlias {alias}
-      | epsilon -> TokenAliasEpsilon
+    nonterm Alias of nonterm_alias ::=
+      | alias:ISTRING -> Alias {alias}
+      | epsilon -> AliasEpsilon
+
+    nonterm TokenType of nonterm_token_type ::=
+      | symbol_type:SymbolType proto:Code -> TokenType {symbol_type; proto}
+      | epsilon -> TokenTypeEpsilon
 
     nonterm Token of nonterm_token ::=
-      | "token" cident:CIDENT token_alias:TokenAlias symbol_type0:SymbolType0 prec_ref:PrecRef ->
-        Token {cident; token_alias; symbol_type0; prec_ref}
+      | "token" cident:CIDENT alias:Alias token_type:TokenType prec_ref:PrecRef ->
+        Token {cident; alias; token_type; prec_ref}
 
     nonterm Sep of nonterm_sep ::=
       | line_delim:LINE_DELIM -> SepLineDelim {line_delim}
@@ -438,7 +496,7 @@ include hocc
     nonterm CodeTl of nonterm_code_tl ::=
       | delimited:Delimited code_tl:CodeTl -> CodeTlDelimited {delimited; code_tl}
       | code_token:CodeToken code_tl:CodeTl -> CodeTlCodeToken {code_token; code_tl}
-      | epsilon -> CodeTlEpsilon
+      | epsilon prec pCodeTlEpsilon -> CodeTlEpsilon
 
     nonterm Code of nonterm_code ::=
       | delimited:Delimited code_tl:CodeTl -> CodeDelimited {delimited; code_tl}
@@ -676,6 +734,21 @@ let rec scan scanner =
       end
       | mals -> scanner, scan_token, Token.OTHER_TOKEN (OTHER_TOKEN {token=scan_token}), mals
 
+let pp_expect expect formatter =
+    let names =
+      expect
+      |> Ordset.to_list
+      |> List.map ~f:(fun token ->
+        match Token.spec token with
+          | {alias=Some alias; _} -> alias
+          | {name; _} -> name
+      )
+      in
+    formatter
+      |> Fmt.fmt "{⸱"
+      |> Fmt.fmt (String.join ~sep:"⸱" names)
+      |> Fmt.fmt "⸱}"
+
 let hmhi scanner =
     let rec inner scanner errs parser = begin
         let scanner, scan_token, token, mals = scan scanner in
@@ -689,7 +762,13 @@ let hmhi scanner =
           | Accept (Hmhi hmhi), [] -> scanner, Ok hmhi
           | Accept (Hmhi _), _ -> scanner, Error errs
           | Reject _, _ ->
-            let errs = Error.init_token scan_token "Unexpected token" :: errs in
+            let msg =
+              String.Fmt.empty
+              |> Fmt.fmt "Unexpected token not in "
+              |> pp_expect (expect parser)
+              |> Fmt.to_string
+              in
+            let errs = Error.init_token scan_token msg :: errs in
             scanner, Error errs
           | _ -> not_reached ()
       end in
@@ -709,7 +788,13 @@ let hmh scanner =
           | Accept (Hmh hmh), [] -> scanner, Ok hmh
           | Accept (Hmh _), _ -> scanner, Error errs
           | Reject _, _ -> begin
-            let errs = Error.init_token scan_token "Unexpected token" :: errs in
+            let msg =
+              String.Fmt.empty
+              |> Fmt.fmt "Unexpected token not in "
+              |> pp_expect (expect parser)
+              |> Fmt.to_string
+              in
+            let errs = Error.init_token scan_token msg :: errs in
             scanner, Error errs
           end
           | _ -> not_reached ()
@@ -1088,20 +1173,6 @@ let rec pp_token_hocc (HOCC {token}) formatter =
   and pp_symbol_type symbol_type formatter =
     fmt_symbol_type symbol_type formatter
 
-  and fmt_symbol_type0 ?(alt=Fmt.alt_default) ?(width=Fmt.width_default) symbol_type0
-  formatter =
-    let width' = width + 4L in
-    match symbol_type0 with
-      | SymbolType0SymbolType {symbol_type} ->
-        formatter |> Fmt.fmt "SymbolType0SymbolType "
-          |> fmt_lcurly ~alt ~width
-          |> Fmt.fmt "symbol_type=" |> fmt_symbol_type ~alt ~width:width' symbol_type
-          |> fmt_rcurly ~alt ~width
-      | SymbolType0Epsilon ->
-        formatter |> Fmt.fmt "SymbolType0Epsilon"
-  and pp_symbol_type0 symbol_type0 formatter =
-    fmt_symbol_type0 symbol_type0 formatter
-
   and fmt_prec_ref ?(alt=Fmt.alt_default) ?(width=Fmt.width_default) prec_ref formatter =
     match prec_ref with
       | PrecRefUident {uident} ->
@@ -1114,29 +1185,44 @@ let rec pp_token_hocc (HOCC {token}) formatter =
   and pp_prec_ref prec_ref formatter =
     fmt_prec_ref prec_ref formatter
 
-  and fmt_token_alias ?(alt=Fmt.alt_default) ?(width=Fmt.width_default) token_alias formatter =
-    match token_alias with
-      | TokenAlias {alias} ->
-        formatter |> Fmt.fmt "Token "
+  and fmt_alias ?(alt=Fmt.alt_default) ?(width=Fmt.width_default) token formatter =
+    match token with
+      | Alias {alias} ->
+        formatter |> Fmt.fmt "Alias "
           |> fmt_lcurly ~alt ~width
           |> Fmt.fmt "alias=" |> pp_token_istring alias
           |> fmt_rcurly ~alt ~width
-      | TokenAliasEpsilon ->
-        formatter |> Fmt.fmt "TokenAliasEpsilon"
-  and pp_token_alias token_alias formatter =
-    fmt_token_alias token_alias formatter
+      | AliasEpsilon ->
+        formatter |> Fmt.fmt "AliasEpsilon"
+  and pp_alias alias formatter =
+    fmt_alias alias formatter
+
+  and fmt_token_type ?(alt=Fmt.alt_default) ?(width=Fmt.width_default) token formatter =
+    let width' = width + 4L in
+    match token with
+      | TokenType {symbol_type; proto} ->
+        formatter |> Fmt.fmt "TokenType "
+          |> fmt_lcurly ~alt ~width
+          |> Fmt.fmt "symbol_type=" |> pp_symbol_type symbol_type
+          |> fmt_semi ~alt ~width
+          |> Fmt.fmt "proto=" |> fmt_code ~alt ~width:width' proto
+          |> fmt_rcurly ~alt ~width
+      | TokenTypeEpsilon ->
+        formatter |> Fmt.fmt "TokenTypeEpsilon"
+  and pp_token_type token_type formatter =
+    fmt_token_type token_type formatter
 
   and fmt_token ?(alt=Fmt.alt_default) ?(width=Fmt.width_default) token formatter =
     let width' = width + 4L in
     match token with
-      | Token {cident; token_alias; symbol_type0; prec_ref} ->
+      | Token {cident; alias; token_type; prec_ref} ->
         formatter |> Fmt.fmt "Token "
           |> fmt_lcurly ~alt ~width
           |> Fmt.fmt "cident=" |> pp_token_cident cident
           |> fmt_semi ~alt ~width
-          |> Fmt.fmt "token_alias=" |> fmt_token_alias ~alt ~width:width' token_alias
+          |> Fmt.fmt "alias=" |> pp_alias alias
           |> fmt_semi ~alt ~width
-          |> Fmt.fmt "symbol_type0=" |> fmt_symbol_type0 ~alt ~width:width' symbol_type0
+          |> Fmt.fmt "token_type=" |> fmt_token_type ~alt ~width:width' token_type
           |> fmt_semi ~alt ~width
           |> Fmt.fmt "prec_ref=" |> fmt_prec_ref ~alt ~width:width' prec_ref
           |> fmt_rcurly ~alt ~width
@@ -1821,7 +1907,7 @@ let rec source_of_binding = function
 (**************************************************************************************************)
 (* Miscellaneous helper functions. *)
 
-let min_comment_indentation_of_hocc_block = function
+let indentation_of_hocc_block = function
   | Hocc {indent=INDENT {token=indent}; _} ->
     Scan.Token.source indent
       |> Hmc.Source.Slice.base
@@ -1901,7 +1987,7 @@ let source_of_code code =
     Hmc.Source.Slice.of_cursors ~base ~past
 
 let indentation_of_code hocc_block code =
-    let min_comment_indentation = min_comment_indentation_of_hocc_block hocc_block in
+    let min_comment_indentation = indentation_of_hocc_block hocc_block in
     match code with
       | CodeDelimited _ -> min_comment_indentation + 4L
       | CodeCodeToken _ -> min_comment_indentation
@@ -1924,17 +2010,51 @@ let postlude_base_of_hocc (Hocc {stmts=Stmts {stmt; stmts_tl}; _}) =
       and of_prec_rels = function
       | PrecRelsPrecs {precs} -> Some (of_precs precs)
       | PrecRelsEpsilon -> None
-      and of_symbol_type = function
-      | SymbolType {symbol_type; _} -> symbol_type
-      and of_symbol_type0 = function
-      | SymbolType0SymbolType {symbol_type} -> Some (of_symbol_type symbol_type)
-      | SymbolType0Epsilon -> None
       and of_prec_ref = function
       | PrecRefUident {uident} -> Some uident
       | PrecRefEpsilon -> None
-      and of_token_alias = function
-      | TokenAlias {alias=ISTRING {token=alias}} -> Some alias
-      | TokenAliasEpsilon -> None
+      and of_alias = function
+      | Alias {alias=ISTRING {token=alias}} -> Some alias
+      | AliasEpsilon -> None
+      and of_token_type = function
+      | TokenType {proto; _} -> Some (of_code proto)
+      | TokenTypeEpsilon-> None
+      and of_token = function
+      | Token {cident=CIDENT {token=cident}; alias; token_type; prec_ref} -> begin
+        of_prec_ref prec_ref
+          |> Option.some_or_thunk ~f:(fun () -> of_token_type token_type)
+          |> Option.some_or_thunk ~f:(fun () -> of_alias alias)
+          |> Option.value_or_thunk ~f:(fun () -> cident)
+      end
+      and of_delimited = function
+      | DelimitedBlock {dedent=DEDENT {token}; _}
+      | DelimitedParen {rparen=RPAREN {token}; _}
+      | DelimitedCapture {rcapture=RCAPTURE {token}; _}
+      | DelimitedList {rbrack=RBRACK {token}; _}
+      | DelimitedArray {rarray=RARRAY {token}; _}
+      | DelimitedModule {rcurly=RCURLY {token}; _} -> token
+      and of_code_token = function
+      | CodeToken {token} -> token
+      and of_code_tl = function
+      | CodeTlDelimited {delimited; code_tl} -> begin
+        of_code_tl code_tl
+          |> Option.some_or_thunk ~f:(fun () -> Some (of_delimited delimited))
+      end
+      | CodeTlCodeToken {code_token; code_tl} -> begin
+        of_code_tl code_tl
+          |> Option.some_or_thunk ~f:(fun () -> Some (of_code_token code_token))
+      end
+      | CodeTlEpsilon -> None
+      and of_code = function
+      | CodeDelimited {delimited; code_tl} -> begin
+        of_code_tl code_tl
+          |> Option.value_or_thunk ~f:(fun () -> of_delimited delimited)
+      end
+      | CodeCodeToken {code_token; code_tl} -> begin
+        of_code_tl code_tl
+          |> Option.value_or_thunk ~f:(fun () -> of_code_token code_token)
+      end
+
       and of_prod_param_symbol = function
       | ProdParamSymbolCident {cident=CIDENT {token=cident}} -> cident
       | ProdParamSymbolAlias {alias=ISTRING {token=alias}} -> alias
@@ -1993,13 +2113,7 @@ let postlude_base_of_hocc (Hocc {stmts=Stmts {stmt; stmts_tl}; _}) =
         of_prec_rels prec_rels
           |> Option.value_or_thunk ~f:(fun () -> of_precs prec_set)
       end
-      | StmtToken {token=Token {cident=CIDENT {token=cident}; token_alias; symbol_type0;
-      prec_ref; _}} -> begin
-        of_prec_ref prec_ref
-          |> Option.some_or_thunk ~f:(fun () -> of_symbol_type0 symbol_type0)
-          |> Option.some_or_thunk ~f:(fun () -> of_token_alias token_alias)
-          |> Option.value_or_thunk ~f:(fun () -> cident)
-      end
+      | StmtToken {token} -> of_token token
       | StmtNonterm {nonterm} -> of_nonterm nonterm
       and of_stmts_tl = function
       | StmtsTl {stmt; stmts_tl} -> begin

--- a/bootstrap/bin/hocc/Parse.ml
+++ b/bootstrap/bin/hocc/Parse.ml
@@ -150,18 +150,18 @@ type nonterm_uident =
   | SymbolTypeQualifierEpsilon
   and nonterm_symbol_type =
   | SymbolType of {symbol_type_qualifier: nonterm_symbol_type_qualifier; symbol_type: Scan.Token.t}
-  and nonterm_symbol_type0 =
-  | SymbolType0SymbolType of {symbol_type: nonterm_symbol_type}
-  | SymbolType0Epsilon
   and nonterm_prec_ref =
   | PrecRefUident of {uident: Scan.Token.t}
   | PrecRefEpsilon
-  and nonterm_token_alias =
-  | TokenAlias of {alias: token_istring}
-  | TokenAliasEpsilon
+  and nonterm_alias =
+  | Alias of {alias: token_istring}
+  | AliasEpsilon
+  and nonterm_token_type =
+  | TokenType of {symbol_type: nonterm_symbol_type; proto: nonterm_code}
+  | TokenTypeEpsilon
   and nonterm_token =
-  | Token of {cident: token_cident; token_alias: nonterm_token_alias;
-  symbol_type0: nonterm_symbol_type0; prec_ref: nonterm_prec_ref}
+  | Token of {cident: token_cident; alias: nonterm_alias; token_type: nonterm_token_type;
+  prec_ref: nonterm_prec_ref}
   and nonterm_sep =
   | SepLineDelim of {line_delim: token_line_delim}
   | SepSemi of {semi: token_semi}
@@ -268,6 +268,61 @@ type nonterm_uident =
   and nonterm_hmhi =
   | Hmhi of {prelude: nonterm_matter; hocc_: token_hocc; postlude: nonterm_matter; eoi: token_eoi}
 
+(* Fake prototype token payload. *)
+let fake_token =
+    let source =
+      ""
+      |> String.C.Slice.of_string
+      |> Text.of_string_slice
+      |> Hmc.Source.init
+      in
+    let base = Hmc.Source.Cursor.hd source in
+    let past = Hmc.Source.Cursor.tl source in
+    let slice = Hmc.Source.Slice.of_cursors ~base ~past in
+    Scan.Token.HmcToken (Hmc.Scan.Token.Tok_error {source=slice; error=[]})
+
+(* Prototype tokens. *)
+let proto_hocc = HOCC {token=fake_token}
+let proto_nonterm = NONTERM {token=fake_token}
+let proto_epsilon = EPSILON {token=fake_token}
+let proto_start = START {token=fake_token}
+let proto_token = TOKEN {token=fake_token}
+let proto_neutral = NEUTRAL {token=fake_token}
+let proto_left = LEFT {token=fake_token}
+let proto_right = RIGHT {token=fake_token}
+let proto_nonassoc = NONASSOC {token=fake_token}
+let proto_prec = PREC {token=fake_token}
+let proto_uident = UIDENT {token=fake_token}
+let proto_cident = CIDENT {token=fake_token}
+let proto_uscore = USCORE {token=fake_token}
+let proto_istring = ISTRING {token=fake_token}
+let proto_colon_colon_eq = COLON_COLON_EQ {token=fake_token}
+let proto_of = OF {token=fake_token}
+let proto_colon = COLON {token=fake_token}
+let proto_dot = DOT {token=fake_token}
+let proto_arrow = ARROW {token=fake_token}
+let proto_bar = BAR {token=fake_token}
+let proto_lt = LT {token=fake_token}
+let proto_eq = EQ {token=fake_token}
+let proto_comma = COMMA {token=fake_token}
+let proto_semi = SEMI {token=fake_token}
+let proto_as = AS {token=fake_token}
+let proto_line_delim = LINE_DELIM {token=fake_token}
+let proto_indent = INDENT {token=fake_token}
+let proto_dedent = DEDENT {token=fake_token}
+let proto_lparen = LPAREN {token=fake_token}
+let proto_rparen = RPAREN {token=fake_token}
+let proto_lcapture = LCAPTURE {token=fake_token}
+let proto_rcapture = RCAPTURE {token=fake_token}
+let proto_lbrack = LBRACK {token=fake_token}
+let proto_rbrack = RBRACK {token=fake_token}
+let proto_larray = LARRAY {token=fake_token}
+let proto_rarray = RARRAY {token=fake_token}
+let proto_lcurly = LCURLY {token=fake_token}
+let proto_rcurly = RCURLY {token=fake_token}
+let proto_other_token = OTHER_TOKEN {token=fake_token}
+let proto_eoi = EOI {token=fake_token}
+
 include struct
     module Spec = struct
         module Algorithm = struct
@@ -372,11 +427,13 @@ include struct
           end
 
         let prec_sets = [|
-            PrecSet.init ~index:0L ~names:[|"pCIDENT"|] ~assoc:None ~doms:(Bitset.empty);
-            PrecSet.init ~index:1L ~names:[|"pDOT"|] ~assoc:(Some Left) ~doms:(Bitset.empty);
-            PrecSet.init ~index:2L ~names:[|"pCOMMA"|] ~assoc:(Some Left) ~doms:(Bitset.singleton 0L);
-            PrecSet.init ~index:3L ~names:[|"pSEMI"|] ~assoc:(Some Right) ~doms:(Bitset.empty);
-            PrecSet.init ~index:4L ~names:[|"pAS"|] ~assoc:None ~doms:(Bitset.of_list [0L; 2L])
+            PrecSet.init ~index:0L ~names:[|"pCodeTlEpsilon"|] ~assoc:None ~doms:(Bitset.empty);
+            PrecSet.init ~index:1L ~names:[|"pPrec"|] ~assoc:None ~doms:(Bitset.singleton 0L);
+            PrecSet.init ~index:2L ~names:[|"pCIDENT"|] ~assoc:None ~doms:(Bitset.empty);
+            PrecSet.init ~index:3L ~names:[|"pDOT"|] ~assoc:(Some Left) ~doms:(Bitset.empty);
+            PrecSet.init ~index:4L ~names:[|"pCOMMA"|] ~assoc:(Some Left) ~doms:(Bitset.singleton 2L);
+            PrecSet.init ~index:5L ~names:[|"pSEMI"|] ~assoc:(Some Right) ~doms:(Bitset.empty);
+            PrecSet.init ~index:6L ~names:[|"pAS"|] ~assoc:None ~doms:(Bitset.of_list [2L; 4L])
           |]
 
         module Prec = struct
@@ -489,19 +546,19 @@ include struct
               ~prec:None ~callback:22L;
             Prod.init ~index:23L ~lhs_index:49L ~rhs_indexes:[|17L; 48L; 42L|]
               ~prec:None ~callback:23L;
-            Prod.init ~index:24L ~lhs_index:50L ~rhs_indexes:[|49L|]
+            Prod.init ~index:24L ~lhs_index:50L ~rhs_indexes:[|11L; 42L|]
               ~prec:None ~callback:24L;
             Prod.init ~index:25L ~lhs_index:50L ~rhs_indexes:[||]
               ~prec:None ~callback:25L;
-            Prod.init ~index:26L ~lhs_index:51L ~rhs_indexes:[|11L; 42L|]
+            Prod.init ~index:26L ~lhs_index:51L ~rhs_indexes:[|15L|]
               ~prec:None ~callback:26L;
             Prod.init ~index:27L ~lhs_index:51L ~rhs_indexes:[||]
               ~prec:None ~callback:27L;
-            Prod.init ~index:28L ~lhs_index:52L ~rhs_indexes:[|15L|]
+            Prod.init ~index:28L ~lhs_index:52L ~rhs_indexes:[|49L; 61L|]
               ~prec:None ~callback:28L;
             Prod.init ~index:29L ~lhs_index:52L ~rhs_indexes:[||]
               ~prec:None ~callback:29L;
-            Prod.init ~index:30L ~lhs_index:53L ~rhs_indexes:[|6L; 13L; 52L; 50L; 51L|]
+            Prod.init ~index:30L ~lhs_index:53L ~rhs_indexes:[|6L; 13L; 51L; 52L; 50L|]
               ~prec:None ~callback:30L;
             Prod.init ~index:31L ~lhs_index:54L ~rhs_indexes:[|27L|]
               ~prec:None ~callback:31L;
@@ -564,7 +621,7 @@ include struct
             Prod.init ~index:60L ~lhs_index:60L ~rhs_indexes:[|59L; 60L|]
               ~prec:None ~callback:60L;
             Prod.init ~index:61L ~lhs_index:60L ~rhs_indexes:[||]
-              ~prec:None ~callback:61L;
+              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:0L)) ~callback:61L;
             Prod.init ~index:62L ~lhs_index:61L ~rhs_indexes:[|58L; 60L|]
               ~prec:None ~callback:62L;
             Prod.init ~index:63L ~lhs_index:61L ~rhs_indexes:[|59L; 60L|]
@@ -574,7 +631,7 @@ include struct
             Prod.init ~index:65L ~lhs_index:62L ~rhs_indexes:[|42L; 23L; 66L|]
               ~prec:None ~callback:65L;
             Prod.init ~index:66L ~lhs_index:63L ~rhs_indexes:[|62L|]
-              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:3L)) ~callback:66L;
+              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:5L)) ~callback:66L;
             Prod.init ~index:67L ~lhs_index:63L ~rhs_indexes:[|62L; 25L; 14L|]
               ~prec:None ~callback:67L;
             Prod.init ~index:68L ~lhs_index:63L ~rhs_indexes:[|62L; 25L; 63L|]
@@ -586,7 +643,7 @@ include struct
             Prod.init ~index:71L ~lhs_index:65L ~rhs_indexes:[|13L|]
               ~prec:None ~callback:71L;
             Prod.init ~index:72L ~lhs_index:65L ~rhs_indexes:[|65L; 19L; 65L|]
-              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:1L)) ~callback:72L;
+              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:3L)) ~callback:72L;
             Prod.init ~index:73L ~lhs_index:66L ~rhs_indexes:[|14L|]
               ~prec:None ~callback:73L;
             Prod.init ~index:74L ~lhs_index:66L ~rhs_indexes:[|42L|]
@@ -596,11 +653,11 @@ include struct
             Prod.init ~index:76L ~lhs_index:66L ~rhs_indexes:[|30L; 66L; 31L|]
               ~prec:None ~callback:76L;
             Prod.init ~index:77L ~lhs_index:66L ~rhs_indexes:[|13L; 66L|]
-              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:0L)) ~callback:77L;
+              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:2L)) ~callback:77L;
             Prod.init ~index:78L ~lhs_index:66L ~rhs_indexes:[|65L; 19L; 30L; 66L; 31L|]
               ~prec:None ~callback:78L;
             Prod.init ~index:79L ~lhs_index:66L ~rhs_indexes:[|66L; 24L; 66L|]
-              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:2L)) ~callback:79L;
+              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:4L)) ~callback:79L;
             Prod.init ~index:80L ~lhs_index:66L ~rhs_indexes:[|38L; 63L; 64L; 39L|]
               ~prec:None ~callback:80L;
             Prod.init ~index:81L ~lhs_index:66L ~rhs_indexes:[|65L; 19L; 38L; 63L; 64L; 39L|]
@@ -625,13 +682,13 @@ include struct
               ~prec:None ~callback:90L;
             Prod.init ~index:91L ~lhs_index:69L ~rhs_indexes:[|68L; 69L|]
               ~prec:None ~callback:91L;
-            Prod.init ~index:92L ~lhs_index:69L ~rhs_indexes:[|51L|]
+            Prod.init ~index:92L ~lhs_index:69L ~rhs_indexes:[|50L|]
               ~prec:None ~callback:92L;
             Prod.init ~index:93L ~lhs_index:70L ~rhs_indexes:[|68L; 69L|]
               ~prec:None ~callback:93L;
             Prod.init ~index:94L ~lhs_index:71L ~rhs_indexes:[|70L|]
               ~prec:None ~callback:94L;
-            Prod.init ~index:95L ~lhs_index:71L ~rhs_indexes:[|4L; 51L|]
+            Prod.init ~index:95L ~lhs_index:71L ~rhs_indexes:[|4L; 50L|]
               ~prec:None ~callback:95L;
             Prod.init ~index:96L ~lhs_index:72L ~rhs_indexes:[|71L|]
               ~prec:None ~callback:96L;
@@ -655,9 +712,9 @@ include struct
               ~prec:None ~callback:105L;
             Prod.init ~index:106L ~lhs_index:78L ~rhs_indexes:[|5L|]
               ~prec:None ~callback:106L;
-            Prod.init ~index:107L ~lhs_index:79L ~rhs_indexes:[|78L; 13L; 51L; 16L; 74L|]
+            Prod.init ~index:107L ~lhs_index:79L ~rhs_indexes:[|78L; 13L; 50L; 16L; 74L|]
               ~prec:None ~callback:107L;
-            Prod.init ~index:108L ~lhs_index:79L ~rhs_indexes:[|78L; 13L; 49L; 51L; 16L; 77L|]
+            Prod.init ~index:108L ~lhs_index:79L ~rhs_indexes:[|78L; 13L; 49L; 50L; 16L; 77L|]
               ~prec:None ~callback:108L;
             Prod.init ~index:109L ~lhs_index:80L ~rhs_indexes:[|47L|]
               ~prec:None ~callback:109L;
@@ -857,7 +914,8 @@ include struct
               ~first:(Bitset.singleton 10L)
               ~follow:(Bitset.of_nat (Nat.of_string "0x3ff_ffff_fffcn"));
             Symbol.init ~index:11L ~name:"PREC"
-              ~prec:None ~alias:(Some "prec") ~start:false
+              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:1L))
+              ~alias:(Some "prec") ~start:false
               ~prods:(Ordset.empty (module Prod))
               ~first:(Bitset.singleton 11L)
               ~follow:(Bitset.of_nat (Nat.of_string "0x3ff_ffff_fffcn"));
@@ -897,7 +955,7 @@ include struct
               ~first:(Bitset.singleton 18L)
               ~follow:(Bitset.of_nat (Nat.of_string "0x3ff_ffff_fffcn"));
             Symbol.init ~index:19L ~name:"DOT"
-              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:1L))
+              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:3L))
               ~alias:(Some ".") ~start:false
               ~prods:(Ordset.empty (module Prod))
               ~first:(Bitset.singleton 19L)
@@ -923,19 +981,19 @@ include struct
               ~first:(Bitset.singleton 23L)
               ~follow:(Bitset.of_nat (Nat.of_string "0x3ff_ffff_fffcn"));
             Symbol.init ~index:24L ~name:"COMMA"
-              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:2L))
+              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:4L))
               ~alias:(Some ",") ~start:false
               ~prods:(Ordset.empty (module Prod))
               ~first:(Bitset.singleton 24L)
               ~follow:(Bitset.of_nat (Nat.of_string "0x3ff_ffff_fffcn"));
             Symbol.init ~index:25L ~name:"SEMI"
-              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:3L))
+              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:5L))
               ~alias:(Some ";") ~start:false
               ~prods:(Ordset.empty (module Prod))
               ~first:(Bitset.singleton 25L)
               ~follow:(Bitset.of_nat (Nat.of_string "0x3ff_ffff_fffcn"));
             Symbol.init ~index:26L ~name:"AS"
-              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:4L))
+              ~prec:(Some (Prec.init ~name_index:0L ~prec_set_index:6L))
               ~alias:(Some "as") ~start:false
               ~prods:(Ordset.empty (module Prod))
               ~first:(Bitset.singleton 26L)
@@ -1080,31 +1138,31 @@ include struct
               ~prec:None ~alias:None ~start:false
               ~prods:(Ordset.singleton (module Prod) (Array.get 23L prods))
               ~first:(Bitset.singleton 17L)
-              ~follow:(Bitset.of_nat (Nat.of_string "0x2801_0800n"));
-            Symbol.init ~index:50L ~name:"SymbolType0"
+              ~follow:(Bitset.of_nat (Nat.of_string "0x155_55df_fffcn"));
+            Symbol.init ~index:50L ~name:"PrecRef"
               ~prec:None ~alias:None ~start:false
               ~prods:(Ordset.of_list (module Prod) [
                 Array.get 24L prods;
                 Array.get 25L prods;
               ])
-              ~first:(Bitset.of_nat (Nat.of_string "0x2_0001n"))
-              ~follow:(Bitset.of_nat (Nat.of_string "0x2800_0800n"));
-            Symbol.init ~index:51L ~name:"PrecRef"
+              ~first:(Bitset.of_nat (Nat.of_string "0x801n"))
+              ~follow:(Bitset.of_nat (Nat.of_string "0x2831_0000n"));
+            Symbol.init ~index:51L ~name:"Alias"
               ~prec:None ~alias:None ~start:false
               ~prods:(Ordset.of_list (module Prod) [
                 Array.get 26L prods;
                 Array.get 27L prods;
               ])
-              ~first:(Bitset.of_nat (Nat.of_string "0x801n"))
-              ~follow:(Bitset.of_nat (Nat.of_string "0x2831_0000n"));
-            Symbol.init ~index:52L ~name:"TokenAlias"
+              ~first:(Bitset.of_nat (Nat.of_string "0x8001n"))
+              ~follow:(Bitset.of_nat (Nat.of_string "0x2802_0800n"));
+            Symbol.init ~index:52L ~name:"TokenType"
               ~prec:None ~alias:None ~start:false
               ~prods:(Ordset.of_list (module Prod) [
                 Array.get 28L prods;
                 Array.get 29L prods;
               ])
-              ~first:(Bitset.of_nat (Nat.of_string "0x8001n"))
-              ~follow:(Bitset.of_nat (Nat.of_string "0x2802_0800n"));
+              ~first:(Bitset.of_nat (Nat.of_string "0x2_0001n"))
+              ~follow:(Bitset.of_nat (Nat.of_string "0x2800_0800n"));
             Symbol.init ~index:53L ~name:"Token"
               ~prec:None ~alias:None ~start:false
               ~prods:(Ordset.singleton (module Prod) (Array.get 30L prods))
@@ -1180,7 +1238,7 @@ include struct
                 Array.get 61L prods;
               ])
               ~first:(Bitset.of_nat (Nat.of_string "0x155_55df_fffdn"))
-              ~follow:(Bitset.of_nat (Nat.of_string "0xaa_aa20_0000n"));
+              ~follow:(Bitset.of_nat (Nat.of_string "0xaa_aa20_0800n"));
             Symbol.init ~index:61L ~name:"Code"
               ~prec:None ~alias:None ~start:false
               ~prods:(Ordset.of_list (module Prod) [
@@ -1188,7 +1246,7 @@ include struct
                 Array.get 63L prods;
               ])
               ~first:(Bitset.of_nat (Nat.of_string "0x155_55df_fffcn"))
-              ~follow:(Bitset.of_nat (Nat.of_string "0xaa_aa20_0000n"));
+              ~follow:(Bitset.of_nat (Nat.of_string "0xaa_aa20_0800n"));
             Symbol.init ~index:62L ~name:"PatternField"
               ~prec:None ~alias:None ~start:false
               ~prods:(Ordset.of_list (module Prod) [
@@ -5270,16 +5328,16 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (11L, Action.Reduce 29L);
+                    (11L, Action.Reduce 27L);
                     (15L, Action.ShiftPrefix 89L);
-                    (17L, Action.Reduce 29L);
-                    (27L, Action.Reduce 29L);
-                    (29L, Action.Reduce 29L);
+                    (17L, Action.Reduce 27L);
+                    (27L, Action.Reduce 27L);
+                    (29L, Action.Reduce 27L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (52L, 90L);
+                    (51L, 90L);
                   ]
               );
             (* 72 *) State.init
@@ -6047,14 +6105,14 @@ include struct
               ~actions:(
                 Map.of_alist (module Uns) [
                     (11L, Action.ShiftPrefix 95L);
-                    (16L, Action.Reduce 27L);
+                    (16L, Action.Reduce 25L);
                     (17L, Action.ShiftPrefix 96L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
                     (49L, 97L);
-                    (51L, 98L);
+                    (50L, 98L);
                   ]
               );
             (* 86 *) State.init
@@ -6187,7 +6245,7 @@ include struct
                   ~kernel:(
                     Lr1Itemset.init [
                         (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 28L prods) ~dot:1L in
+                            let lr0item = Lr0Item.init ~prod:(Array.get 26L prods) ~dot:1L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
                                 Bitset.of_nat (Nat.of_string "0x2802_0800n")
                               ) in
@@ -6198,10 +6256,10 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (11L, Action.Reduce 28L);
-                    (17L, Action.Reduce 28L);
-                    (27L, Action.Reduce 28L);
-                    (29L, Action.Reduce 28L);
+                    (11L, Action.Reduce 26L);
+                    (17L, Action.Reduce 26L);
+                    (27L, Action.Reduce 26L);
+                    (29L, Action.Reduce 26L);
                   ]
               )
               ~gotos:(
@@ -6225,16 +6283,16 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (11L, Action.Reduce 25L);
+                    (11L, Action.Reduce 29L);
                     (17L, Action.ShiftPrefix 96L);
-                    (27L, Action.Reduce 25L);
-                    (29L, Action.Reduce 25L);
+                    (27L, Action.Reduce 29L);
+                    (29L, Action.Reduce 29L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
                     (49L, 100L);
-                    (50L, 101L);
+                    (52L, 101L);
                   ]
               );
             (* 91 *) State.init
@@ -6368,7 +6426,7 @@ include struct
                   ~kernel:(
                     Lr1Itemset.init [
                         (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 26L prods) ~dot:1L in
+                            let lr0item = Lr0Item.init ~prod:(Array.get 24L prods) ~dot:1L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
                                 Bitset.of_nat (Nat.of_string "0x2831_0000n")
                               ) in
@@ -6406,7 +6464,7 @@ include struct
                         (
                             let lr0item = Lr0Item.init ~prod:(Array.get 23L prods) ~dot:1L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2801_0800n")
+                                Bitset.of_nat (Nat.of_string "0x155_55df_fffcn")
                               ) in
                             lr0item, lr1item
                           );
@@ -6453,12 +6511,12 @@ include struct
               ~actions:(
                 Map.of_alist (module Uns) [
                     (11L, Action.ShiftPrefix 95L);
-                    (16L, Action.Reduce 27L);
+                    (16L, Action.Reduce 25L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (51L, 107L);
+                    (50L, 107L);
                   ]
               );
             (* 98 *) State.init
@@ -6519,7 +6577,7 @@ include struct
                   ~kernel:(
                     Lr1Itemset.init [
                         (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 24L prods) ~dot:1L in
+                            let lr0item = Lr0Item.init ~prod:(Array.get 28L prods) ~dot:1L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
                                 Bitset.of_nat (Nat.of_string "0x2800_0800n")
                               ) in
@@ -6530,13 +6588,45 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (11L, Action.Reduce 24L);
-                    (27L, Action.Reduce 24L);
-                    (29L, Action.Reduce 24L);
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
+                    (26L, Action.ShiftPrefix 121L);
+                    (28L, Action.ShiftPrefix 122L);
+                    (30L, Action.ShiftPrefix 123L);
+                    (32L, Action.ShiftPrefix 124L);
+                    (34L, Action.ShiftPrefix 125L);
+                    (36L, Action.ShiftPrefix 126L);
+                    (38L, Action.ShiftPrefix 127L);
+                    (40L, Action.ShiftPrefix 128L);
                   ]
               )
               ~gotos:(
-                Map.empty (module Uns)
+                Map.of_alist (module Uns) [
+                    (42L, 129L);
+                    (58L, 130L);
+                    (59L, 131L);
+                    (61L, 132L);
+                  ]
               );
             (* 101 *) State.init
               ~lr1ItemsetClosure:(
@@ -6557,13 +6647,13 @@ include struct
               ~actions:(
                 Map.of_alist (module Uns) [
                     (11L, Action.ShiftPrefix 95L);
-                    (27L, Action.Reduce 27L);
-                    (29L, Action.Reduce 27L);
+                    (27L, Action.Reduce 25L);
+                    (29L, Action.Reduce 25L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (51L, 110L);
+                    (50L, 133L);
                   ]
               );
             (* 102 *) State.init
@@ -6592,7 +6682,7 @@ include struct
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (43L, 111L);
+                    (43L, 134L);
                   ]
               );
             (* 103 *) State.init
@@ -6627,7 +6717,7 @@ include struct
                   ~kernel:(
                     Lr1Itemset.init [
                         (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 26L prods) ~dot:2L in
+                            let lr0item = Lr0Item.init ~prod:(Array.get 24L prods) ~dot:2L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
                                 Bitset.of_nat (Nat.of_string "0x2831_0000n")
                               ) in
@@ -6638,11 +6728,11 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (16L, Action.Reduce 26L);
-                    (20L, Action.Reduce 26L);
-                    (21L, Action.Reduce 26L);
-                    (27L, Action.Reduce 26L);
-                    (29L, Action.Reduce 26L);
+                    (16L, Action.Reduce 24L);
+                    (20L, Action.Reduce 24L);
+                    (21L, Action.Reduce 24L);
+                    (27L, Action.Reduce 24L);
+                    (29L, Action.Reduce 24L);
                   ]
               )
               ~gotos:(
@@ -6666,7 +6756,7 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (19L, Action.ShiftPrefix 112L);
+                    (19L, Action.ShiftPrefix 135L);
                   ]
               )
               ~gotos:(
@@ -6681,7 +6771,7 @@ include struct
                         (
                             let lr0item = Lr0Item.init ~prod:(Array.get 23L prods) ~dot:2L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2801_0800n")
+                                Bitset.of_nat (Nat.of_string "0x155_55df_fffcn")
                               ) in
                             lr0item, lr1item
                           );
@@ -6705,7 +6795,7 @@ include struct
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (42L, 113L);
+                    (42L, 136L);
                   ]
               );
             (* 107 *) State.init
@@ -6726,7 +6816,7 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (16L, Action.ShiftPrefix 114L);
+                    (16L, Action.ShiftPrefix 137L);
                   ]
               )
               ~gotos:(
@@ -6752,7 +6842,7 @@ include struct
                 Map.of_alist (module Uns) [
                     (2L, Action.ShiftPrefix 72L);
                     (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 115L);
+                    (4L, Action.ShiftPrefix 138L);
                     (5L, Action.ShiftPrefix 75L);
                     (6L, Action.ShiftPrefix 76L);
                     (7L, Action.ShiftPrefix 77L);
@@ -6761,24 +6851,24 @@ include struct
                     (10L, Action.ShiftPrefix 80L);
                     (11L, Action.ShiftPrefix 81L);
                     (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 116L);
-                    (14L, Action.ShiftPrefix 117L);
-                    (15L, Action.ShiftPrefix 118L);
-                    (21L, Action.ShiftPrefix 119L);
-                    (30L, Action.ShiftPrefix 120L);
-                    (38L, Action.ShiftPrefix 121L);
+                    (13L, Action.ShiftPrefix 139L);
+                    (14L, Action.ShiftPrefix 140L);
+                    (15L, Action.ShiftPrefix 141L);
+                    (21L, Action.ShiftPrefix 142L);
+                    (30L, Action.ShiftPrefix 143L);
+                    (38L, Action.ShiftPrefix 144L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (42L, 122L);
-                    (65L, 123L);
-                    (67L, 124L);
-                    (68L, 125L);
-                    (70L, 126L);
-                    (71L, 127L);
-                    (72L, 128L);
-                    (74L, 129L);
+                    (42L, 145L);
+                    (65L, 146L);
+                    (67L, 147L);
+                    (68L, 148L);
+                    (70L, 149L);
+                    (71L, 150L);
+                    (72L, 151L);
+                    (74L, 152L);
                   ]
               );
             (* 109 *) State.init
@@ -6809,2433 +6899,6 @@ include struct
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
                   ~index:110L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 30L prods) ~dot:5L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (27L, Action.Reduce 30L);
-                    (29L, Action.Reduce 30L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 111 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:111L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 11L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2840_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (22L, Action.Reduce 11L);
-                    (27L, Action.Reduce 11L);
-                    (29L, Action.Reduce 11L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 112 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:112L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 21L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x1ffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.Reduce 22L);
-                    (3L, Action.Reduce 22L);
-                    (4L, Action.Reduce 22L);
-                    (5L, Action.Reduce 22L);
-                    (6L, Action.Reduce 22L);
-                    (7L, Action.Reduce 22L);
-                    (8L, Action.Reduce 22L);
-                    (9L, Action.Reduce 22L);
-                    (10L, Action.Reduce 22L);
-                    (11L, Action.Reduce 22L);
-                    (12L, Action.Reduce 22L);
-                    (13L, Action.ShiftPrefix 105L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (48L, 130L);
-                  ]
-              );
-            (* 113 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:113L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 23L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2801_0800n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (11L, Action.Reduce 23L);
-                    (16L, Action.Reduce 23L);
-                    (27L, Action.Reduce 23L);
-                    (29L, Action.Reduce 23L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 114 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:114L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 108L prods) ~dot:5L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 115L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 116L);
-                    (14L, Action.ShiftPrefix 117L);
-                    (15L, Action.ShiftPrefix 118L);
-                    (21L, Action.ShiftPrefix 119L);
-                    (30L, Action.ShiftPrefix 120L);
-                    (38L, Action.ShiftPrefix 121L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 122L);
-                    (65L, 123L);
-                    (67L, 124L);
-                    (68L, 125L);
-                    (70L, 126L);
-                    (71L, 127L);
-                    (72L, 128L);
-                    (74L, 131L);
-                    (75L, 132L);
-                    (77L, 133L);
-                  ]
-              );
-            (* 115 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:115L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 2L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.singleton 18L
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 95L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (11L, Action.ShiftPrefix 95L);
-                    (18L, Action.Reduce 2L);
-                    (20L, Action.Reduce 27L);
-                    (21L, Action.Reduce 27L);
-                    (27L, Action.Reduce 27L);
-                    (29L, Action.Reduce 27L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (51L, 134L);
-                  ]
-              );
-            (* 116 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:116L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 71L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.singleton 19L
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 82L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.Reduce 82L);
-                    (3L, Action.Reduce 82L);
-                    (4L, Action.Reduce 82L);
-                    (5L, Action.Reduce 82L);
-                    (6L, Action.Reduce 82L);
-                    (7L, Action.Reduce 82L);
-                    (8L, Action.Reduce 82L);
-                    (9L, Action.Reduce 82L);
-                    (10L, Action.Reduce 82L);
-                    (11L, Action.Reduce 82L);
-                    (12L, Action.Reduce 82L);
-                    (13L, Action.Reduce 82L);
-                    (14L, Action.Reduce 82L);
-                    (15L, Action.Reduce 82L);
-                    (19L, Action.Reduce 71L);
-                    (20L, Action.Reduce 82L);
-                    (21L, Action.Reduce 82L);
-                    (27L, Action.Reduce 82L);
-                    (29L, Action.Reduce 82L);
-                    (30L, Action.Reduce 82L);
-                    (38L, Action.Reduce 82L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 117 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:117L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 89L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (18L, Action.ShiftPrefix 135L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 118 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:118L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 83L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.Reduce 83L);
-                    (3L, Action.Reduce 83L);
-                    (4L, Action.Reduce 83L);
-                    (5L, Action.Reduce 83L);
-                    (6L, Action.Reduce 83L);
-                    (7L, Action.Reduce 83L);
-                    (8L, Action.Reduce 83L);
-                    (9L, Action.Reduce 83L);
-                    (10L, Action.Reduce 83L);
-                    (11L, Action.Reduce 83L);
-                    (12L, Action.Reduce 83L);
-                    (13L, Action.Reduce 83L);
-                    (14L, Action.Reduce 83L);
-                    (15L, Action.Reduce 83L);
-                    (20L, Action.Reduce 83L);
-                    (21L, Action.Reduce 83L);
-                    (27L, Action.Reduce 83L);
-                    (29L, Action.Reduce 83L);
-                    (30L, Action.Reduce 83L);
-                    (38L, Action.Reduce 83L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 119 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:119L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 99L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 115L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 116L);
-                    (14L, Action.ShiftPrefix 117L);
-                    (15L, Action.ShiftPrefix 118L);
-                    (30L, Action.ShiftPrefix 120L);
-                    (38L, Action.ShiftPrefix 121L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 122L);
-                    (65L, 123L);
-                    (67L, 124L);
-                    (68L, 125L);
-                    (70L, 126L);
-                    (71L, 127L);
-                    (72L, 136L);
-                  ]
-              );
-            (* 120 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:120L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 85L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 137L);
-                    (14L, Action.ShiftPrefix 138L);
-                    (30L, Action.ShiftPrefix 139L);
-                    (38L, Action.ShiftPrefix 140L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 141L);
-                    (65L, 142L);
-                    (66L, 143L);
-                  ]
-              );
-            (* 121 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:121L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 87L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 144L);
-                    (62L, 145L);
-                    (63L, 146L);
-                  ]
-              );
-            (* 122 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:122L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 84L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (18L, Action.ShiftPrefix 147L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 123 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:123L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 72L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.singleton 19L
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 86L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 88L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (19L, Action.ShiftPrefix 148L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 124 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:124L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 90L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.Reduce 90L);
-                    (3L, Action.Reduce 90L);
-                    (4L, Action.Reduce 90L);
-                    (5L, Action.Reduce 90L);
-                    (6L, Action.Reduce 90L);
-                    (7L, Action.Reduce 90L);
-                    (8L, Action.Reduce 90L);
-                    (9L, Action.Reduce 90L);
-                    (10L, Action.Reduce 90L);
-                    (11L, Action.Reduce 90L);
-                    (12L, Action.Reduce 90L);
-                    (13L, Action.Reduce 90L);
-                    (14L, Action.Reduce 90L);
-                    (15L, Action.Reduce 90L);
-                    (20L, Action.Reduce 90L);
-                    (21L, Action.Reduce 90L);
-                    (27L, Action.Reduce 90L);
-                    (29L, Action.Reduce 90L);
-                    (30L, Action.Reduce 90L);
-                    (38L, Action.Reduce 90L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 125 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:125L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 93L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 149L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 116L);
-                    (14L, Action.ShiftPrefix 117L);
-                    (15L, Action.ShiftPrefix 118L);
-                    (20L, Action.Reduce 27L);
-                    (21L, Action.Reduce 27L);
-                    (27L, Action.Reduce 27L);
-                    (29L, Action.Reduce 27L);
-                    (30L, Action.ShiftPrefix 120L);
-                    (38L, Action.ShiftPrefix 121L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 122L);
-                    (51L, 150L);
-                    (65L, 123L);
-                    (67L, 124L);
-                    (68L, 151L);
-                    (69L, 152L);
-                  ]
-              );
-            (* 126 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:126L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 94L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (20L, Action.Reduce 94L);
-                    (21L, Action.Reduce 94L);
-                    (27L, Action.Reduce 94L);
-                    (29L, Action.Reduce 94L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 127 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:127L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 96L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (20L, Action.Reduce 96L);
-                    (21L, Action.Reduce 96L);
-                    (27L, Action.Reduce 96L);
-                    (29L, Action.Reduce 96L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 128 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:128L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 100L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (20L, Action.Reduce 98L);
-                    (21L, Action.ShiftPrefix 153L);
-                    (27L, Action.Reduce 98L);
-                    (29L, Action.Reduce 98L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (73L, 154L);
-                  ]
-              );
-            (* 129 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:129L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 107L prods) ~dot:5L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (27L, Action.Reduce 107L);
-                    (29L, Action.Reduce 107L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 130 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:130L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 21L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x1ffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.Reduce 21L);
-                    (3L, Action.Reduce 21L);
-                    (4L, Action.Reduce 21L);
-                    (5L, Action.Reduce 21L);
-                    (6L, Action.Reduce 21L);
-                    (7L, Action.Reduce 21L);
-                    (8L, Action.Reduce 21L);
-                    (9L, Action.Reduce 21L);
-                    (10L, Action.Reduce 21L);
-                    (11L, Action.Reduce 21L);
-                    (12L, Action.Reduce 21L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 131 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:131L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 101L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2820_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (20L, Action.ShiftPrefix 155L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 132 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:132L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 104L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (21L, Action.ShiftPrefix 156L);
-                    (27L, Action.Reduce 103L);
-                    (29L, Action.Reduce 103L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (76L, 157L);
-                  ]
-              );
-            (* 133 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:133L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 108L prods) ~dot:6L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (27L, Action.Reduce 108L);
-                    (29L, Action.Reduce 108L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 134 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:134L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 95L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (20L, Action.Reduce 95L);
-                    (21L, Action.Reduce 95L);
-                    (27L, Action.Reduce 95L);
-                    (29L, Action.Reduce 95L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 135 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:135L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 89L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (13L, Action.ShiftPrefix 158L);
-                    (15L, Action.ShiftPrefix 118L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (67L, 159L);
-                  ]
-              );
-            (* 136 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:136L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 99L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (20L, Action.Reduce 98L);
-                    (21L, Action.ShiftPrefix 153L);
-                    (27L, Action.Reduce 98L);
-                    (29L, Action.Reduce 98L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (73L, 160L);
-                  ]
-              );
-            (* 137 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:137L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 71L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.singleton 19L
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 77L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 137L);
-                    (14L, Action.ShiftPrefix 138L);
-                    (19L, Action.Reduce 71L);
-                    (30L, Action.ShiftPrefix 139L);
-                    (38L, Action.ShiftPrefix 140L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 141L);
-                    (65L, 142L);
-                    (66L, 161L);
-                  ]
-              );
-            (* 138 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:138L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 73L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (24L, Action.Reduce 73L);
-                    (25L, Action.Reduce 73L);
-                    (26L, Action.Reduce 73L);
-                    (31L, Action.Reduce 73L);
-                    (39L, Action.Reduce 73L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 139 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:139L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 76L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 137L);
-                    (14L, Action.ShiftPrefix 138L);
-                    (30L, Action.ShiftPrefix 139L);
-                    (38L, Action.ShiftPrefix 140L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 141L);
-                    (65L, 142L);
-                    (66L, 162L);
-                  ]
-              );
-            (* 140 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:140L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 80L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 144L);
-                    (62L, 145L);
-                    (63L, 163L);
-                  ]
-              );
-            (* 141 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:141L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 74L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (24L, Action.Reduce 74L);
-                    (25L, Action.Reduce 74L);
-                    (26L, Action.Reduce 74L);
-                    (31L, Action.Reduce 74L);
-                    (39L, Action.Reduce 74L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 142 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:142L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 72L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.singleton 19L
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 78L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 81L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (19L, Action.ShiftPrefix 164L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 143 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:143L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x8500_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x8500_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 85L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (24L, Action.ShiftPrefix 165L);
-                    (26L, Action.ShiftPrefix 166L);
-                    (31L, Action.ShiftPrefix 167L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 144 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:144L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 64L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 65L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (23L, Action.ShiftPrefix 168L);
-                    (25L, Action.Reduce 64L);
-                    (39L, Action.Reduce 64L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 145 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:145L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 66L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 67L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 68L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (25L, Action.ShiftPrefix 169L);
-                    (39L, Action.Reduce 66L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 146 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:146L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 87L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (25L, Action.ShiftPrefix 170L);
-                    (39L, Action.Reduce 70L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (64L, 171L);
-                  ]
-              );
-            (* 147 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:147L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 84L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (13L, Action.ShiftPrefix 158L);
-                    (15L, Action.ShiftPrefix 118L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (67L, 172L);
-                  ]
-              );
-            (* 148 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:148L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 72L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.singleton 19L
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 86L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 88L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (13L, Action.ShiftPrefix 173L);
-                    (30L, Action.ShiftPrefix 174L);
-                    (38L, Action.ShiftPrefix 175L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (65L, 176L);
-                  ]
-              );
-            (* 149 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:149L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 9L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.singleton 18L
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 26L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (18L, Action.Reduce 9L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 104L);
-                  ]
-              );
-            (* 150 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:150L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 92L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (20L, Action.Reduce 92L);
-                    (21L, Action.Reduce 92L);
-                    (27L, Action.Reduce 92L);
-                    (29L, Action.Reduce 92L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 151 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:151L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 91L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 149L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 116L);
-                    (14L, Action.ShiftPrefix 117L);
-                    (15L, Action.ShiftPrefix 118L);
-                    (20L, Action.Reduce 27L);
-                    (21L, Action.Reduce 27L);
-                    (27L, Action.Reduce 27L);
-                    (29L, Action.Reduce 27L);
-                    (30L, Action.ShiftPrefix 120L);
-                    (38L, Action.ShiftPrefix 121L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 122L);
-                    (51L, 150L);
-                    (65L, 123L);
-                    (67L, 124L);
-                    (68L, 151L);
-                    (69L, 177L);
-                  ]
-              );
-            (* 152 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:152L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 93L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (20L, Action.Reduce 93L);
-                    (21L, Action.Reduce 93L);
-                    (27L, Action.Reduce 93L);
-                    (29L, Action.Reduce 93L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 153 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:153L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 97L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 115L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 116L);
-                    (14L, Action.ShiftPrefix 117L);
-                    (15L, Action.ShiftPrefix 118L);
-                    (30L, Action.ShiftPrefix 120L);
-                    (38L, Action.ShiftPrefix 121L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 122L);
-                    (65L, 123L);
-                    (67L, 124L);
-                    (68L, 125L);
-                    (70L, 126L);
-                    (71L, 127L);
-                    (72L, 178L);
-                  ]
-              );
-            (* 154 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:154L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 100L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (20L, Action.Reduce 100L);
-                    (27L, Action.Reduce 100L);
-                    (29L, Action.Reduce 100L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 155 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:155L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 101L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2820_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 179L);
-                    (14L, Action.ShiftPrefix 180L);
-                    (15L, Action.ShiftPrefix 181L);
-                    (16L, Action.ShiftPrefix 182L);
-                    (17L, Action.ShiftPrefix 183L);
-                    (18L, Action.ShiftPrefix 184L);
-                    (19L, Action.ShiftPrefix 185L);
-                    (20L, Action.ShiftPrefix 186L);
-                    (22L, Action.ShiftPrefix 187L);
-                    (23L, Action.ShiftPrefix 188L);
-                    (24L, Action.ShiftPrefix 189L);
-                    (26L, Action.ShiftPrefix 190L);
-                    (28L, Action.ShiftPrefix 191L);
-                    (30L, Action.ShiftPrefix 192L);
-                    (32L, Action.ShiftPrefix 193L);
-                    (34L, Action.ShiftPrefix 194L);
-                    (36L, Action.ShiftPrefix 195L);
-                    (38L, Action.ShiftPrefix 196L);
-                    (40L, Action.ShiftPrefix 197L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 198L);
-                    (58L, 199L);
-                    (59L, 200L);
-                    (61L, 201L);
-                  ]
-              );
-            (* 156 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:156L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 102L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 115L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 116L);
-                    (14L, Action.ShiftPrefix 117L);
-                    (15L, Action.ShiftPrefix 118L);
-                    (21L, Action.ShiftPrefix 119L);
-                    (30L, Action.ShiftPrefix 120L);
-                    (38L, Action.ShiftPrefix 121L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 122L);
-                    (65L, 123L);
-                    (67L, 124L);
-                    (68L, 125L);
-                    (70L, 126L);
-                    (71L, 127L);
-                    (72L, 128L);
-                    (74L, 131L);
-                    (75L, 202L);
-                  ]
-              );
-            (* 157 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:157L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 104L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (27L, Action.Reduce 104L);
-                    (29L, Action.Reduce 104L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 158 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:158L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 82L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.Reduce 82L);
-                    (3L, Action.Reduce 82L);
-                    (4L, Action.Reduce 82L);
-                    (5L, Action.Reduce 82L);
-                    (6L, Action.Reduce 82L);
-                    (7L, Action.Reduce 82L);
-                    (8L, Action.Reduce 82L);
-                    (9L, Action.Reduce 82L);
-                    (10L, Action.Reduce 82L);
-                    (11L, Action.Reduce 82L);
-                    (12L, Action.Reduce 82L);
-                    (13L, Action.Reduce 82L);
-                    (14L, Action.Reduce 82L);
-                    (15L, Action.Reduce 82L);
-                    (20L, Action.Reduce 82L);
-                    (21L, Action.Reduce 82L);
-                    (27L, Action.Reduce 82L);
-                    (29L, Action.Reduce 82L);
-                    (30L, Action.Reduce 82L);
-                    (38L, Action.Reduce 82L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 159 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:159L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 89L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.Reduce 89L);
-                    (3L, Action.Reduce 89L);
-                    (4L, Action.Reduce 89L);
-                    (5L, Action.Reduce 89L);
-                    (6L, Action.Reduce 89L);
-                    (7L, Action.Reduce 89L);
-                    (8L, Action.Reduce 89L);
-                    (9L, Action.Reduce 89L);
-                    (10L, Action.Reduce 89L);
-                    (11L, Action.Reduce 89L);
-                    (12L, Action.Reduce 89L);
-                    (13L, Action.Reduce 89L);
-                    (14L, Action.Reduce 89L);
-                    (15L, Action.Reduce 89L);
-                    (20L, Action.Reduce 89L);
-                    (21L, Action.Reduce 89L);
-                    (27L, Action.Reduce 89L);
-                    (29L, Action.Reduce 89L);
-                    (30L, Action.Reduce 89L);
-                    (38L, Action.Reduce 89L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 160 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:160L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 99L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (20L, Action.Reduce 99L);
-                    (27L, Action.Reduce 99L);
-                    (29L, Action.Reduce 99L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 161 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:161L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 77L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (24L, Action.Reduce 77L);
-                    (25L, Action.Reduce 77L);
-                    (26L, Action.Reduce 77L);
-                    (31L, Action.Reduce 77L);
-                    (39L, Action.Reduce 77L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 162 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:162L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x8500_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 76L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x8500_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (24L, Action.ShiftPrefix 165L);
-                    (26L, Action.ShiftPrefix 166L);
-                    (31L, Action.ShiftPrefix 203L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 163 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:163L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 80L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (25L, Action.ShiftPrefix 170L);
-                    (39L, Action.Reduce 70L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (64L, 204L);
-                  ]
-              );
-            (* 164 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:164L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 72L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.singleton 19L
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 78L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 81L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (13L, Action.ShiftPrefix 173L);
-                    (30L, Action.ShiftPrefix 205L);
-                    (38L, Action.ShiftPrefix 206L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (65L, 176L);
-                  ]
-              );
-            (* 165 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:165L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 137L);
-                    (14L, Action.ShiftPrefix 138L);
-                    (30L, Action.ShiftPrefix 139L);
-                    (38L, Action.ShiftPrefix 140L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 141L);
-                    (65L, 142L);
-                    (66L, 207L);
-                  ]
-              );
-            (* 166 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:166L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 208L);
-                  ]
-              );
-            (* 167 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:167L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 85L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (18L, Action.ShiftPrefix 209L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 168 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:168L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 65L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 137L);
-                    (14L, Action.ShiftPrefix 138L);
-                    (30L, Action.ShiftPrefix 139L);
-                    (38L, Action.ShiftPrefix 140L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 141L);
-                    (65L, 142L);
-                    (66L, 210L);
-                  ]
-              );
-            (* 169 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:169L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 67L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 68L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (14L, Action.ShiftPrefix 211L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 144L);
-                    (62L, 145L);
-                    (63L, 212L);
-                  ]
-              );
-            (* 170 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:170L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 69L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.singleton 39L
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (39L, Action.Reduce 69L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 171 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:171L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 87L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (39L, Action.ShiftPrefix 213L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 172 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:172L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 84L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.Reduce 84L);
-                    (3L, Action.Reduce 84L);
-                    (4L, Action.Reduce 84L);
-                    (5L, Action.Reduce 84L);
-                    (6L, Action.Reduce 84L);
-                    (7L, Action.Reduce 84L);
-                    (8L, Action.Reduce 84L);
-                    (9L, Action.Reduce 84L);
-                    (10L, Action.Reduce 84L);
-                    (11L, Action.Reduce 84L);
-                    (12L, Action.Reduce 84L);
-                    (13L, Action.Reduce 84L);
-                    (14L, Action.Reduce 84L);
-                    (15L, Action.Reduce 84L);
-                    (20L, Action.Reduce 84L);
-                    (21L, Action.Reduce 84L);
-                    (27L, Action.Reduce 84L);
-                    (29L, Action.Reduce 84L);
-                    (30L, Action.Reduce 84L);
-                    (38L, Action.Reduce 84L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 173 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:173L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 71L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.singleton 19L
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (19L, Action.Reduce 71L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 174 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:174L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 86L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 137L);
-                    (14L, Action.ShiftPrefix 138L);
-                    (30L, Action.ShiftPrefix 139L);
-                    (38L, Action.ShiftPrefix 140L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 141L);
-                    (65L, 142L);
-                    (66L, 214L);
-                  ]
-              );
-            (* 175 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:175L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 88L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 144L);
-                    (62L, 145L);
-                    (63L, 215L);
-                  ]
-              );
-            (* 176 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:176L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 72L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.singleton 19L
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 72L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.singleton 19L
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (19L, Action.Reduce 72L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 177 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:177L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 91L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (20L, Action.Reduce 91L);
-                    (21L, Action.Reduce 91L);
-                    (27L, Action.Reduce 91L);
-                    (29L, Action.Reduce 91L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 178 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:178L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 97L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (20L, Action.Reduce 98L);
-                    (21L, Action.ShiftPrefix 153L);
-                    (27L, Action.Reduce 98L);
-                    (29L, Action.Reduce 98L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (73L, 216L);
-                  ]
-              );
-            (* 179 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:179L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -9294,10 +6957,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 180 *) State.init
+            (* 111 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:180L
+                  ~index:111L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -9356,10 +7019,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 181 *) State.init
+            (* 112 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:181L
+                  ~index:112L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -9418,10 +7081,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 182 *) State.init
+            (* 113 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:182L
+                  ~index:113L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -9480,10 +7143,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 183 *) State.init
+            (* 114 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:183L
+                  ~index:114L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -9542,10 +7205,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 184 *) State.init
+            (* 115 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:184L
+                  ~index:115L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -9604,10 +7267,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 185 *) State.init
+            (* 116 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:185L
+                  ~index:116L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -9666,10 +7329,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 186 *) State.init
+            (* 117 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:186L
+                  ~index:117L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -9728,10 +7391,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 187 *) State.init
+            (* 118 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:187L
+                  ~index:118L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -9790,10 +7453,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 188 *) State.init
+            (* 119 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:188L
+                  ~index:119L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -9852,10 +7515,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 189 *) State.init
+            (* 120 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:189L
+                  ~index:120L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -9914,10 +7577,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 190 *) State.init
+            (* 121 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:190L
+                  ~index:121L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -9976,10 +7639,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 191 *) State.init
+            (* 122 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:191L
+                  ~index:122L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -10005,40 +7668,40 @@ include struct
                     (10L, Action.ShiftPrefix 80L);
                     (11L, Action.ShiftPrefix 81L);
                     (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 179L);
-                    (14L, Action.ShiftPrefix 180L);
-                    (15L, Action.ShiftPrefix 181L);
-                    (16L, Action.ShiftPrefix 182L);
-                    (17L, Action.ShiftPrefix 183L);
-                    (18L, Action.ShiftPrefix 184L);
-                    (19L, Action.ShiftPrefix 185L);
-                    (20L, Action.ShiftPrefix 186L);
-                    (22L, Action.ShiftPrefix 187L);
-                    (23L, Action.ShiftPrefix 188L);
-                    (24L, Action.ShiftPrefix 189L);
-                    (26L, Action.ShiftPrefix 190L);
-                    (28L, Action.ShiftPrefix 191L);
-                    (30L, Action.ShiftPrefix 192L);
-                    (32L, Action.ShiftPrefix 193L);
-                    (34L, Action.ShiftPrefix 194L);
-                    (36L, Action.ShiftPrefix 195L);
-                    (38L, Action.ShiftPrefix 196L);
-                    (40L, Action.ShiftPrefix 197L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
+                    (26L, Action.ShiftPrefix 121L);
+                    (28L, Action.ShiftPrefix 122L);
+                    (30L, Action.ShiftPrefix 123L);
+                    (32L, Action.ShiftPrefix 124L);
+                    (34L, Action.ShiftPrefix 125L);
+                    (36L, Action.ShiftPrefix 126L);
+                    (38L, Action.ShiftPrefix 127L);
+                    (40L, Action.ShiftPrefix 128L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (42L, 198L);
-                    (56L, 217L);
-                    (58L, 199L);
-                    (59L, 200L);
-                    (61L, 218L);
+                    (42L, 129L);
+                    (56L, 153L);
+                    (58L, 154L);
+                    (59L, 155L);
+                    (61L, 156L);
                   ]
               );
-            (* 192 *) State.init
+            (* 123 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:192L
+                  ~index:123L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -10064,42 +7727,42 @@ include struct
                     (10L, Action.ShiftPrefix 80L);
                     (11L, Action.ShiftPrefix 81L);
                     (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 179L);
-                    (14L, Action.ShiftPrefix 180L);
-                    (15L, Action.ShiftPrefix 181L);
-                    (16L, Action.ShiftPrefix 182L);
-                    (17L, Action.ShiftPrefix 183L);
-                    (18L, Action.ShiftPrefix 184L);
-                    (19L, Action.ShiftPrefix 185L);
-                    (20L, Action.ShiftPrefix 186L);
-                    (22L, Action.ShiftPrefix 187L);
-                    (23L, Action.ShiftPrefix 188L);
-                    (24L, Action.ShiftPrefix 189L);
-                    (26L, Action.ShiftPrefix 190L);
-                    (28L, Action.ShiftPrefix 191L);
-                    (30L, Action.ShiftPrefix 192L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
+                    (26L, Action.ShiftPrefix 121L);
+                    (28L, Action.ShiftPrefix 122L);
+                    (30L, Action.ShiftPrefix 123L);
                     (31L, Action.Reduce 38L);
-                    (32L, Action.ShiftPrefix 193L);
-                    (34L, Action.ShiftPrefix 194L);
-                    (36L, Action.ShiftPrefix 195L);
-                    (38L, Action.ShiftPrefix 196L);
-                    (40L, Action.ShiftPrefix 197L);
+                    (32L, Action.ShiftPrefix 124L);
+                    (34L, Action.ShiftPrefix 125L);
+                    (36L, Action.ShiftPrefix 126L);
+                    (38L, Action.ShiftPrefix 127L);
+                    (40L, Action.ShiftPrefix 128L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (42L, 198L);
-                    (56L, 219L);
-                    (57L, 220L);
-                    (58L, 199L);
-                    (59L, 200L);
-                    (61L, 218L);
+                    (42L, 129L);
+                    (56L, 157L);
+                    (57L, 158L);
+                    (58L, 154L);
+                    (59L, 155L);
+                    (61L, 156L);
                   ]
               );
-            (* 193 *) State.init
+            (* 124 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:193L
+                  ~index:124L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -10125,42 +7788,42 @@ include struct
                     (10L, Action.ShiftPrefix 80L);
                     (11L, Action.ShiftPrefix 81L);
                     (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 179L);
-                    (14L, Action.ShiftPrefix 180L);
-                    (15L, Action.ShiftPrefix 181L);
-                    (16L, Action.ShiftPrefix 182L);
-                    (17L, Action.ShiftPrefix 183L);
-                    (18L, Action.ShiftPrefix 184L);
-                    (19L, Action.ShiftPrefix 185L);
-                    (20L, Action.ShiftPrefix 186L);
-                    (22L, Action.ShiftPrefix 187L);
-                    (23L, Action.ShiftPrefix 188L);
-                    (24L, Action.ShiftPrefix 189L);
-                    (26L, Action.ShiftPrefix 190L);
-                    (28L, Action.ShiftPrefix 191L);
-                    (30L, Action.ShiftPrefix 192L);
-                    (32L, Action.ShiftPrefix 193L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
+                    (26L, Action.ShiftPrefix 121L);
+                    (28L, Action.ShiftPrefix 122L);
+                    (30L, Action.ShiftPrefix 123L);
+                    (32L, Action.ShiftPrefix 124L);
                     (33L, Action.Reduce 38L);
-                    (34L, Action.ShiftPrefix 194L);
-                    (36L, Action.ShiftPrefix 195L);
-                    (38L, Action.ShiftPrefix 196L);
-                    (40L, Action.ShiftPrefix 197L);
+                    (34L, Action.ShiftPrefix 125L);
+                    (36L, Action.ShiftPrefix 126L);
+                    (38L, Action.ShiftPrefix 127L);
+                    (40L, Action.ShiftPrefix 128L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (42L, 198L);
-                    (56L, 219L);
-                    (57L, 221L);
-                    (58L, 199L);
-                    (59L, 200L);
-                    (61L, 218L);
+                    (42L, 129L);
+                    (56L, 157L);
+                    (57L, 159L);
+                    (58L, 154L);
+                    (59L, 155L);
+                    (61L, 156L);
                   ]
               );
-            (* 194 *) State.init
+            (* 125 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:194L
+                  ~index:125L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -10186,42 +7849,42 @@ include struct
                     (10L, Action.ShiftPrefix 80L);
                     (11L, Action.ShiftPrefix 81L);
                     (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 179L);
-                    (14L, Action.ShiftPrefix 180L);
-                    (15L, Action.ShiftPrefix 181L);
-                    (16L, Action.ShiftPrefix 182L);
-                    (17L, Action.ShiftPrefix 183L);
-                    (18L, Action.ShiftPrefix 184L);
-                    (19L, Action.ShiftPrefix 185L);
-                    (20L, Action.ShiftPrefix 186L);
-                    (22L, Action.ShiftPrefix 187L);
-                    (23L, Action.ShiftPrefix 188L);
-                    (24L, Action.ShiftPrefix 189L);
-                    (26L, Action.ShiftPrefix 190L);
-                    (28L, Action.ShiftPrefix 191L);
-                    (30L, Action.ShiftPrefix 192L);
-                    (32L, Action.ShiftPrefix 193L);
-                    (34L, Action.ShiftPrefix 194L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
+                    (26L, Action.ShiftPrefix 121L);
+                    (28L, Action.ShiftPrefix 122L);
+                    (30L, Action.ShiftPrefix 123L);
+                    (32L, Action.ShiftPrefix 124L);
+                    (34L, Action.ShiftPrefix 125L);
                     (35L, Action.Reduce 38L);
-                    (36L, Action.ShiftPrefix 195L);
-                    (38L, Action.ShiftPrefix 196L);
-                    (40L, Action.ShiftPrefix 197L);
+                    (36L, Action.ShiftPrefix 126L);
+                    (38L, Action.ShiftPrefix 127L);
+                    (40L, Action.ShiftPrefix 128L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (42L, 198L);
-                    (56L, 219L);
-                    (57L, 222L);
-                    (58L, 199L);
-                    (59L, 200L);
-                    (61L, 218L);
+                    (42L, 129L);
+                    (56L, 157L);
+                    (57L, 160L);
+                    (58L, 154L);
+                    (59L, 155L);
+                    (61L, 156L);
                   ]
               );
-            (* 195 *) State.init
+            (* 126 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:195L
+                  ~index:126L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -10247,42 +7910,42 @@ include struct
                     (10L, Action.ShiftPrefix 80L);
                     (11L, Action.ShiftPrefix 81L);
                     (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 179L);
-                    (14L, Action.ShiftPrefix 180L);
-                    (15L, Action.ShiftPrefix 181L);
-                    (16L, Action.ShiftPrefix 182L);
-                    (17L, Action.ShiftPrefix 183L);
-                    (18L, Action.ShiftPrefix 184L);
-                    (19L, Action.ShiftPrefix 185L);
-                    (20L, Action.ShiftPrefix 186L);
-                    (22L, Action.ShiftPrefix 187L);
-                    (23L, Action.ShiftPrefix 188L);
-                    (24L, Action.ShiftPrefix 189L);
-                    (26L, Action.ShiftPrefix 190L);
-                    (28L, Action.ShiftPrefix 191L);
-                    (30L, Action.ShiftPrefix 192L);
-                    (32L, Action.ShiftPrefix 193L);
-                    (34L, Action.ShiftPrefix 194L);
-                    (36L, Action.ShiftPrefix 195L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
+                    (26L, Action.ShiftPrefix 121L);
+                    (28L, Action.ShiftPrefix 122L);
+                    (30L, Action.ShiftPrefix 123L);
+                    (32L, Action.ShiftPrefix 124L);
+                    (34L, Action.ShiftPrefix 125L);
+                    (36L, Action.ShiftPrefix 126L);
                     (37L, Action.Reduce 38L);
-                    (38L, Action.ShiftPrefix 196L);
-                    (40L, Action.ShiftPrefix 197L);
+                    (38L, Action.ShiftPrefix 127L);
+                    (40L, Action.ShiftPrefix 128L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (42L, 198L);
-                    (56L, 219L);
-                    (57L, 223L);
-                    (58L, 199L);
-                    (59L, 200L);
-                    (61L, 218L);
+                    (42L, 129L);
+                    (56L, 157L);
+                    (57L, 161L);
+                    (58L, 154L);
+                    (59L, 155L);
+                    (61L, 156L);
                   ]
               );
-            (* 196 *) State.init
+            (* 127 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:196L
+                  ~index:127L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -10308,42 +7971,42 @@ include struct
                     (10L, Action.ShiftPrefix 80L);
                     (11L, Action.ShiftPrefix 81L);
                     (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 179L);
-                    (14L, Action.ShiftPrefix 180L);
-                    (15L, Action.ShiftPrefix 181L);
-                    (16L, Action.ShiftPrefix 182L);
-                    (17L, Action.ShiftPrefix 183L);
-                    (18L, Action.ShiftPrefix 184L);
-                    (19L, Action.ShiftPrefix 185L);
-                    (20L, Action.ShiftPrefix 186L);
-                    (22L, Action.ShiftPrefix 187L);
-                    (23L, Action.ShiftPrefix 188L);
-                    (24L, Action.ShiftPrefix 189L);
-                    (26L, Action.ShiftPrefix 190L);
-                    (28L, Action.ShiftPrefix 191L);
-                    (30L, Action.ShiftPrefix 192L);
-                    (32L, Action.ShiftPrefix 193L);
-                    (34L, Action.ShiftPrefix 194L);
-                    (36L, Action.ShiftPrefix 195L);
-                    (38L, Action.ShiftPrefix 196L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
+                    (26L, Action.ShiftPrefix 121L);
+                    (28L, Action.ShiftPrefix 122L);
+                    (30L, Action.ShiftPrefix 123L);
+                    (32L, Action.ShiftPrefix 124L);
+                    (34L, Action.ShiftPrefix 125L);
+                    (36L, Action.ShiftPrefix 126L);
+                    (38L, Action.ShiftPrefix 127L);
                     (39L, Action.Reduce 38L);
-                    (40L, Action.ShiftPrefix 197L);
+                    (40L, Action.ShiftPrefix 128L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (42L, 198L);
-                    (56L, 219L);
-                    (57L, 224L);
-                    (58L, 199L);
-                    (59L, 200L);
-                    (61L, 218L);
+                    (42L, 129L);
+                    (56L, 157L);
+                    (57L, 162L);
+                    (58L, 154L);
+                    (59L, 155L);
+                    (61L, 156L);
                   ]
               );
-            (* 197 *) State.init
+            (* 128 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:197L
+                  ~index:128L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -10402,10 +8065,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 198 *) State.init
+            (* 129 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:198L
+                  ~index:129L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -10464,10 +8127,918 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 199 *) State.init
+            (* 130 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:199L
+                  ~index:130L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 62L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2800_0800n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.Reduce 61L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
+                    (26L, Action.ShiftPrefix 121L);
+                    (27L, Action.Reduce 61L);
+                    (28L, Action.ShiftPrefix 122L);
+                    (29L, Action.Reduce 61L);
+                    (30L, Action.ShiftPrefix 123L);
+                    (32L, Action.ShiftPrefix 124L);
+                    (34L, Action.ShiftPrefix 125L);
+                    (36L, Action.ShiftPrefix 126L);
+                    (38L, Action.ShiftPrefix 127L);
+                    (40L, Action.ShiftPrefix 128L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 129L);
+                    (58L, 163L);
+                    (59L, 164L);
+                    (60L, 165L);
+                  ]
+              );
+            (* 131 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:131L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 63L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2800_0800n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.Reduce 61L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
+                    (26L, Action.ShiftPrefix 121L);
+                    (27L, Action.Reduce 61L);
+                    (28L, Action.ShiftPrefix 122L);
+                    (29L, Action.Reduce 61L);
+                    (30L, Action.ShiftPrefix 123L);
+                    (32L, Action.ShiftPrefix 124L);
+                    (34L, Action.ShiftPrefix 125L);
+                    (36L, Action.ShiftPrefix 126L);
+                    (38L, Action.ShiftPrefix 127L);
+                    (40L, Action.ShiftPrefix 128L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 129L);
+                    (58L, 163L);
+                    (59L, 164L);
+                    (60L, 166L);
+                  ]
+              );
+            (* 132 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:132L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 28L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2800_0800n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (11L, Action.Reduce 28L);
+                    (27L, Action.Reduce 28L);
+                    (29L, Action.Reduce 28L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 133 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:133L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 30L prods) ~dot:5L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (27L, Action.Reduce 30L);
+                    (29L, Action.Reduce 30L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 134 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:134L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 11L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2840_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (22L, Action.Reduce 11L);
+                    (27L, Action.Reduce 11L);
+                    (29L, Action.Reduce 11L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 135 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:135L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 21L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x1ffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.Reduce 22L);
+                    (3L, Action.Reduce 22L);
+                    (4L, Action.Reduce 22L);
+                    (5L, Action.Reduce 22L);
+                    (6L, Action.Reduce 22L);
+                    (7L, Action.Reduce 22L);
+                    (8L, Action.Reduce 22L);
+                    (9L, Action.Reduce 22L);
+                    (10L, Action.Reduce 22L);
+                    (11L, Action.Reduce 22L);
+                    (12L, Action.Reduce 22L);
+                    (13L, Action.ShiftPrefix 105L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (48L, 167L);
+                  ]
+              );
+            (* 136 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:136L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 23L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x155_55df_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.Reduce 23L);
+                    (3L, Action.Reduce 23L);
+                    (4L, Action.Reduce 23L);
+                    (5L, Action.Reduce 23L);
+                    (6L, Action.Reduce 23L);
+                    (7L, Action.Reduce 23L);
+                    (8L, Action.Reduce 23L);
+                    (9L, Action.Reduce 23L);
+                    (10L, Action.Reduce 23L);
+                    (11L, Action.Reduce 23L);
+                    (12L, Action.Reduce 23L);
+                    (13L, Action.Reduce 23L);
+                    (14L, Action.Reduce 23L);
+                    (15L, Action.Reduce 23L);
+                    (16L, Action.Reduce 23L);
+                    (17L, Action.Reduce 23L);
+                    (18L, Action.Reduce 23L);
+                    (19L, Action.Reduce 23L);
+                    (20L, Action.Reduce 23L);
+                    (22L, Action.Reduce 23L);
+                    (23L, Action.Reduce 23L);
+                    (24L, Action.Reduce 23L);
+                    (26L, Action.Reduce 23L);
+                    (28L, Action.Reduce 23L);
+                    (30L, Action.Reduce 23L);
+                    (32L, Action.Reduce 23L);
+                    (34L, Action.Reduce 23L);
+                    (36L, Action.Reduce 23L);
+                    (38L, Action.Reduce 23L);
+                    (40L, Action.Reduce 23L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 137 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:137L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 108L prods) ~dot:5L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 138L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 139L);
+                    (14L, Action.ShiftPrefix 140L);
+                    (15L, Action.ShiftPrefix 141L);
+                    (21L, Action.ShiftPrefix 142L);
+                    (30L, Action.ShiftPrefix 143L);
+                    (38L, Action.ShiftPrefix 144L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 145L);
+                    (65L, 146L);
+                    (67L, 147L);
+                    (68L, 148L);
+                    (70L, 149L);
+                    (71L, 150L);
+                    (72L, 151L);
+                    (74L, 168L);
+                    (75L, 169L);
+                    (77L, 170L);
+                  ]
+              );
+            (* 138 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:138L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 2L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.singleton 18L
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 95L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (11L, Action.ShiftPrefix 95L);
+                    (18L, Action.Reduce 2L);
+                    (20L, Action.Reduce 25L);
+                    (21L, Action.Reduce 25L);
+                    (27L, Action.Reduce 25L);
+                    (29L, Action.Reduce 25L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (50L, 171L);
+                  ]
+              );
+            (* 139 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:139L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 71L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.singleton 19L
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 82L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.Reduce 82L);
+                    (3L, Action.Reduce 82L);
+                    (4L, Action.Reduce 82L);
+                    (5L, Action.Reduce 82L);
+                    (6L, Action.Reduce 82L);
+                    (7L, Action.Reduce 82L);
+                    (8L, Action.Reduce 82L);
+                    (9L, Action.Reduce 82L);
+                    (10L, Action.Reduce 82L);
+                    (11L, Action.Reduce 82L);
+                    (12L, Action.Reduce 82L);
+                    (13L, Action.Reduce 82L);
+                    (14L, Action.Reduce 82L);
+                    (15L, Action.Reduce 82L);
+                    (19L, Action.Reduce 71L);
+                    (20L, Action.Reduce 82L);
+                    (21L, Action.Reduce 82L);
+                    (27L, Action.Reduce 82L);
+                    (29L, Action.Reduce 82L);
+                    (30L, Action.Reduce 82L);
+                    (38L, Action.Reduce 82L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 140 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:140L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 89L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (18L, Action.ShiftPrefix 172L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 141 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:141L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 83L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.Reduce 83L);
+                    (3L, Action.Reduce 83L);
+                    (4L, Action.Reduce 83L);
+                    (5L, Action.Reduce 83L);
+                    (6L, Action.Reduce 83L);
+                    (7L, Action.Reduce 83L);
+                    (8L, Action.Reduce 83L);
+                    (9L, Action.Reduce 83L);
+                    (10L, Action.Reduce 83L);
+                    (11L, Action.Reduce 83L);
+                    (12L, Action.Reduce 83L);
+                    (13L, Action.Reduce 83L);
+                    (14L, Action.Reduce 83L);
+                    (15L, Action.Reduce 83L);
+                    (20L, Action.Reduce 83L);
+                    (21L, Action.Reduce 83L);
+                    (27L, Action.Reduce 83L);
+                    (29L, Action.Reduce 83L);
+                    (30L, Action.Reduce 83L);
+                    (38L, Action.Reduce 83L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 142 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:142L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 99L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 138L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 139L);
+                    (14L, Action.ShiftPrefix 140L);
+                    (15L, Action.ShiftPrefix 141L);
+                    (30L, Action.ShiftPrefix 143L);
+                    (38L, Action.ShiftPrefix 144L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 145L);
+                    (65L, 146L);
+                    (67L, 147L);
+                    (68L, 148L);
+                    (70L, 149L);
+                    (71L, 150L);
+                    (72L, 173L);
+                  ]
+              );
+            (* 143 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:143L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 85L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 174L);
+                    (14L, Action.ShiftPrefix 175L);
+                    (30L, Action.ShiftPrefix 176L);
+                    (38L, Action.ShiftPrefix 177L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 178L);
+                    (65L, 179L);
+                    (66L, 180L);
+                  ]
+              );
+            (* 144 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:144L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 87L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 181L);
+                    (62L, 182L);
+                    (63L, 183L);
+                  ]
+              );
+            (* 145 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:145L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 84L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (18L, Action.ShiftPrefix 184L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 146 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:146L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 72L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.singleton 19L
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 86L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 88L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (19L, Action.ShiftPrefix 185L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 147 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:147L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 90L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.Reduce 90L);
+                    (3L, Action.Reduce 90L);
+                    (4L, Action.Reduce 90L);
+                    (5L, Action.Reduce 90L);
+                    (6L, Action.Reduce 90L);
+                    (7L, Action.Reduce 90L);
+                    (8L, Action.Reduce 90L);
+                    (9L, Action.Reduce 90L);
+                    (10L, Action.Reduce 90L);
+                    (11L, Action.Reduce 90L);
+                    (12L, Action.Reduce 90L);
+                    (13L, Action.Reduce 90L);
+                    (14L, Action.Reduce 90L);
+                    (15L, Action.Reduce 90L);
+                    (20L, Action.Reduce 90L);
+                    (21L, Action.Reduce 90L);
+                    (27L, Action.Reduce 90L);
+                    (29L, Action.Reduce 90L);
+                    (30L, Action.Reduce 90L);
+                    (38L, Action.Reduce 90L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 148 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:148L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 93L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 186L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 139L);
+                    (14L, Action.ShiftPrefix 140L);
+                    (15L, Action.ShiftPrefix 141L);
+                    (20L, Action.Reduce 25L);
+                    (21L, Action.Reduce 25L);
+                    (27L, Action.Reduce 25L);
+                    (29L, Action.Reduce 25L);
+                    (30L, Action.ShiftPrefix 143L);
+                    (38L, Action.ShiftPrefix 144L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 145L);
+                    (50L, 187L);
+                    (65L, 146L);
+                    (67L, 147L);
+                    (68L, 188L);
+                    (69L, 189L);
+                  ]
+              );
+            (* 149 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:149L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 94L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (20L, Action.Reduce 94L);
+                    (21L, Action.Reduce 94L);
+                    (27L, Action.Reduce 94L);
+                    (29L, Action.Reduce 94L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 150 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:150L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 96L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (20L, Action.Reduce 96L);
+                    (21L, Action.Reduce 96L);
+                    (27L, Action.Reduce 96L);
+                    (29L, Action.Reduce 96L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 151 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:151L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 100L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (20L, Action.Reduce 98L);
+                    (21L, Action.ShiftPrefix 190L);
+                    (27L, Action.Reduce 98L);
+                    (29L, Action.Reduce 98L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (73L, 191L);
+                  ]
+              );
+            (* 152 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:152L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 107L prods) ~dot:5L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (27L, Action.Reduce 107L);
+                    (29L, Action.Reduce 107L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 153 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:153L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 39L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x1ff_ffff_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (29L, Action.ShiftPrefix 192L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 154 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:154L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -10493,48 +9064,48 @@ include struct
                     (10L, Action.ShiftPrefix 80L);
                     (11L, Action.ShiftPrefix 81L);
                     (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 179L);
-                    (14L, Action.ShiftPrefix 180L);
-                    (15L, Action.ShiftPrefix 181L);
-                    (16L, Action.ShiftPrefix 182L);
-                    (17L, Action.ShiftPrefix 183L);
-                    (18L, Action.ShiftPrefix 184L);
-                    (19L, Action.ShiftPrefix 185L);
-                    (20L, Action.ShiftPrefix 186L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
                     (21L, Action.Reduce 61L);
-                    (22L, Action.ShiftPrefix 187L);
-                    (23L, Action.ShiftPrefix 188L);
-                    (24L, Action.ShiftPrefix 189L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
                     (25L, Action.Reduce 61L);
-                    (26L, Action.ShiftPrefix 190L);
+                    (26L, Action.ShiftPrefix 121L);
                     (27L, Action.Reduce 61L);
-                    (28L, Action.ShiftPrefix 191L);
+                    (28L, Action.ShiftPrefix 122L);
                     (29L, Action.Reduce 61L);
-                    (30L, Action.ShiftPrefix 192L);
+                    (30L, Action.ShiftPrefix 123L);
                     (31L, Action.Reduce 61L);
-                    (32L, Action.ShiftPrefix 193L);
+                    (32L, Action.ShiftPrefix 124L);
                     (33L, Action.Reduce 61L);
-                    (34L, Action.ShiftPrefix 194L);
+                    (34L, Action.ShiftPrefix 125L);
                     (35L, Action.Reduce 61L);
-                    (36L, Action.ShiftPrefix 195L);
+                    (36L, Action.ShiftPrefix 126L);
                     (37L, Action.Reduce 61L);
-                    (38L, Action.ShiftPrefix 196L);
+                    (38L, Action.ShiftPrefix 127L);
                     (39L, Action.Reduce 61L);
-                    (40L, Action.ShiftPrefix 197L);
+                    (40L, Action.ShiftPrefix 128L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (42L, 198L);
-                    (58L, 225L);
-                    (59L, 226L);
-                    (60L, 227L);
+                    (42L, 129L);
+                    (58L, 193L);
+                    (59L, 194L);
+                    (60L, 165L);
                   ]
               );
-            (* 200 *) State.init
+            (* 155 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:200L
+                  ~index:155L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -10560,563 +9131,48 @@ include struct
                     (10L, Action.ShiftPrefix 80L);
                     (11L, Action.ShiftPrefix 81L);
                     (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 179L);
-                    (14L, Action.ShiftPrefix 180L);
-                    (15L, Action.ShiftPrefix 181L);
-                    (16L, Action.ShiftPrefix 182L);
-                    (17L, Action.ShiftPrefix 183L);
-                    (18L, Action.ShiftPrefix 184L);
-                    (19L, Action.ShiftPrefix 185L);
-                    (20L, Action.ShiftPrefix 186L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
                     (21L, Action.Reduce 61L);
-                    (22L, Action.ShiftPrefix 187L);
-                    (23L, Action.ShiftPrefix 188L);
-                    (24L, Action.ShiftPrefix 189L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
                     (25L, Action.Reduce 61L);
-                    (26L, Action.ShiftPrefix 190L);
+                    (26L, Action.ShiftPrefix 121L);
                     (27L, Action.Reduce 61L);
-                    (28L, Action.ShiftPrefix 191L);
+                    (28L, Action.ShiftPrefix 122L);
                     (29L, Action.Reduce 61L);
-                    (30L, Action.ShiftPrefix 192L);
+                    (30L, Action.ShiftPrefix 123L);
                     (31L, Action.Reduce 61L);
-                    (32L, Action.ShiftPrefix 193L);
+                    (32L, Action.ShiftPrefix 124L);
                     (33L, Action.Reduce 61L);
-                    (34L, Action.ShiftPrefix 194L);
+                    (34L, Action.ShiftPrefix 125L);
                     (35L, Action.Reduce 61L);
-                    (36L, Action.ShiftPrefix 195L);
+                    (36L, Action.ShiftPrefix 126L);
                     (37L, Action.Reduce 61L);
-                    (38L, Action.ShiftPrefix 196L);
+                    (38L, Action.ShiftPrefix 127L);
                     (39L, Action.Reduce 61L);
-                    (40L, Action.ShiftPrefix 197L);
+                    (40L, Action.ShiftPrefix 128L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (42L, 198L);
-                    (58L, 225L);
-                    (59L, 226L);
-                    (60L, 228L);
+                    (42L, 129L);
+                    (58L, 193L);
+                    (59L, 194L);
+                    (60L, 166L);
                   ]
               );
-            (* 201 *) State.init
+            (* 156 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:201L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 101L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2820_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (21L, Action.Reduce 101L);
-                    (27L, Action.Reduce 101L);
-                    (29L, Action.Reduce 101L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 202 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:202L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 102L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (21L, Action.ShiftPrefix 156L);
-                    (27L, Action.Reduce 103L);
-                    (29L, Action.Reduce 103L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (76L, 229L);
-                  ]
-              );
-            (* 203 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:203L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 76L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (24L, Action.Reduce 76L);
-                    (25L, Action.Reduce 76L);
-                    (26L, Action.Reduce 76L);
-                    (31L, Action.Reduce 76L);
-                    (39L, Action.Reduce 76L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 204 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:204L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 80L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (39L, Action.ShiftPrefix 230L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 205 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:205L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 78L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 137L);
-                    (14L, Action.ShiftPrefix 138L);
-                    (30L, Action.ShiftPrefix 139L);
-                    (38L, Action.ShiftPrefix 140L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 141L);
-                    (65L, 142L);
-                    (66L, 231L);
-                  ]
-              );
-            (* 206 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:206L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 81L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (2L, Action.ShiftPrefix 72L);
-                    (3L, Action.ShiftPrefix 73L);
-                    (4L, Action.ShiftPrefix 74L);
-                    (5L, Action.ShiftPrefix 75L);
-                    (6L, Action.ShiftPrefix 76L);
-                    (7L, Action.ShiftPrefix 77L);
-                    (8L, Action.ShiftPrefix 78L);
-                    (9L, Action.ShiftPrefix 79L);
-                    (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
-                    (12L, Action.ShiftPrefix 82L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (42L, 144L);
-                    (62L, 145L);
-                    (63L, 232L);
-                  ]
-              );
-            (* 207 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:207L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (24L, Action.Reduce 79L);
-                    (25L, Action.Reduce 79L);
-                    (26L, Action.Reduce 79L);
-                    (31L, Action.Reduce 79L);
-                    (39L, Action.Reduce 79L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 208 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:208L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (24L, Action.Reduce 75L);
-                    (25L, Action.Reduce 75L);
-                    (26L, Action.Reduce 75L);
-                    (31L, Action.Reduce 75L);
-                    (39L, Action.Reduce 75L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 209 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:209L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 85L prods) ~dot:4L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (13L, Action.ShiftPrefix 158L);
-                    (15L, Action.ShiftPrefix 118L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (67L, 233L);
-                  ]
-              );
-            (* 210 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:210L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 65L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_0700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_0700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (24L, Action.ShiftPrefix 165L);
-                    (25L, Action.Reduce 65L);
-                    (26L, Action.ShiftPrefix 166L);
-                    (39L, Action.Reduce 65L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 211 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:211L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 67L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (25L, Action.Reduce 67L);
-                    (39L, Action.Reduce 67L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 212 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:212L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 68L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (25L, Action.Reduce 68L);
-                    (39L, Action.Reduce 68L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 213 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:213L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 87L prods) ~dot:4L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (18L, Action.ShiftPrefix 234L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 214 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:214L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x8500_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:1L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x8500_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 86L prods) ~dot:4L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (24L, Action.ShiftPrefix 165L);
-                    (26L, Action.ShiftPrefix 166L);
-                    (31L, Action.ShiftPrefix 235L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 215 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:215L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 88L prods) ~dot:4L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (25L, Action.ShiftPrefix 170L);
-                    (39L, Action.Reduce 70L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (64L, 236L);
-                  ]
-              );
-            (* 216 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:216L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 97L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (20L, Action.Reduce 97L);
-                    (27L, Action.Reduce 97L);
-                    (29L, Action.Reduce 97L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 217 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:217L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 39L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x1ff_ffff_fffcn")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (29L, Action.ShiftPrefix 237L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 218 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:218L
+                  ~index:156L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -11144,14 +9200,14 @@ include struct
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (54L, 238L);
-                    (55L, 239L);
+                    (54L, 195L);
+                    (55L, 196L);
                   ]
               );
-            (* 219 *) State.init
+            (* 157 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:219L
+                  ~index:157L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -11176,10 +9232,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 220 *) State.init
+            (* 158 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:220L
+                  ~index:158L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -11194,16 +9250,16 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (31L, Action.ShiftPrefix 240L);
+                    (31L, Action.ShiftPrefix 197L);
                   ]
               )
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 221 *) State.init
+            (* 159 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:221L
+                  ~index:159L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -11218,16 +9274,16 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (33L, Action.ShiftPrefix 241L);
+                    (33L, Action.ShiftPrefix 198L);
                   ]
               )
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 222 *) State.init
+            (* 160 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:222L
+                  ~index:160L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -11242,16 +9298,16 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (35L, Action.ShiftPrefix 242L);
+                    (35L, Action.ShiftPrefix 199L);
                   ]
               )
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 223 *) State.init
+            (* 161 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:223L
+                  ~index:161L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -11266,16 +9322,16 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (37L, Action.ShiftPrefix 243L);
+                    (37L, Action.ShiftPrefix 200L);
                   ]
               )
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 224 *) State.init
+            (* 162 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:224L
+                  ~index:162L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -11290,22 +9346,22 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (39L, Action.ShiftPrefix 244L);
+                    (39L, Action.ShiftPrefix 201L);
                   ]
               )
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 225 *) State.init
+            (* 163 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:225L
+                  ~index:163L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
                             let lr0item = Lr0Item.init ~prod:(Array.get 59L prods) ~dot:1L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0xaa_aa20_0000n")
+                                Bitset.of_nat (Nat.of_string "0x2800_0800n")
                               ) in
                             lr0item, lr1item
                           );
@@ -11323,56 +9379,49 @@ include struct
                     (8L, Action.ShiftPrefix 78L);
                     (9L, Action.ShiftPrefix 79L);
                     (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
+                    (11L, Action.Reduce 61L);
                     (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 179L);
-                    (14L, Action.ShiftPrefix 180L);
-                    (15L, Action.ShiftPrefix 181L);
-                    (16L, Action.ShiftPrefix 182L);
-                    (17L, Action.ShiftPrefix 183L);
-                    (18L, Action.ShiftPrefix 184L);
-                    (19L, Action.ShiftPrefix 185L);
-                    (20L, Action.ShiftPrefix 186L);
-                    (21L, Action.Reduce 61L);
-                    (22L, Action.ShiftPrefix 187L);
-                    (23L, Action.ShiftPrefix 188L);
-                    (24L, Action.ShiftPrefix 189L);
-                    (25L, Action.Reduce 61L);
-                    (26L, Action.ShiftPrefix 190L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
+                    (26L, Action.ShiftPrefix 121L);
                     (27L, Action.Reduce 61L);
-                    (28L, Action.ShiftPrefix 191L);
+                    (28L, Action.ShiftPrefix 122L);
                     (29L, Action.Reduce 61L);
-                    (30L, Action.ShiftPrefix 192L);
-                    (31L, Action.Reduce 61L);
-                    (32L, Action.ShiftPrefix 193L);
-                    (33L, Action.Reduce 61L);
-                    (34L, Action.ShiftPrefix 194L);
-                    (35L, Action.Reduce 61L);
-                    (36L, Action.ShiftPrefix 195L);
-                    (37L, Action.Reduce 61L);
-                    (38L, Action.ShiftPrefix 196L);
-                    (39L, Action.Reduce 61L);
-                    (40L, Action.ShiftPrefix 197L);
+                    (30L, Action.ShiftPrefix 123L);
+                    (32L, Action.ShiftPrefix 124L);
+                    (34L, Action.ShiftPrefix 125L);
+                    (36L, Action.ShiftPrefix 126L);
+                    (38L, Action.ShiftPrefix 127L);
+                    (40L, Action.ShiftPrefix 128L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (42L, 198L);
-                    (58L, 225L);
-                    (59L, 226L);
-                    (60L, 245L);
+                    (42L, 129L);
+                    (58L, 163L);
+                    (59L, 164L);
+                    (60L, 202L);
                   ]
               );
-            (* 226 *) State.init
+            (* 164 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:226L
+                  ~index:164L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
                             let lr0item = Lr0Item.init ~prod:(Array.get 60L prods) ~dot:1L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0xaa_aa20_0000n")
+                                Bitset.of_nat (Nat.of_string "0x2800_0800n")
                               ) in
                             lr0item, lr1item
                           );
@@ -11390,56 +9439,49 @@ include struct
                     (8L, Action.ShiftPrefix 78L);
                     (9L, Action.ShiftPrefix 79L);
                     (10L, Action.ShiftPrefix 80L);
-                    (11L, Action.ShiftPrefix 81L);
+                    (11L, Action.Reduce 61L);
                     (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 179L);
-                    (14L, Action.ShiftPrefix 180L);
-                    (15L, Action.ShiftPrefix 181L);
-                    (16L, Action.ShiftPrefix 182L);
-                    (17L, Action.ShiftPrefix 183L);
-                    (18L, Action.ShiftPrefix 184L);
-                    (19L, Action.ShiftPrefix 185L);
-                    (20L, Action.ShiftPrefix 186L);
-                    (21L, Action.Reduce 61L);
-                    (22L, Action.ShiftPrefix 187L);
-                    (23L, Action.ShiftPrefix 188L);
-                    (24L, Action.ShiftPrefix 189L);
-                    (25L, Action.Reduce 61L);
-                    (26L, Action.ShiftPrefix 190L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
+                    (26L, Action.ShiftPrefix 121L);
                     (27L, Action.Reduce 61L);
-                    (28L, Action.ShiftPrefix 191L);
+                    (28L, Action.ShiftPrefix 122L);
                     (29L, Action.Reduce 61L);
-                    (30L, Action.ShiftPrefix 192L);
-                    (31L, Action.Reduce 61L);
-                    (32L, Action.ShiftPrefix 193L);
-                    (33L, Action.Reduce 61L);
-                    (34L, Action.ShiftPrefix 194L);
-                    (35L, Action.Reduce 61L);
-                    (36L, Action.ShiftPrefix 195L);
-                    (37L, Action.Reduce 61L);
-                    (38L, Action.ShiftPrefix 196L);
-                    (39L, Action.Reduce 61L);
-                    (40L, Action.ShiftPrefix 197L);
+                    (30L, Action.ShiftPrefix 123L);
+                    (32L, Action.ShiftPrefix 124L);
+                    (34L, Action.ShiftPrefix 125L);
+                    (36L, Action.ShiftPrefix 126L);
+                    (38L, Action.ShiftPrefix 127L);
+                    (40L, Action.ShiftPrefix 128L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (42L, 198L);
-                    (58L, 225L);
-                    (59L, 226L);
-                    (60L, 246L);
+                    (42L, 129L);
+                    (58L, 163L);
+                    (59L, 164L);
+                    (60L, 203L);
                   ]
               );
-            (* 227 *) State.init
+            (* 165 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:227L
+                  ~index:165L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
                             let lr0item = Lr0Item.init ~prod:(Array.get 62L prods) ~dot:2L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0xaa_aa20_0000n")
+                                Bitset.of_nat (Nat.of_string "0xaa_aa20_0800n")
                               ) in
                             lr0item, lr1item
                           );
@@ -11448,6 +9490,7 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
+                    (11L, Action.Reduce 62L);
                     (21L, Action.Reduce 62L);
                     (25L, Action.Reduce 62L);
                     (27L, Action.Reduce 62L);
@@ -11462,16 +9505,16 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 228 *) State.init
+            (* 166 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:228L
+                  ~index:166L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
                             let lr0item = Lr0Item.init ~prod:(Array.get 63L prods) ~dot:2L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0xaa_aa20_0000n")
+                                Bitset.of_nat (Nat.of_string "0xaa_aa20_0800n")
                               ) in
                             lr0item, lr1item
                           );
@@ -11480,6 +9523,7 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
+                    (11L, Action.Reduce 63L);
                     (21L, Action.Reduce 63L);
                     (25L, Action.Reduce 63L);
                     (27L, Action.Reduce 63L);
@@ -11494,14 +9538,72 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 229 *) State.init
+            (* 167 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:229L
+                  ~index:167L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 102L prods) ~dot:3L in
+                            let lr0item = Lr0Item.init ~prod:(Array.get 21L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x1ffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.Reduce 21L);
+                    (3L, Action.Reduce 21L);
+                    (4L, Action.Reduce 21L);
+                    (5L, Action.Reduce 21L);
+                    (6L, Action.Reduce 21L);
+                    (7L, Action.Reduce 21L);
+                    (8L, Action.Reduce 21L);
+                    (9L, Action.Reduce 21L);
+                    (10L, Action.Reduce 21L);
+                    (11L, Action.Reduce 21L);
+                    (12L, Action.Reduce 21L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 168 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:168L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 101L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2820_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (20L, Action.ShiftPrefix 204L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 169 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:169L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 104L prods) ~dot:1L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
                                 Bitset.of_nat (Nat.of_string "0x2800_0000n")
                               ) in
@@ -11512,21 +9614,139 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (27L, Action.Reduce 102L);
-                    (29L, Action.Reduce 102L);
+                    (21L, Action.ShiftPrefix 205L);
+                    (27L, Action.Reduce 103L);
+                    (29L, Action.Reduce 103L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (76L, 206L);
+                  ]
+              );
+            (* 170 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:170L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 108L prods) ~dot:6L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (27L, Action.Reduce 108L);
+                    (29L, Action.Reduce 108L);
                   ]
               )
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 230 *) State.init
+            (* 171 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:230L
+                  ~index:171L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 80L prods) ~dot:4L in
+                            let lr0item = Lr0Item.init ~prod:(Array.get 95L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (20L, Action.Reduce 95L);
+                    (21L, Action.Reduce 95L);
+                    (27L, Action.Reduce 95L);
+                    (29L, Action.Reduce 95L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 172 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:172L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 89L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (13L, Action.ShiftPrefix 207L);
+                    (15L, Action.ShiftPrefix 141L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (67L, 208L);
+                  ]
+              );
+            (* 173 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:173L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 99L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (20L, Action.Reduce 98L);
+                    (21L, Action.ShiftPrefix 190L);
+                    (27L, Action.Reduce 98L);
+                    (29L, Action.Reduce 98L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (73L, 209L);
+                  ]
+              );
+            (* 174 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:174L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 71L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.singleton 19L
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 77L prods) ~dot:1L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
                                 Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
                               ) in
@@ -11537,20 +9757,209 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (24L, Action.Reduce 80L);
-                    (25L, Action.Reduce 80L);
-                    (26L, Action.Reduce 80L);
-                    (31L, Action.Reduce 80L);
-                    (39L, Action.Reduce 80L);
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 174L);
+                    (14L, Action.ShiftPrefix 175L);
+                    (19L, Action.Reduce 71L);
+                    (30L, Action.ShiftPrefix 176L);
+                    (38L, Action.ShiftPrefix 177L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 178L);
+                    (65L, 179L);
+                    (66L, 210L);
+                  ]
+              );
+            (* 175 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:175L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 73L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (24L, Action.Reduce 73L);
+                    (25L, Action.Reduce 73L);
+                    (26L, Action.Reduce 73L);
+                    (31L, Action.Reduce 73L);
+                    (39L, Action.Reduce 73L);
                   ]
               )
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 231 *) State.init
+            (* 176 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:231L
+                  ~index:176L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 76L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 174L);
+                    (14L, Action.ShiftPrefix 175L);
+                    (30L, Action.ShiftPrefix 176L);
+                    (38L, Action.ShiftPrefix 177L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 178L);
+                    (65L, 179L);
+                    (66L, 211L);
+                  ]
+              );
+            (* 177 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:177L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 80L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 181L);
+                    (62L, 182L);
+                    (63L, 212L);
+                  ]
+              );
+            (* 178 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:178L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 74L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (24L, Action.Reduce 74L);
+                    (25L, Action.Reduce 74L);
+                    (26L, Action.Reduce 74L);
+                    (31L, Action.Reduce 74L);
+                    (39L, Action.Reduce 74L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 179 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:179L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 72L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.singleton 19L
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 78L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 81L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (19L, Action.ShiftPrefix 213L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 180 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:180L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -11561,42 +9970,16 @@ include struct
                             lr0item, lr1item
                           );
                         (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 78L prods) ~dot:4L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                        (
                             let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:1L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
                                 Bitset.of_nat (Nat.of_string "0x8500_0000n")
                               ) in
                             lr0item, lr1item
                           );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (24L, Action.ShiftPrefix 165L);
-                    (26L, Action.ShiftPrefix 166L);
-                    (31L, Action.ShiftPrefix 247L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 232 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:232L
-                  ~kernel:(
-                    Lr1Itemset.init [
                         (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 81L prods) ~dot:4L in
+                            let lr0item = Lr0Item.init ~prod:(Array.get 85L prods) ~dot:2L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
                               ) in
                             lr0item, lr1item
                           );
@@ -11605,23 +9988,121 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (25L, Action.ShiftPrefix 170L);
+                    (24L, Action.ShiftPrefix 214L);
+                    (26L, Action.ShiftPrefix 215L);
+                    (31L, Action.ShiftPrefix 216L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 181 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:181L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 64L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 65L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (23L, Action.ShiftPrefix 217L);
+                    (25L, Action.Reduce 64L);
+                    (39L, Action.Reduce 64L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 182 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:182L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 66L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 67L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 68L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (25L, Action.ShiftPrefix 218L);
+                    (39L, Action.Reduce 66L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 183 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:183L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 87L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (25L, Action.ShiftPrefix 219L);
                     (39L, Action.Reduce 70L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (64L, 248L);
+                    (64L, 220L);
                   ]
               );
-            (* 233 *) State.init
+            (* 184 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:233L
+                  ~index:184L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 85L prods) ~dot:5L in
+                            let lr0item = Lr0Item.init ~prod:(Array.get 84L prods) ~dot:2L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
                                 Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
                               ) in
@@ -11632,41 +10113,138 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (2L, Action.Reduce 85L);
-                    (3L, Action.Reduce 85L);
-                    (4L, Action.Reduce 85L);
-                    (5L, Action.Reduce 85L);
-                    (6L, Action.Reduce 85L);
-                    (7L, Action.Reduce 85L);
-                    (8L, Action.Reduce 85L);
-                    (9L, Action.Reduce 85L);
-                    (10L, Action.Reduce 85L);
-                    (11L, Action.Reduce 85L);
-                    (12L, Action.Reduce 85L);
-                    (13L, Action.Reduce 85L);
-                    (14L, Action.Reduce 85L);
-                    (15L, Action.Reduce 85L);
-                    (20L, Action.Reduce 85L);
-                    (21L, Action.Reduce 85L);
-                    (27L, Action.Reduce 85L);
-                    (29L, Action.Reduce 85L);
-                    (30L, Action.Reduce 85L);
-                    (38L, Action.Reduce 85L);
+                    (13L, Action.ShiftPrefix 207L);
+                    (15L, Action.ShiftPrefix 141L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (67L, 221L);
+                  ]
+              );
+            (* 185 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:185L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 72L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.singleton 19L
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 86L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 88L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (13L, Action.ShiftPrefix 222L);
+                    (30L, Action.ShiftPrefix 223L);
+                    (38L, Action.ShiftPrefix 224L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (65L, 225L);
+                  ]
+              );
+            (* 186 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:186L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 9L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.singleton 18L
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 24L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (18L, Action.Reduce 9L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 104L);
+                  ]
+              );
+            (* 187 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:187L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 92L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (20L, Action.Reduce 92L);
+                    (21L, Action.Reduce 92L);
+                    (27L, Action.Reduce 92L);
+                    (29L, Action.Reduce 92L);
                   ]
               )
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 234 *) State.init
+            (* 188 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:234L
+                  ~index:188L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 87L prods) ~dot:5L in
+                            let lr0item = Lr0Item.init ~prod:(Array.get 91L prods) ~dot:1L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
                               ) in
                             lr0item, lr1item
                           );
@@ -11675,25 +10253,48 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (13L, Action.ShiftPrefix 158L);
-                    (15L, Action.ShiftPrefix 118L);
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 186L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 139L);
+                    (14L, Action.ShiftPrefix 140L);
+                    (15L, Action.ShiftPrefix 141L);
+                    (20L, Action.Reduce 25L);
+                    (21L, Action.Reduce 25L);
+                    (27L, Action.Reduce 25L);
+                    (29L, Action.Reduce 25L);
+                    (30L, Action.ShiftPrefix 143L);
+                    (38L, Action.ShiftPrefix 144L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (67L, 249L);
+                    (42L, 145L);
+                    (50L, 187L);
+                    (65L, 146L);
+                    (67L, 147L);
+                    (68L, 188L);
+                    (69L, 226L);
                   ]
               );
-            (* 235 *) State.init
+            (* 189 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:235L
+                  ~index:189L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 86L prods) ~dot:5L in
+                            let lr0item = Lr0Item.init ~prod:(Array.get 93L prods) ~dot:2L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
                               ) in
                             lr0item, lr1item
                           );
@@ -11702,22 +10303,25 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (18L, Action.ShiftPrefix 250L);
+                    (20L, Action.Reduce 93L);
+                    (21L, Action.Reduce 93L);
+                    (27L, Action.Reduce 93L);
+                    (29L, Action.Reduce 93L);
                   ]
               )
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 236 *) State.init
+            (* 190 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:236L
+                  ~index:190L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 88L prods) ~dot:5L in
+                            let lr0item = Lr0Item.init ~prod:(Array.get 97L prods) ~dot:1L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
                               ) in
                             lr0item, lr1item
                           );
@@ -11726,16 +10330,65 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (39L, Action.ShiftPrefix 251L);
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 138L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 139L);
+                    (14L, Action.ShiftPrefix 140L);
+                    (15L, Action.ShiftPrefix 141L);
+                    (30L, Action.ShiftPrefix 143L);
+                    (38L, Action.ShiftPrefix 144L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 145L);
+                    (65L, 146L);
+                    (67L, 147L);
+                    (68L, 148L);
+                    (70L, 149L);
+                    (71L, 150L);
+                    (72L, 227L);
+                  ]
+              );
+            (* 191 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:191L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 100L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (20L, Action.Reduce 100L);
+                    (27L, Action.Reduce 100L);
+                    (29L, Action.Reduce 100L);
                   ]
               )
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 237 *) State.init
+            (* 192 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:237L
+                  ~index:192L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -11794,10 +10447,144 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 238 *) State.init
+            (* 193 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:238L
+                  ~index:193L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 59L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0xaa_aa20_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
+                    (21L, Action.Reduce 61L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
+                    (25L, Action.Reduce 61L);
+                    (26L, Action.ShiftPrefix 121L);
+                    (27L, Action.Reduce 61L);
+                    (28L, Action.ShiftPrefix 122L);
+                    (29L, Action.Reduce 61L);
+                    (30L, Action.ShiftPrefix 123L);
+                    (31L, Action.Reduce 61L);
+                    (32L, Action.ShiftPrefix 124L);
+                    (33L, Action.Reduce 61L);
+                    (34L, Action.ShiftPrefix 125L);
+                    (35L, Action.Reduce 61L);
+                    (36L, Action.ShiftPrefix 126L);
+                    (37L, Action.Reduce 61L);
+                    (38L, Action.ShiftPrefix 127L);
+                    (39L, Action.Reduce 61L);
+                    (40L, Action.ShiftPrefix 128L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 129L);
+                    (58L, 193L);
+                    (59L, 194L);
+                    (60L, 202L);
+                  ]
+              );
+            (* 194 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:194L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 60L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0xaa_aa20_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
+                    (21L, Action.Reduce 61L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
+                    (25L, Action.Reduce 61L);
+                    (26L, Action.ShiftPrefix 121L);
+                    (27L, Action.Reduce 61L);
+                    (28L, Action.ShiftPrefix 122L);
+                    (29L, Action.Reduce 61L);
+                    (30L, Action.ShiftPrefix 123L);
+                    (31L, Action.Reduce 61L);
+                    (32L, Action.ShiftPrefix 124L);
+                    (33L, Action.Reduce 61L);
+                    (34L, Action.ShiftPrefix 125L);
+                    (35L, Action.Reduce 61L);
+                    (36L, Action.ShiftPrefix 126L);
+                    (37L, Action.Reduce 61L);
+                    (38L, Action.ShiftPrefix 127L);
+                    (39L, Action.Reduce 61L);
+                    (40L, Action.ShiftPrefix 128L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 129L);
+                    (58L, 193L);
+                    (59L, 194L);
+                    (60L, 203L);
+                  ]
+              );
+            (* 195 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:195L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -11823,39 +10610,39 @@ include struct
                     (10L, Action.ShiftPrefix 80L);
                     (11L, Action.ShiftPrefix 81L);
                     (12L, Action.ShiftPrefix 82L);
-                    (13L, Action.ShiftPrefix 179L);
-                    (14L, Action.ShiftPrefix 180L);
-                    (15L, Action.ShiftPrefix 181L);
-                    (16L, Action.ShiftPrefix 182L);
-                    (17L, Action.ShiftPrefix 183L);
-                    (18L, Action.ShiftPrefix 184L);
-                    (19L, Action.ShiftPrefix 185L);
-                    (20L, Action.ShiftPrefix 186L);
-                    (22L, Action.ShiftPrefix 187L);
-                    (23L, Action.ShiftPrefix 188L);
-                    (24L, Action.ShiftPrefix 189L);
-                    (26L, Action.ShiftPrefix 190L);
-                    (28L, Action.ShiftPrefix 191L);
-                    (30L, Action.ShiftPrefix 192L);
-                    (32L, Action.ShiftPrefix 193L);
-                    (34L, Action.ShiftPrefix 194L);
-                    (36L, Action.ShiftPrefix 195L);
-                    (38L, Action.ShiftPrefix 196L);
-                    (40L, Action.ShiftPrefix 197L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
+                    (26L, Action.ShiftPrefix 121L);
+                    (28L, Action.ShiftPrefix 122L);
+                    (30L, Action.ShiftPrefix 123L);
+                    (32L, Action.ShiftPrefix 124L);
+                    (34L, Action.ShiftPrefix 125L);
+                    (36L, Action.ShiftPrefix 126L);
+                    (38L, Action.ShiftPrefix 127L);
+                    (40L, Action.ShiftPrefix 128L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (42L, 198L);
-                    (58L, 199L);
-                    (59L, 200L);
-                    (61L, 252L);
+                    (42L, 129L);
+                    (58L, 154L);
+                    (59L, 155L);
+                    (61L, 228L);
                   ]
               );
-            (* 239 *) State.init
+            (* 196 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:239L
+                  ~index:196L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -11881,10 +10668,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 240 *) State.init
+            (* 197 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:240L
+                  ~index:197L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -11943,10 +10730,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 241 *) State.init
+            (* 198 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:241L
+                  ~index:198L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -12005,10 +10792,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 242 *) State.init
+            (* 199 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:242L
+                  ~index:199L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -12067,10 +10854,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 243 *) State.init
+            (* 200 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:243L
+                  ~index:200L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -12129,10 +10916,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 244 *) State.init
+            (* 201 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:244L
+                  ~index:201L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -12191,16 +10978,16 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 245 *) State.init
+            (* 202 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:245L
+                  ~index:202L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
                             let lr0item = Lr0Item.init ~prod:(Array.get 59L prods) ~dot:2L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0xaa_aa20_0000n")
+                                Bitset.of_nat (Nat.of_string "0xaa_aa20_0800n")
                               ) in
                             lr0item, lr1item
                           );
@@ -12209,6 +10996,7 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
+                    (11L, Action.Reduce 59L);
                     (21L, Action.Reduce 59L);
                     (25L, Action.Reduce 59L);
                     (27L, Action.Reduce 59L);
@@ -12223,16 +11011,16 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 246 *) State.init
+            (* 203 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:246L
+                  ~index:203L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
                             let lr0item = Lr0Item.init ~prod:(Array.get 60L prods) ~dot:2L in
                             let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0xaa_aa20_0000n")
+                                Bitset.of_nat (Nat.of_string "0xaa_aa20_0800n")
                               ) in
                             lr0item, lr1item
                           );
@@ -12241,6 +11029,7 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
+                    (11L, Action.Reduce 60L);
                     (21L, Action.Reduce 60L);
                     (25L, Action.Reduce 60L);
                     (27L, Action.Reduce 60L);
@@ -12255,10 +11044,1671 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
+            (* 204 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:204L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 101L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2820_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 110L);
+                    (14L, Action.ShiftPrefix 111L);
+                    (15L, Action.ShiftPrefix 112L);
+                    (16L, Action.ShiftPrefix 113L);
+                    (17L, Action.ShiftPrefix 114L);
+                    (18L, Action.ShiftPrefix 115L);
+                    (19L, Action.ShiftPrefix 116L);
+                    (20L, Action.ShiftPrefix 117L);
+                    (22L, Action.ShiftPrefix 118L);
+                    (23L, Action.ShiftPrefix 119L);
+                    (24L, Action.ShiftPrefix 120L);
+                    (26L, Action.ShiftPrefix 121L);
+                    (28L, Action.ShiftPrefix 122L);
+                    (30L, Action.ShiftPrefix 123L);
+                    (32L, Action.ShiftPrefix 124L);
+                    (34L, Action.ShiftPrefix 125L);
+                    (36L, Action.ShiftPrefix 126L);
+                    (38L, Action.ShiftPrefix 127L);
+                    (40L, Action.ShiftPrefix 128L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 129L);
+                    (58L, 154L);
+                    (59L, 155L);
+                    (61L, 229L);
+                  ]
+              );
+            (* 205 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:205L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 102L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 138L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 139L);
+                    (14L, Action.ShiftPrefix 140L);
+                    (15L, Action.ShiftPrefix 141L);
+                    (21L, Action.ShiftPrefix 142L);
+                    (30L, Action.ShiftPrefix 143L);
+                    (38L, Action.ShiftPrefix 144L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 145L);
+                    (65L, 146L);
+                    (67L, 147L);
+                    (68L, 148L);
+                    (70L, 149L);
+                    (71L, 150L);
+                    (72L, 151L);
+                    (74L, 168L);
+                    (75L, 230L);
+                  ]
+              );
+            (* 206 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:206L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 104L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (27L, Action.Reduce 104L);
+                    (29L, Action.Reduce 104L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 207 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:207L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 82L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.Reduce 82L);
+                    (3L, Action.Reduce 82L);
+                    (4L, Action.Reduce 82L);
+                    (5L, Action.Reduce 82L);
+                    (6L, Action.Reduce 82L);
+                    (7L, Action.Reduce 82L);
+                    (8L, Action.Reduce 82L);
+                    (9L, Action.Reduce 82L);
+                    (10L, Action.Reduce 82L);
+                    (11L, Action.Reduce 82L);
+                    (12L, Action.Reduce 82L);
+                    (13L, Action.Reduce 82L);
+                    (14L, Action.Reduce 82L);
+                    (15L, Action.Reduce 82L);
+                    (20L, Action.Reduce 82L);
+                    (21L, Action.Reduce 82L);
+                    (27L, Action.Reduce 82L);
+                    (29L, Action.Reduce 82L);
+                    (30L, Action.Reduce 82L);
+                    (38L, Action.Reduce 82L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 208 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:208L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 89L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.Reduce 89L);
+                    (3L, Action.Reduce 89L);
+                    (4L, Action.Reduce 89L);
+                    (5L, Action.Reduce 89L);
+                    (6L, Action.Reduce 89L);
+                    (7L, Action.Reduce 89L);
+                    (8L, Action.Reduce 89L);
+                    (9L, Action.Reduce 89L);
+                    (10L, Action.Reduce 89L);
+                    (11L, Action.Reduce 89L);
+                    (12L, Action.Reduce 89L);
+                    (13L, Action.Reduce 89L);
+                    (14L, Action.Reduce 89L);
+                    (15L, Action.Reduce 89L);
+                    (20L, Action.Reduce 89L);
+                    (21L, Action.Reduce 89L);
+                    (27L, Action.Reduce 89L);
+                    (29L, Action.Reduce 89L);
+                    (30L, Action.Reduce 89L);
+                    (38L, Action.Reduce 89L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 209 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:209L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 99L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (20L, Action.Reduce 99L);
+                    (27L, Action.Reduce 99L);
+                    (29L, Action.Reduce 99L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 210 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:210L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 77L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (24L, Action.Reduce 77L);
+                    (25L, Action.Reduce 77L);
+                    (26L, Action.Reduce 77L);
+                    (31L, Action.Reduce 77L);
+                    (39L, Action.Reduce 77L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 211 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:211L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x8500_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 76L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x8500_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (24L, Action.ShiftPrefix 214L);
+                    (26L, Action.ShiftPrefix 215L);
+                    (31L, Action.ShiftPrefix 231L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 212 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:212L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 80L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (25L, Action.ShiftPrefix 219L);
+                    (39L, Action.Reduce 70L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (64L, 232L);
+                  ]
+              );
+            (* 213 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:213L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 72L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.singleton 19L
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 78L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 81L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (13L, Action.ShiftPrefix 222L);
+                    (30L, Action.ShiftPrefix 233L);
+                    (38L, Action.ShiftPrefix 234L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (65L, 225L);
+                  ]
+              );
+            (* 214 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:214L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 174L);
+                    (14L, Action.ShiftPrefix 175L);
+                    (30L, Action.ShiftPrefix 176L);
+                    (38L, Action.ShiftPrefix 177L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 178L);
+                    (65L, 179L);
+                    (66L, 235L);
+                  ]
+              );
+            (* 215 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:215L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 236L);
+                  ]
+              );
+            (* 216 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:216L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 85L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (18L, Action.ShiftPrefix 237L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 217 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:217L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 65L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 174L);
+                    (14L, Action.ShiftPrefix 175L);
+                    (30L, Action.ShiftPrefix 176L);
+                    (38L, Action.ShiftPrefix 177L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 178L);
+                    (65L, 179L);
+                    (66L, 238L);
+                  ]
+              );
+            (* 218 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:218L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 67L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 68L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (14L, Action.ShiftPrefix 239L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 181L);
+                    (62L, 182L);
+                    (63L, 240L);
+                  ]
+              );
+            (* 219 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:219L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 69L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.singleton 39L
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (39L, Action.Reduce 69L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 220 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:220L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 87L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (39L, Action.ShiftPrefix 241L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 221 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:221L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 84L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.Reduce 84L);
+                    (3L, Action.Reduce 84L);
+                    (4L, Action.Reduce 84L);
+                    (5L, Action.Reduce 84L);
+                    (6L, Action.Reduce 84L);
+                    (7L, Action.Reduce 84L);
+                    (8L, Action.Reduce 84L);
+                    (9L, Action.Reduce 84L);
+                    (10L, Action.Reduce 84L);
+                    (11L, Action.Reduce 84L);
+                    (12L, Action.Reduce 84L);
+                    (13L, Action.Reduce 84L);
+                    (14L, Action.Reduce 84L);
+                    (15L, Action.Reduce 84L);
+                    (20L, Action.Reduce 84L);
+                    (21L, Action.Reduce 84L);
+                    (27L, Action.Reduce 84L);
+                    (29L, Action.Reduce 84L);
+                    (30L, Action.Reduce 84L);
+                    (38L, Action.Reduce 84L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 222 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:222L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 71L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.singleton 19L
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (19L, Action.Reduce 71L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 223 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:223L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 86L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 174L);
+                    (14L, Action.ShiftPrefix 175L);
+                    (30L, Action.ShiftPrefix 176L);
+                    (38L, Action.ShiftPrefix 177L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 178L);
+                    (65L, 179L);
+                    (66L, 242L);
+                  ]
+              );
+            (* 224 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:224L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 88L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 181L);
+                    (62L, 182L);
+                    (63L, 243L);
+                  ]
+              );
+            (* 225 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:225L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 72L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.singleton 19L
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 72L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.singleton 19L
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (19L, Action.Reduce 72L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 226 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:226L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 91L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2830_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (20L, Action.Reduce 91L);
+                    (21L, Action.Reduce 91L);
+                    (27L, Action.Reduce 91L);
+                    (29L, Action.Reduce 91L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 227 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:227L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 97L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (20L, Action.Reduce 98L);
+                    (21L, Action.ShiftPrefix 190L);
+                    (27L, Action.Reduce 98L);
+                    (29L, Action.Reduce 98L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (73L, 244L);
+                  ]
+              );
+            (* 228 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:228L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 34L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0xaa_a000_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (21L, Action.ShiftPrefix 20L);
+                    (25L, Action.ShiftPrefix 24L);
+                    (27L, Action.ShiftPrefix 26L);
+                    (29L, Action.Reduce 35L);
+                    (31L, Action.Reduce 35L);
+                    (33L, Action.Reduce 35L);
+                    (35L, Action.Reduce 35L);
+                    (37L, Action.Reduce 35L);
+                    (39L, Action.Reduce 35L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (54L, 195L);
+                    (55L, 245L);
+                  ]
+              );
+            (* 229 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:229L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 101L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2820_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (21L, Action.Reduce 101L);
+                    (27L, Action.Reduce 101L);
+                    (29L, Action.Reduce 101L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 230 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:230L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 102L prods) ~dot:2L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (21L, Action.ShiftPrefix 205L);
+                    (27L, Action.Reduce 103L);
+                    (29L, Action.Reduce 103L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (76L, 246L);
+                  ]
+              );
+            (* 231 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:231L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 76L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (24L, Action.Reduce 76L);
+                    (25L, Action.Reduce 76L);
+                    (26L, Action.Reduce 76L);
+                    (31L, Action.Reduce 76L);
+                    (39L, Action.Reduce 76L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 232 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:232L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 80L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (39L, Action.ShiftPrefix 247L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 233 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:233L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 78L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                    (13L, Action.ShiftPrefix 174L);
+                    (14L, Action.ShiftPrefix 175L);
+                    (30L, Action.ShiftPrefix 176L);
+                    (38L, Action.ShiftPrefix 177L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 178L);
+                    (65L, 179L);
+                    (66L, 248L);
+                  ]
+              );
+            (* 234 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:234L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 81L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.ShiftPrefix 72L);
+                    (3L, Action.ShiftPrefix 73L);
+                    (4L, Action.ShiftPrefix 74L);
+                    (5L, Action.ShiftPrefix 75L);
+                    (6L, Action.ShiftPrefix 76L);
+                    (7L, Action.ShiftPrefix 77L);
+                    (8L, Action.ShiftPrefix 78L);
+                    (9L, Action.ShiftPrefix 79L);
+                    (10L, Action.ShiftPrefix 80L);
+                    (11L, Action.ShiftPrefix 81L);
+                    (12L, Action.ShiftPrefix 82L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (42L, 181L);
+                    (62L, 182L);
+                    (63L, 249L);
+                  ]
+              );
+            (* 235 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:235L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (24L, Action.Reduce 79L);
+                    (25L, Action.Reduce 79L);
+                    (26L, Action.Reduce 79L);
+                    (31L, Action.Reduce 79L);
+                    (39L, Action.Reduce 79L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 236 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:236L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (24L, Action.Reduce 75L);
+                    (25L, Action.Reduce 75L);
+                    (26L, Action.Reduce 75L);
+                    (31L, Action.Reduce 75L);
+                    (39L, Action.Reduce 75L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 237 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:237L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 85L prods) ~dot:4L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (13L, Action.ShiftPrefix 207L);
+                    (15L, Action.ShiftPrefix 141L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (67L, 250L);
+                  ]
+              );
+            (* 238 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:238L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 65L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_0700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_0700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (24L, Action.ShiftPrefix 214L);
+                    (25L, Action.Reduce 65L);
+                    (26L, Action.ShiftPrefix 215L);
+                    (39L, Action.Reduce 65L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 239 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:239L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 67L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (25L, Action.Reduce 67L);
+                    (39L, Action.Reduce 67L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 240 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:240L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 68L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_0200_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (25L, Action.Reduce 68L);
+                    (39L, Action.Reduce 68L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 241 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:241L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 87L prods) ~dot:4L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (18L, Action.ShiftPrefix 251L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 242 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:242L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x8500_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x8500_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 86L prods) ~dot:4L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (24L, Action.ShiftPrefix 214L);
+                    (26L, Action.ShiftPrefix 215L);
+                    (31L, Action.ShiftPrefix 252L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 243 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:243L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 88L prods) ~dot:4L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (25L, Action.ShiftPrefix 219L);
+                    (39L, Action.Reduce 70L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (64L, 253L);
+                  ]
+              );
+            (* 244 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:244L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 97L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2810_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (20L, Action.Reduce 97L);
+                    (27L, Action.Reduce 97L);
+                    (29L, Action.Reduce 97L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 245 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:245L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 34L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0xaa_a000_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (29L, Action.Reduce 34L);
+                    (31L, Action.Reduce 34L);
+                    (33L, Action.Reduce 34L);
+                    (35L, Action.Reduce 34L);
+                    (37L, Action.Reduce 34L);
+                    (39L, Action.Reduce 34L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 246 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:246L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 102L prods) ~dot:3L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x2800_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (27L, Action.Reduce 102L);
+                    (29L, Action.Reduce 102L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
             (* 247 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
                   ~index:247L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 80L prods) ~dot:4L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (24L, Action.Reduce 80L);
+                    (25L, Action.Reduce 80L);
+                    (26L, Action.Reduce 80L);
+                    (31L, Action.Reduce 80L);
+                    (39L, Action.Reduce 80L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 248 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:248L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 75L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x8500_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 78L prods) ~dot:4L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 79L prods) ~dot:1L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x8500_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (24L, Action.ShiftPrefix 214L);
+                    (26L, Action.ShiftPrefix 215L);
+                    (31L, Action.ShiftPrefix 254L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 249 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:249L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 81L prods) ~dot:4L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x80_8700_0000n")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (25L, Action.ShiftPrefix 219L);
+                    (39L, Action.Reduce 70L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (64L, 255L);
+                  ]
+              );
+            (* 250 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:250L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 85L prods) ~dot:5L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (2L, Action.Reduce 85L);
+                    (3L, Action.Reduce 85L);
+                    (4L, Action.Reduce 85L);
+                    (5L, Action.Reduce 85L);
+                    (6L, Action.Reduce 85L);
+                    (7L, Action.Reduce 85L);
+                    (8L, Action.Reduce 85L);
+                    (9L, Action.Reduce 85L);
+                    (10L, Action.Reduce 85L);
+                    (11L, Action.Reduce 85L);
+                    (12L, Action.Reduce 85L);
+                    (13L, Action.Reduce 85L);
+                    (14L, Action.Reduce 85L);
+                    (15L, Action.Reduce 85L);
+                    (20L, Action.Reduce 85L);
+                    (21L, Action.Reduce 85L);
+                    (27L, Action.Reduce 85L);
+                    (29L, Action.Reduce 85L);
+                    (30L, Action.Reduce 85L);
+                    (38L, Action.Reduce 85L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 251 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:251L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 87L prods) ~dot:5L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (13L, Action.ShiftPrefix 207L);
+                    (15L, Action.ShiftPrefix 141L);
+                  ]
+              )
+              ~gotos:(
+                Map.of_alist (module Uns) [
+                    (67L, 256L);
+                  ]
+              );
+            (* 252 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:252L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 86L prods) ~dot:5L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (18L, Action.ShiftPrefix 257L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 253 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:253L
+                  ~kernel:(
+                    Lr1Itemset.init [
+                        (
+                            let lr0item = Lr0Item.init ~prod:(Array.get 88L prods) ~dot:5L in
+                            let lr1item = Lr1Item.init ~lr0item ~follow:(
+                                Bitset.of_nat (Nat.of_string "0x40_6830_fffcn")
+                              ) in
+                            lr0item, lr1item
+                          );
+                      ]
+                  )
+              )
+              ~actions:(
+                Map.of_alist (module Uns) [
+                    (39L, Action.ShiftPrefix 258L);
+                  ]
+              )
+              ~gotos:(
+                Map.empty (module Uns)
+              );
+            (* 254 *) State.init
+              ~lr1ItemsetClosure:(
+                Lr1ItemsetClosure.init
+                  ~index:254L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -12283,10 +12733,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 248 *) State.init
+            (* 255 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:248L
+                  ~index:255L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -12301,16 +12751,16 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (39L, Action.ShiftPrefix 253L);
+                    (39L, Action.ShiftPrefix 259L);
                   ]
               )
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 249 *) State.init
+            (* 256 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:249L
+                  ~index:256L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -12350,10 +12800,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 250 *) State.init
+            (* 257 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:250L
+                  ~index:257L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -12368,19 +12818,19 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (13L, Action.ShiftPrefix 158L);
-                    (15L, Action.ShiftPrefix 118L);
+                    (13L, Action.ShiftPrefix 207L);
+                    (15L, Action.ShiftPrefix 141L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (67L, 254L);
+                    (67L, 260L);
                   ]
               );
-            (* 251 *) State.init
+            (* 258 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:251L
+                  ~index:258L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -12395,51 +12845,16 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (18L, Action.ShiftPrefix 255L);
+                    (18L, Action.ShiftPrefix 261L);
                   ]
               )
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 252 *) State.init
+            (* 259 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:252L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 34L prods) ~dot:2L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0xaa_a000_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (21L, Action.ShiftPrefix 20L);
-                    (25L, Action.ShiftPrefix 24L);
-                    (27L, Action.ShiftPrefix 26L);
-                    (29L, Action.Reduce 35L);
-                    (31L, Action.Reduce 35L);
-                    (33L, Action.Reduce 35L);
-                    (35L, Action.Reduce 35L);
-                    (37L, Action.Reduce 35L);
-                    (39L, Action.Reduce 35L);
-                  ]
-              )
-              ~gotos:(
-                Map.of_alist (module Uns) [
-                    (54L, 238L);
-                    (55L, 256L);
-                  ]
-              );
-            (* 253 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:253L
+                  ~index:259L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -12464,10 +12879,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 254 *) State.init
+            (* 260 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:254L
+                  ~index:260L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -12507,10 +12922,10 @@ include struct
               ~gotos:(
                 Map.empty (module Uns)
               );
-            (* 255 *) State.init
+            (* 261 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:255L
+                  ~index:261L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -12525,48 +12940,19 @@ include struct
               )
               ~actions:(
                 Map.of_alist (module Uns) [
-                    (13L, Action.ShiftPrefix 158L);
-                    (15L, Action.ShiftPrefix 118L);
+                    (13L, Action.ShiftPrefix 207L);
+                    (15L, Action.ShiftPrefix 141L);
                   ]
               )
               ~gotos:(
                 Map.of_alist (module Uns) [
-                    (67L, 257L);
+                    (67L, 262L);
                   ]
               );
-            (* 256 *) State.init
+            (* 262 *) State.init
               ~lr1ItemsetClosure:(
                 Lr1ItemsetClosure.init
-                  ~index:256L
-                  ~kernel:(
-                    Lr1Itemset.init [
-                        (
-                            let lr0item = Lr0Item.init ~prod:(Array.get 34L prods) ~dot:3L in
-                            let lr1item = Lr1Item.init ~lr0item ~follow:(
-                                Bitset.of_nat (Nat.of_string "0xaa_a000_0000n")
-                              ) in
-                            lr0item, lr1item
-                          );
-                      ]
-                  )
-              )
-              ~actions:(
-                Map.of_alist (module Uns) [
-                    (29L, Action.Reduce 34L);
-                    (31L, Action.Reduce 34L);
-                    (33L, Action.Reduce 34L);
-                    (35L, Action.Reduce 34L);
-                    (37L, Action.Reduce 34L);
-                    (39L, Action.Reduce 34L);
-                  ]
-              )
-              ~gotos:(
-                Map.empty (module Uns)
-              );
-            (* 257 *) State.init
-              ~lr1ItemsetClosure:(
-                Lr1ItemsetClosure.init
-                  ~index:257L
+                  ~index:262L
                   ~kernel:(
                     Lr1Itemset.init [
                         (
@@ -12699,6 +13085,91 @@ include struct
               | OTHER_TOKEN _ -> 40L
               | EOI _ -> 41L
 
+            let protos = [|
+                EPSILON;
+                PSEUDO_END;
+#337 "./Parse.hmh"
+                HOCC proto_hocc;
+#338 "./Parse.hmh"
+                NONTERM proto_nonterm;
+#339 "./Parse.hmh"
+                EPSILON_ proto_epsilon;
+#340 "./Parse.hmh"
+                START proto_start;
+#341 "./Parse.hmh"
+                TOKEN proto_token;
+#342 "./Parse.hmh"
+                NEUTRAL proto_neutral;
+#343 "./Parse.hmh"
+                LEFT proto_left;
+#344 "./Parse.hmh"
+                RIGHT proto_right;
+#345 "./Parse.hmh"
+                NONASSOC proto_nonassoc;
+#346 "./Parse.hmh"
+                PREC proto_prec;
+#349 "./Parse.hmh"
+                UIDENT proto_uident;
+#351 "./Parse.hmh"
+                CIDENT proto_cident;
+#352 "./Parse.hmh"
+                USCORE proto_uscore;
+#355 "./Parse.hmh"
+                ISTRING proto_istring;
+#358 "./Parse.hmh"
+                COLON_COLON_EQ proto_colon_colon_eq;
+#359 "./Parse.hmh"
+                OF proto_of;
+#360 "./Parse.hmh"
+                COLON proto_colon;
+#362 "./Parse.hmh"
+                DOT proto_dot;
+#363 "./Parse.hmh"
+                ARROW proto_arrow;
+#364 "./Parse.hmh"
+                BAR proto_bar;
+#365 "./Parse.hmh"
+                LT proto_lt;
+#366 "./Parse.hmh"
+                EQ proto_eq;
+#368 "./Parse.hmh"
+                COMMA proto_comma;
+#370 "./Parse.hmh"
+                SEMI proto_semi;
+#372 "./Parse.hmh"
+                AS proto_as;
+#373 "./Parse.hmh"
+                LINE_DELIM proto_line_delim;
+#376 "./Parse.hmh"
+                INDENT proto_indent;
+#377 "./Parse.hmh"
+                DEDENT proto_dedent;
+#378 "./Parse.hmh"
+                LPAREN proto_lparen;
+#379 "./Parse.hmh"
+                RPAREN proto_rparen;
+#380 "./Parse.hmh"
+                LCAPTURE proto_lcapture;
+#381 "./Parse.hmh"
+                RCAPTURE proto_rcapture;
+#382 "./Parse.hmh"
+                LBRACK proto_lbrack;
+#383 "./Parse.hmh"
+                RBRACK proto_rbrack;
+#384 "./Parse.hmh"
+                LARRAY proto_larray;
+#385 "./Parse.hmh"
+                RARRAY proto_rarray;
+#386 "./Parse.hmh"
+                LCURLY proto_lcurly;
+#387 "./Parse.hmh"
+                RCURLY proto_rcurly;
+#390 "./Parse.hmh"
+                OTHER_TOKEN proto_other_token;
+#393 "./Parse.hmh"
+                EOI proto_eoi
+              |]
+
             let hash_fold t state =
                 state |> Uns.hash_fold (index t)
 
@@ -12727,9 +13198,9 @@ include struct
               | PrecSet of nonterm_prec_set
               | SymbolTypeQualifier of nonterm_symbol_type_qualifier
               | SymbolType of nonterm_symbol_type
-              | SymbolType0 of nonterm_symbol_type0
               | PrecRef of nonterm_prec_ref
-              | TokenAlias of nonterm_token_alias
+              | Alias of nonterm_alias
+              | TokenType of nonterm_token_type
               | Token of nonterm_token
               | Sep of nonterm_sep
               | CodesTl of nonterm_codes_tl
@@ -12777,9 +13248,9 @@ include struct
               | PrecSet _ -> 47L
               | SymbolTypeQualifier _ -> 48L
               | SymbolType _ -> 49L
-              | SymbolType0 _ -> 50L
-              | PrecRef _ -> 51L
-              | TokenAlias _ -> 52L
+              | PrecRef _ -> 50L
+              | Alias _ -> 51L
+              | TokenType _ -> 52L
               | Token _ -> 53L
               | Sep _ -> 54L
               | CodesTl _ -> 55L
@@ -12950,7 +13421,7 @@ include struct
                   | Elm.{symbol=Symbol.Token (HOCC (HOCC {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Uident (
                   (*______________________________________________________________________________*)
-#349 "./Parse.hmh"
+#407 "./Parse.hmh"
 Uident {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -12960,7 +13431,7 @@ Uident {token}
                   | Elm.{symbol=Symbol.Token (NONTERM (NONTERM {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Uident (
                   (*______________________________________________________________________________*)
-#349 "./Parse.hmh"
+#407 "./Parse.hmh"
 Uident {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -12970,7 +13441,7 @@ Uident {token}
                   | Elm.{symbol=Symbol.Token (EPSILON_ (EPSILON {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Uident (
                   (*______________________________________________________________________________*)
-#349 "./Parse.hmh"
+#407 "./Parse.hmh"
 Uident {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -12980,7 +13451,7 @@ Uident {token}
                   | Elm.{symbol=Symbol.Token (START (START {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Uident (
                   (*______________________________________________________________________________*)
-#349 "./Parse.hmh"
+#407 "./Parse.hmh"
 Uident {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -12990,7 +13461,7 @@ Uident {token}
                   | Elm.{symbol=Symbol.Token (TOKEN (TOKEN {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Uident (
                   (*______________________________________________________________________________*)
-#349 "./Parse.hmh"
+#407 "./Parse.hmh"
 Uident {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13000,7 +13471,7 @@ Uident {token}
                   | Elm.{symbol=Symbol.Token (NEUTRAL (NEUTRAL {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Uident (
                   (*______________________________________________________________________________*)
-#349 "./Parse.hmh"
+#407 "./Parse.hmh"
 Uident {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13010,7 +13481,7 @@ Uident {token}
                   | Elm.{symbol=Symbol.Token (LEFT (LEFT {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Uident (
                   (*______________________________________________________________________________*)
-#349 "./Parse.hmh"
+#407 "./Parse.hmh"
 Uident {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13020,7 +13491,7 @@ Uident {token}
                   | Elm.{symbol=Symbol.Token (RIGHT (RIGHT {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Uident (
                   (*______________________________________________________________________________*)
-#349 "./Parse.hmh"
+#407 "./Parse.hmh"
 Uident {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13030,7 +13501,7 @@ Uident {token}
                   | Elm.{symbol=Symbol.Token (NONASSOC (NONASSOC {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Uident (
                   (*______________________________________________________________________________*)
-#349 "./Parse.hmh"
+#407 "./Parse.hmh"
 Uident {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13040,7 +13511,7 @@ Uident {token}
                   | Elm.{symbol=Symbol.Token (PREC (PREC {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Uident (
                   (*______________________________________________________________________________*)
-#349 "./Parse.hmh"
+#407 "./Parse.hmh"
 Uident {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13050,7 +13521,7 @@ Uident {token}
                   | Elm.{symbol=Symbol.Token (UIDENT (UIDENT {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Uident (
                   (*______________________________________________________________________________*)
-#349 "./Parse.hmh"
+#407 "./Parse.hmh"
 Uident {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13062,7 +13533,7 @@ Uident {token}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (PrecsTl (
                   (*______________________________________________________________________________*)
-#352 "./Parse.hmh"
+#410 "./Parse.hmh"
 PrecsTlUident {uident=token; precs_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13071,7 +13542,7 @@ PrecsTlUident {uident=token; precs_tl}
                 (* 12 *) (function
                   tl__hocc__ -> Symbol.Nonterm (PrecsTl (
                   (*______________________________________________________________________________*)
-#353 "./Parse.hmh"
+#411 "./Parse.hmh"
 PrecsTlEpsilon
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13081,7 +13552,7 @@ PrecsTlEpsilon
                   :: Elm.{symbol=Symbol.Nonterm (Uident (Uident {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Precs (
                   (*______________________________________________________________________________*)
-#356 "./Parse.hmh"
+#414 "./Parse.hmh"
 Precs {uident=token; precs_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13092,7 +13563,7 @@ Precs {uident=token; precs_tl}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (PrecRels (
                   (*______________________________________________________________________________*)
-#359 "./Parse.hmh"
+#417 "./Parse.hmh"
 PrecRelsPrecs {precs}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13101,7 +13572,7 @@ PrecRelsPrecs {precs}
                 (* 15 *) (function
                   tl__hocc__ -> Symbol.Nonterm (PrecRels (
                   (*______________________________________________________________________________*)
-#360 "./Parse.hmh"
+#418 "./Parse.hmh"
 PrecRelsEpsilon
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13110,7 +13581,7 @@ PrecRelsEpsilon
                   | _
                   :: tl__hocc__ -> Symbol.Nonterm (PrecType (
                   (*______________________________________________________________________________*)
-#363 "./Parse.hmh"
+#421 "./Parse.hmh"
 PrecTypeNeutral
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13120,7 +13591,7 @@ PrecTypeNeutral
                   | _
                   :: tl__hocc__ -> Symbol.Nonterm (PrecType (
                   (*______________________________________________________________________________*)
-#364 "./Parse.hmh"
+#422 "./Parse.hmh"
 PrecTypeLeft
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13130,7 +13601,7 @@ PrecTypeLeft
                   | _
                   :: tl__hocc__ -> Symbol.Nonterm (PrecType (
                   (*______________________________________________________________________________*)
-#365 "./Parse.hmh"
+#423 "./Parse.hmh"
 PrecTypeRight
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13140,7 +13611,7 @@ PrecTypeRight
                   | _
                   :: tl__hocc__ -> Symbol.Nonterm (PrecType (
                   (*______________________________________________________________________________*)
-#366 "./Parse.hmh"
+#424 "./Parse.hmh"
 PrecTypeNonassoc
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13152,7 +13623,7 @@ PrecTypeNonassoc
                   :: Elm.{symbol=Symbol.Nonterm (PrecType prec_type); _}
                   :: tl__hocc__ -> Symbol.Nonterm (PrecSet (
                   (*______________________________________________________________________________*)
-#370 "./Parse.hmh"
+#428 "./Parse.hmh"
 PrecSet {prec_type; prec_set; prec_rels}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13164,7 +13635,7 @@ PrecSet {prec_type; prec_set; prec_rels}
                   :: Elm.{symbol=Symbol.Token (CIDENT cident); _}
                   :: tl__hocc__ -> Symbol.Nonterm (SymbolTypeQualifier (
                   (*______________________________________________________________________________*)
-#374 "./Parse.hmh"
+#432 "./Parse.hmh"
 SymbolTypeQualifier {cident; symbol_type_qualifier_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13173,7 +13644,7 @@ SymbolTypeQualifier {cident; symbol_type_qualifier_tl}
                 (* 22 *) (function
                   tl__hocc__ -> Symbol.Nonterm (SymbolTypeQualifier (
                   (*______________________________________________________________________________*)
-#375 "./Parse.hmh"
+#433 "./Parse.hmh"
 SymbolTypeQualifierEpsilon
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13184,77 +13655,78 @@ SymbolTypeQualifierEpsilon
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (SymbolType (
                   (*______________________________________________________________________________*)
-#379 "./Parse.hmh"
+#437 "./Parse.hmh"
 SymbolType {symbol_type_qualifier; symbol_type=token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
                   | _ -> not_reached ()
                 );
                 (* 24 *) (function
-                  | Elm.{symbol=Symbol.Nonterm (SymbolType symbol_type); _}
-                  :: tl__hocc__ -> Symbol.Nonterm (SymbolType0 (
-                  (*______________________________________________________________________________*)
-#382 "./Parse.hmh"
-SymbolType0SymbolType {symbol_type}
-                  (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
-                  )), tl__hocc__
-                  | _ -> not_reached ()
-                );
-                (* 25 *) (function
-                  tl__hocc__ -> Symbol.Nonterm (SymbolType0 (
-                  (*______________________________________________________________________________*)
-#383 "./Parse.hmh"
-SymbolType0Epsilon
-                  (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
-                  )), tl__hocc__
-                );
-                (* 26 *) (function
                   | Elm.{symbol=Symbol.Nonterm (Uident (Uident {token})); _}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (PrecRef (
                   (*______________________________________________________________________________*)
-#386 "./Parse.hmh"
+#440 "./Parse.hmh"
 PrecRefUident {uident=token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
                   | _ -> not_reached ()
                 );
-                (* 27 *) (function
+                (* 25 *) (function
                   tl__hocc__ -> Symbol.Nonterm (PrecRef (
                   (*______________________________________________________________________________*)
-#387 "./Parse.hmh"
+#441 "./Parse.hmh"
 PrecRefEpsilon
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
                 );
-                (* 28 *) (function
+                (* 26 *) (function
                   | Elm.{symbol=Symbol.Token (ISTRING alias); _}
-                  :: tl__hocc__ -> Symbol.Nonterm (TokenAlias (
+                  :: tl__hocc__ -> Symbol.Nonterm (Alias (
                   (*______________________________________________________________________________*)
-#390 "./Parse.hmh"
-TokenAlias {alias}
+#444 "./Parse.hmh"
+Alias {alias}
+                  (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
+                  )), tl__hocc__
+                  | _ -> not_reached ()
+                );
+                (* 27 *) (function
+                  tl__hocc__ -> Symbol.Nonterm (Alias (
+                  (*______________________________________________________________________________*)
+#445 "./Parse.hmh"
+AliasEpsilon
+                  (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
+                  )), tl__hocc__
+                );
+                (* 28 *) (function
+                  | Elm.{symbol=Symbol.Nonterm (Code proto); _}
+                  :: Elm.{symbol=Symbol.Nonterm (SymbolType symbol_type); _}
+                  :: tl__hocc__ -> Symbol.Nonterm (TokenType (
+                  (*______________________________________________________________________________*)
+#448 "./Parse.hmh"
+TokenType {symbol_type; proto}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
                   | _ -> not_reached ()
                 );
                 (* 29 *) (function
-                  tl__hocc__ -> Symbol.Nonterm (TokenAlias (
+                  tl__hocc__ -> Symbol.Nonterm (TokenType (
                   (*______________________________________________________________________________*)
-#391 "./Parse.hmh"
-TokenAliasEpsilon
+#449 "./Parse.hmh"
+TokenTypeEpsilon
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
                 );
                 (* 30 *) (function
                   | Elm.{symbol=Symbol.Nonterm (PrecRef prec_ref); _}
-                  :: Elm.{symbol=Symbol.Nonterm (SymbolType0 symbol_type0); _}
-                  :: Elm.{symbol=Symbol.Nonterm (TokenAlias token_alias); _}
+                  :: Elm.{symbol=Symbol.Nonterm (TokenType token_type); _}
+                  :: Elm.{symbol=Symbol.Nonterm (Alias alias); _}
                   :: Elm.{symbol=Symbol.Token (CIDENT cident); _}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (Token (
                   (*______________________________________________________________________________*)
-#395 "./Parse.hmh"
-Token {cident; token_alias; symbol_type0; prec_ref}
+#453 "./Parse.hmh"
+Token {cident; alias; token_type; prec_ref}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
                   | _ -> not_reached ()
@@ -13263,7 +13735,7 @@ Token {cident; token_alias; symbol_type0; prec_ref}
                   | Elm.{symbol=Symbol.Token (LINE_DELIM line_delim); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Sep (
                   (*______________________________________________________________________________*)
-#398 "./Parse.hmh"
+#456 "./Parse.hmh"
 SepLineDelim {line_delim}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13273,7 +13745,7 @@ SepLineDelim {line_delim}
                   | Elm.{symbol=Symbol.Token (SEMI semi); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Sep (
                   (*______________________________________________________________________________*)
-#399 "./Parse.hmh"
+#457 "./Parse.hmh"
 SepSemi {semi}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13283,7 +13755,7 @@ SepSemi {semi}
                   | Elm.{symbol=Symbol.Token (BAR bar); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Sep (
                   (*______________________________________________________________________________*)
-#400 "./Parse.hmh"
+#458 "./Parse.hmh"
 SepBar {bar}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13295,7 +13767,7 @@ SepBar {bar}
                   :: Elm.{symbol=Symbol.Nonterm (Sep sep); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodesTl (
                   (*______________________________________________________________________________*)
-#403 "./Parse.hmh"
+#461 "./Parse.hmh"
 CodesTlSepCode {sep; code; codes_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13304,7 +13776,7 @@ CodesTlSepCode {sep; code; codes_tl}
                 (* 35 *) (function
                   tl__hocc__ -> Symbol.Nonterm (CodesTl (
                   (*______________________________________________________________________________*)
-#404 "./Parse.hmh"
+#462 "./Parse.hmh"
 CodesTlEpsilon
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13314,7 +13786,7 @@ CodesTlEpsilon
                   :: Elm.{symbol=Symbol.Nonterm (Code code); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Codes (
                   (*______________________________________________________________________________*)
-#407 "./Parse.hmh"
+#465 "./Parse.hmh"
 Codes {code; codes_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13324,7 +13796,7 @@ Codes {code; codes_tl}
                   | Elm.{symbol=Symbol.Nonterm (Codes codes); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Codes0 (
                   (*______________________________________________________________________________*)
-#410 "./Parse.hmh"
+#468 "./Parse.hmh"
 Codes0Codes {codes}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13333,7 +13805,7 @@ Codes0Codes {codes}
                 (* 38 *) (function
                   tl__hocc__ -> Symbol.Nonterm (Codes0 (
                   (*______________________________________________________________________________*)
-#411 "./Parse.hmh"
+#469 "./Parse.hmh"
 Codes0Epsilon
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13344,7 +13816,7 @@ Codes0Epsilon
                   :: Elm.{symbol=Symbol.Token (INDENT indent); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Delimited (
                   (*______________________________________________________________________________*)
-#414 "./Parse.hmh"
+#472 "./Parse.hmh"
 DelimitedBlock {indent; codes; dedent}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13356,7 +13828,7 @@ DelimitedBlock {indent; codes; dedent}
                   :: Elm.{symbol=Symbol.Token (LPAREN lparen); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Delimited (
                   (*______________________________________________________________________________*)
-#415 "./Parse.hmh"
+#473 "./Parse.hmh"
 DelimitedParen {lparen; codes0; rparen}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13368,7 +13840,7 @@ DelimitedParen {lparen; codes0; rparen}
                   :: Elm.{symbol=Symbol.Token (LCAPTURE lcapture); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Delimited (
                   (*______________________________________________________________________________*)
-#416 "./Parse.hmh"
+#474 "./Parse.hmh"
 DelimitedCapture {lcapture; codes0; rcapture}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13380,7 +13852,7 @@ DelimitedCapture {lcapture; codes0; rcapture}
                   :: Elm.{symbol=Symbol.Token (LBRACK lbrack); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Delimited (
                   (*______________________________________________________________________________*)
-#417 "./Parse.hmh"
+#475 "./Parse.hmh"
 DelimitedList {lbrack; codes0; rbrack}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13392,7 +13864,7 @@ DelimitedList {lbrack; codes0; rbrack}
                   :: Elm.{symbol=Symbol.Token (LARRAY larray); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Delimited (
                   (*______________________________________________________________________________*)
-#418 "./Parse.hmh"
+#476 "./Parse.hmh"
 DelimitedArray {larray; codes0; rarray}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13404,7 +13876,7 @@ DelimitedArray {larray; codes0; rarray}
                   :: Elm.{symbol=Symbol.Token (LCURLY lcurly); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Delimited (
                   (*______________________________________________________________________________*)
-#419 "./Parse.hmh"
+#477 "./Parse.hmh"
 DelimitedModule {lcurly; codes0; rcurly}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13414,7 +13886,7 @@ DelimitedModule {lcurly; codes0; rcurly}
                   | Elm.{symbol=Symbol.Token (OTHER_TOKEN (OTHER_TOKEN {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeToken (
                   (*______________________________________________________________________________*)
-#436 "./Parse.hmh"
+#494 "./Parse.hmh"
 CodeToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13424,7 +13896,7 @@ CodeToken {token}
                   | Elm.{symbol=Symbol.Nonterm (Uident (Uident {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeToken (
                   (*______________________________________________________________________________*)
-#436 "./Parse.hmh"
+#494 "./Parse.hmh"
 CodeToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13434,7 +13906,7 @@ CodeToken {token}
                   | Elm.{symbol=Symbol.Token (CIDENT (CIDENT {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeToken (
                   (*______________________________________________________________________________*)
-#436 "./Parse.hmh"
+#494 "./Parse.hmh"
 CodeToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13444,7 +13916,7 @@ CodeToken {token}
                   | Elm.{symbol=Symbol.Token (USCORE (USCORE {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeToken (
                   (*______________________________________________________________________________*)
-#436 "./Parse.hmh"
+#494 "./Parse.hmh"
 CodeToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13454,7 +13926,7 @@ CodeToken {token}
                   | Elm.{symbol=Symbol.Token (ISTRING (ISTRING {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeToken (
                   (*______________________________________________________________________________*)
-#436 "./Parse.hmh"
+#494 "./Parse.hmh"
 CodeToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13464,7 +13936,7 @@ CodeToken {token}
                   | Elm.{symbol=Symbol.Token (COLON_COLON_EQ (COLON_COLON_EQ {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeToken (
                   (*______________________________________________________________________________*)
-#436 "./Parse.hmh"
+#494 "./Parse.hmh"
 CodeToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13474,7 +13946,7 @@ CodeToken {token}
                   | Elm.{symbol=Symbol.Token (AS (AS {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeToken (
                   (*______________________________________________________________________________*)
-#436 "./Parse.hmh"
+#494 "./Parse.hmh"
 CodeToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13484,7 +13956,7 @@ CodeToken {token}
                   | Elm.{symbol=Symbol.Token (OF (OF {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeToken (
                   (*______________________________________________________________________________*)
-#436 "./Parse.hmh"
+#494 "./Parse.hmh"
 CodeToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13494,7 +13966,7 @@ CodeToken {token}
                   | Elm.{symbol=Symbol.Token (COLON (COLON {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeToken (
                   (*______________________________________________________________________________*)
-#436 "./Parse.hmh"
+#494 "./Parse.hmh"
 CodeToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13504,7 +13976,7 @@ CodeToken {token}
                   | Elm.{symbol=Symbol.Token (DOT (DOT {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeToken (
                   (*______________________________________________________________________________*)
-#436 "./Parse.hmh"
+#494 "./Parse.hmh"
 CodeToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13514,7 +13986,7 @@ CodeToken {token}
                   | Elm.{symbol=Symbol.Token (ARROW (ARROW {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeToken (
                   (*______________________________________________________________________________*)
-#436 "./Parse.hmh"
+#494 "./Parse.hmh"
 CodeToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13524,7 +13996,7 @@ CodeToken {token}
                   | Elm.{symbol=Symbol.Token (LT (LT {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeToken (
                   (*______________________________________________________________________________*)
-#436 "./Parse.hmh"
+#494 "./Parse.hmh"
 CodeToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13534,7 +14006,7 @@ CodeToken {token}
                   | Elm.{symbol=Symbol.Token (EQ (EQ {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeToken (
                   (*______________________________________________________________________________*)
-#436 "./Parse.hmh"
+#494 "./Parse.hmh"
 CodeToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13544,7 +14016,7 @@ CodeToken {token}
                   | Elm.{symbol=Symbol.Token (COMMA (COMMA {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeToken (
                   (*______________________________________________________________________________*)
-#436 "./Parse.hmh"
+#494 "./Parse.hmh"
 CodeToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13555,7 +14027,7 @@ CodeToken {token}
                   :: Elm.{symbol=Symbol.Nonterm (Delimited delimited); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeTl (
                   (*______________________________________________________________________________*)
-#439 "./Parse.hmh"
+#497 "./Parse.hmh"
 CodeTlDelimited {delimited; code_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13566,7 +14038,7 @@ CodeTlDelimited {delimited; code_tl}
                   :: Elm.{symbol=Symbol.Nonterm (CodeToken code_token); _}
                   :: tl__hocc__ -> Symbol.Nonterm (CodeTl (
                   (*______________________________________________________________________________*)
-#440 "./Parse.hmh"
+#498 "./Parse.hmh"
 CodeTlCodeToken {code_token; code_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13575,7 +14047,7 @@ CodeTlCodeToken {code_token; code_tl}
                 (* 61 *) (function
                   tl__hocc__ -> Symbol.Nonterm (CodeTl (
                   (*______________________________________________________________________________*)
-#441 "./Parse.hmh"
+#499 "./Parse.hmh"
 CodeTlEpsilon
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13585,7 +14057,7 @@ CodeTlEpsilon
                   :: Elm.{symbol=Symbol.Nonterm (Delimited delimited); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Code (
                   (*______________________________________________________________________________*)
-#444 "./Parse.hmh"
+#502 "./Parse.hmh"
 CodeDelimited {delimited; code_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13596,7 +14068,7 @@ CodeDelimited {delimited; code_tl}
                   :: Elm.{symbol=Symbol.Nonterm (CodeToken code_token); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Code (
                   (*______________________________________________________________________________*)
-#445 "./Parse.hmh"
+#503 "./Parse.hmh"
 CodeCodeToken {code_token; code_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13606,7 +14078,7 @@ CodeCodeToken {code_token; code_tl}
                   | Elm.{symbol=Symbol.Nonterm (Uident binding); _}
                   :: tl__hocc__ -> Symbol.Nonterm (PatternField (
                   (*______________________________________________________________________________*)
-#448 "./Parse.hmh"
+#506 "./Parse.hmh"
 PatternFieldBinding {binding}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13618,7 +14090,7 @@ PatternFieldBinding {binding}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (PatternField (
                   (*______________________________________________________________________________*)
-#449 "./Parse.hmh"
+#507 "./Parse.hmh"
 PatternFieldPattern {pattern}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13628,7 +14100,7 @@ PatternFieldPattern {pattern}
                   | Elm.{symbol=Symbol.Nonterm (PatternField field); _}
                   :: tl__hocc__ -> Symbol.Nonterm (PatternFields (
                   (*______________________________________________________________________________*)
-#454 "./Parse.hmh"
+#512 "./Parse.hmh"
 PatternFieldsOne {field}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13640,7 +14112,7 @@ PatternFieldsOne {field}
                   :: Elm.{symbol=Symbol.Nonterm (PatternField field); _}
                   :: tl__hocc__ -> Symbol.Nonterm (PatternFields (
                   (*______________________________________________________________________________*)
-#454 "./Parse.hmh"
+#512 "./Parse.hmh"
 PatternFieldsOne {field}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13652,7 +14124,7 @@ PatternFieldsOne {field}
                   :: Elm.{symbol=Symbol.Nonterm (PatternField field); _}
                   :: tl__hocc__ -> Symbol.Nonterm (PatternFields (
                   (*______________________________________________________________________________*)
-#456 "./Parse.hmh"
+#514 "./Parse.hmh"
 PatternFieldsMulti {field; fields}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13662,7 +14134,7 @@ PatternFieldsMulti {field; fields}
                   | _
                   :: tl__hocc__ -> Symbol.Nonterm (SemiSuffix (
                   (*______________________________________________________________________________*)
-#461 "./Parse.hmh"
+#519 "./Parse.hmh"
 SemiSuffix
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13671,7 +14143,7 @@ SemiSuffix
                 (* 70 *) (function
                   tl__hocc__ -> Symbol.Nonterm (SemiSuffix (
                   (*______________________________________________________________________________*)
-#461 "./Parse.hmh"
+#519 "./Parse.hmh"
 SemiSuffix
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13680,7 +14152,7 @@ SemiSuffix
                   | _
                   :: tl__hocc__ -> Symbol.Nonterm (ModulePath (
                   (*______________________________________________________________________________*)
-#466 "./Parse.hmh"
+#524 "./Parse.hmh"
 ModulePath
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13692,7 +14164,7 @@ ModulePath
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (ModulePath (
                   (*______________________________________________________________________________*)
-#466 "./Parse.hmh"
+#524 "./Parse.hmh"
 ModulePath
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13702,7 +14174,7 @@ ModulePath
                   | _
                   :: tl__hocc__ -> Symbol.Nonterm (Pattern (
                   (*______________________________________________________________________________*)
-#470 "./Parse.hmh"
+#528 "./Parse.hmh"
 PatternUscore
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13712,7 +14184,7 @@ PatternUscore
                   | Elm.{symbol=Symbol.Nonterm (Uident binding); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Pattern (
                   (*______________________________________________________________________________*)
-#473 "./Parse.hmh"
+#531 "./Parse.hmh"
 PatternBinding {binding}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13724,7 +14196,7 @@ PatternBinding {binding}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (Pattern (
                   (*______________________________________________________________________________*)
-#473 "./Parse.hmh"
+#531 "./Parse.hmh"
 PatternBinding {binding}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13736,7 +14208,7 @@ PatternBinding {binding}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (Pattern (
                   (*______________________________________________________________________________*)
-#477 "./Parse.hmh"
+#535 "./Parse.hmh"
 PatternPattern {pattern}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13747,7 +14219,7 @@ PatternPattern {pattern}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (Pattern (
                   (*______________________________________________________________________________*)
-#477 "./Parse.hmh"
+#535 "./Parse.hmh"
 PatternPattern {pattern}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13761,7 +14233,7 @@ PatternPattern {pattern}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (Pattern (
                   (*______________________________________________________________________________*)
-#477 "./Parse.hmh"
+#535 "./Parse.hmh"
 PatternPattern {pattern}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13773,7 +14245,7 @@ PatternPattern {pattern}
                   :: Elm.{symbol=Symbol.Nonterm (Pattern pattern_a); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Pattern (
                   (*______________________________________________________________________________*)
-#479 "./Parse.hmh"
+#537 "./Parse.hmh"
 PatternComma {pattern_a; pattern_b}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13786,7 +14258,7 @@ PatternComma {pattern_a; pattern_b}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (Pattern (
                   (*______________________________________________________________________________*)
-#482 "./Parse.hmh"
+#540 "./Parse.hmh"
 PatternFields {fields}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13801,7 +14273,7 @@ PatternFields {fields}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (Pattern (
                   (*______________________________________________________________________________*)
-#482 "./Parse.hmh"
+#540 "./Parse.hmh"
 PatternFields {fields}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13811,7 +14283,7 @@ PatternFields {fields}
                   | Elm.{symbol=Symbol.Token (CIDENT cident); _}
                   :: tl__hocc__ -> Symbol.Nonterm (ProdParamSymbol (
                   (*______________________________________________________________________________*)
-#485 "./Parse.hmh"
+#543 "./Parse.hmh"
 ProdParamSymbolCident {cident}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13821,7 +14293,7 @@ ProdParamSymbolCident {cident}
                   | Elm.{symbol=Symbol.Token (ISTRING alias); _}
                   :: tl__hocc__ -> Symbol.Nonterm (ProdParamSymbol (
                   (*______________________________________________________________________________*)
-#486 "./Parse.hmh"
+#544 "./Parse.hmh"
 ProdParamSymbolAlias {alias}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13833,7 +14305,7 @@ ProdParamSymbolAlias {alias}
                   :: Elm.{symbol=Symbol.Nonterm (Uident binding); _}
                   :: tl__hocc__ -> Symbol.Nonterm (ProdParam (
                   (*______________________________________________________________________________*)
-#490 "./Parse.hmh"
+#548 "./Parse.hmh"
 ProdParamBinding {binding; prod_param_symbol}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13847,7 +14319,7 @@ ProdParamBinding {binding; prod_param_symbol}
                   :: Elm.{symbol=Symbol.Token (LPAREN lparen); _}
                   :: tl__hocc__ -> Symbol.Nonterm (ProdParam (
                   (*______________________________________________________________________________*)
-#493 "./Parse.hmh"
+#551 "./Parse.hmh"
 ProdParamPattern {lparen; pattern; rparen; prod_param_symbol}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13863,7 +14335,7 @@ ProdParamPattern {lparen; pattern; rparen; prod_param_symbol}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (ProdParam (
                   (*______________________________________________________________________________*)
-#493 "./Parse.hmh"
+#551 "./Parse.hmh"
 ProdParamPattern {lparen; pattern; rparen; prod_param_symbol}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13878,7 +14350,7 @@ ProdParamPattern {lparen; pattern; rparen; prod_param_symbol}
                   :: Elm.{symbol=Symbol.Token (LCURLY lcurly); _}
                   :: tl__hocc__ -> Symbol.Nonterm (ProdParam (
                   (*______________________________________________________________________________*)
-#497 "./Parse.hmh"
+#555 "./Parse.hmh"
 ProdParamFields {lcurly; fields; rcurly; prod_param_symbol}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13895,7 +14367,7 @@ ProdParamFields {lcurly; fields; rcurly; prod_param_symbol}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (ProdParam (
                   (*______________________________________________________________________________*)
-#497 "./Parse.hmh"
+#555 "./Parse.hmh"
 ProdParamFields {lcurly; fields; rcurly; prod_param_symbol}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13907,7 +14379,7 @@ ProdParamFields {lcurly; fields; rcurly; prod_param_symbol}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (ProdParam (
                   (*______________________________________________________________________________*)
-#500 "./Parse.hmh"
+#558 "./Parse.hmh"
 ProdParam {prod_param_symbol}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13917,7 +14389,7 @@ ProdParam {prod_param_symbol}
                   | Elm.{symbol=Symbol.Nonterm (ProdParamSymbol prod_param_symbol); _}
                   :: tl__hocc__ -> Symbol.Nonterm (ProdParam (
                   (*______________________________________________________________________________*)
-#500 "./Parse.hmh"
+#558 "./Parse.hmh"
 ProdParam {prod_param_symbol}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13928,7 +14400,7 @@ ProdParam {prod_param_symbol}
                   :: Elm.{symbol=Symbol.Nonterm (ProdParam prod_param); _}
                   :: tl__hocc__ -> Symbol.Nonterm (ProdParamsTl (
                   (*______________________________________________________________________________*)
-#504 "./Parse.hmh"
+#562 "./Parse.hmh"
 ProdParamsTlProdParam {prod_param; prod_params_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13938,7 +14410,7 @@ ProdParamsTlProdParam {prod_param; prod_params_tl}
                   | Elm.{symbol=Symbol.Nonterm (PrecRef prec_ref); _}
                   :: tl__hocc__ -> Symbol.Nonterm (ProdParamsTl (
                   (*______________________________________________________________________________*)
-#505 "./Parse.hmh"
+#563 "./Parse.hmh"
 ProdParamsTlPrecRef {prec_ref}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13949,7 +14421,7 @@ ProdParamsTlPrecRef {prec_ref}
                   :: Elm.{symbol=Symbol.Nonterm (ProdParam prod_param); _}
                   :: tl__hocc__ -> Symbol.Nonterm (ProdParams (
                   (*______________________________________________________________________________*)
-#509 "./Parse.hmh"
+#567 "./Parse.hmh"
 ProdParamsProdParam {prod_param; prod_params_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13959,7 +14431,7 @@ ProdParamsProdParam {prod_param; prod_params_tl}
                   | Elm.{symbol=Symbol.Nonterm (ProdParams prod_params); _}
                   :: tl__hocc__ -> Symbol.Nonterm (ProdPattern (
                   (*______________________________________________________________________________*)
-#512 "./Parse.hmh"
+#570 "./Parse.hmh"
 ProdPatternParams {prod_params}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13970,7 +14442,7 @@ ProdPatternParams {prod_params}
                   :: Elm.{symbol=Symbol.Token (EPSILON_ epsilon); _}
                   :: tl__hocc__ -> Symbol.Nonterm (ProdPattern (
                   (*______________________________________________________________________________*)
-#513 "./Parse.hmh"
+#571 "./Parse.hmh"
 ProdPatternEpsilon {epsilon; prec_ref}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13980,7 +14452,7 @@ ProdPatternEpsilon {epsilon; prec_ref}
                   | Elm.{symbol=Symbol.Nonterm (ProdPattern prod_pattern); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Prod (
                   (*______________________________________________________________________________*)
-#516 "./Parse.hmh"
+#574 "./Parse.hmh"
 Prod {prod_pattern}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -13992,7 +14464,7 @@ Prod {prod_pattern}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (ProdsTl (
                   (*______________________________________________________________________________*)
-#519 "./Parse.hmh"
+#577 "./Parse.hmh"
 ProdsTlProd {prod; prods_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14001,7 +14473,7 @@ ProdsTlProd {prod; prods_tl}
                 (* 98 *) (function
                   tl__hocc__ -> Symbol.Nonterm (ProdsTl (
                   (*______________________________________________________________________________*)
-#520 "./Parse.hmh"
+#578 "./Parse.hmh"
 ProdsTlEpsilon
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14012,7 +14484,7 @@ ProdsTlEpsilon
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (Prods (
                   (*______________________________________________________________________________*)
-#524 "./Parse.hmh"
+#582 "./Parse.hmh"
 ProdsProd {prod; prods_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14023,7 +14495,7 @@ ProdsProd {prod; prods_tl}
                   :: Elm.{symbol=Symbol.Nonterm (Prod prod); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Prods (
                   (*______________________________________________________________________________*)
-#524 "./Parse.hmh"
+#582 "./Parse.hmh"
 ProdsProd {prod; prods_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14035,7 +14507,7 @@ ProdsProd {prod; prods_tl}
                   :: Elm.{symbol=Symbol.Nonterm (Prods prods); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Reduction (
                   (*______________________________________________________________________________*)
-#527 "./Parse.hmh"
+#585 "./Parse.hmh"
 Reduction {prods; code}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14047,7 +14519,7 @@ Reduction {prods; code}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (ReductionsTl (
                   (*______________________________________________________________________________*)
-#531 "./Parse.hmh"
+#589 "./Parse.hmh"
 ReductionsTlReduction {reduction; reductions_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14056,7 +14528,7 @@ ReductionsTlReduction {reduction; reductions_tl}
                 (* 103 *) (function
                   tl__hocc__ -> Symbol.Nonterm (ReductionsTl (
                   (*______________________________________________________________________________*)
-#532 "./Parse.hmh"
+#590 "./Parse.hmh"
 ReductionsTlEpsilon
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14066,7 +14538,7 @@ ReductionsTlEpsilon
                   :: Elm.{symbol=Symbol.Nonterm (Reduction reduction); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Reductions (
                   (*______________________________________________________________________________*)
-#536 "./Parse.hmh"
+#594 "./Parse.hmh"
 ReductionsReduction {reduction; reductions_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14076,7 +14548,7 @@ ReductionsReduction {reduction; reductions_tl}
                   | _
                   :: tl__hocc__ -> Symbol.Nonterm (NontermType (
                   (*______________________________________________________________________________*)
-#539 "./Parse.hmh"
+#597 "./Parse.hmh"
 NontermTypeNonterm
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14086,7 +14558,7 @@ NontermTypeNonterm
                   | _
                   :: tl__hocc__ -> Symbol.Nonterm (NontermType (
                   (*______________________________________________________________________________*)
-#540 "./Parse.hmh"
+#598 "./Parse.hmh"
 NontermTypeStart
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14100,7 +14572,7 @@ NontermTypeStart
                   :: Elm.{symbol=Symbol.Nonterm (NontermType nonterm_type); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Nonterm (
                   (*______________________________________________________________________________*)
-#544 "./Parse.hmh"
+#602 "./Parse.hmh"
 NontermProds {nonterm_type; cident; prec_ref; prods}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14115,7 +14587,7 @@ NontermProds {nonterm_type; cident; prec_ref; prods}
                   :: Elm.{symbol=Symbol.Nonterm (NontermType nonterm_type); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Nonterm (
                   (*______________________________________________________________________________*)
-#547 "./Parse.hmh"
+#605 "./Parse.hmh"
 NontermReductions {nonterm_type; cident; symbol_type; prec_ref; reductions}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14125,7 +14597,7 @@ NontermReductions {nonterm_type; cident; symbol_type; prec_ref; reductions}
                   | Elm.{symbol=Symbol.Nonterm (PrecSet prec_set); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Stmt (
                   (*______________________________________________________________________________*)
-#550 "./Parse.hmh"
+#608 "./Parse.hmh"
 StmtPrecSet {prec_set}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14135,7 +14607,7 @@ StmtPrecSet {prec_set}
                   | Elm.{symbol=Symbol.Nonterm (Token token); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Stmt (
                   (*______________________________________________________________________________*)
-#551 "./Parse.hmh"
+#609 "./Parse.hmh"
 StmtToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14145,7 +14617,7 @@ StmtToken {token}
                   | Elm.{symbol=Symbol.Nonterm (Nonterm nonterm); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Stmt (
                   (*______________________________________________________________________________*)
-#552 "./Parse.hmh"
+#610 "./Parse.hmh"
 StmtNonterm {nonterm}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14157,7 +14629,7 @@ StmtNonterm {nonterm}
                   :: _
                   :: tl__hocc__ -> Symbol.Nonterm (StmtsTl (
                   (*______________________________________________________________________________*)
-#555 "./Parse.hmh"
+#613 "./Parse.hmh"
 StmtsTl {stmt; stmts_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14166,7 +14638,7 @@ StmtsTl {stmt; stmts_tl}
                 (* 113 *) (function
                   tl__hocc__ -> Symbol.Nonterm (StmtsTl (
                   (*______________________________________________________________________________*)
-#556 "./Parse.hmh"
+#614 "./Parse.hmh"
 StmtsTlEpsilon
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14176,7 +14648,7 @@ StmtsTlEpsilon
                   :: Elm.{symbol=Symbol.Nonterm (Stmt stmt); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Stmts (
                   (*______________________________________________________________________________*)
-#559 "./Parse.hmh"
+#617 "./Parse.hmh"
 Stmts {stmt; stmts_tl}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14189,7 +14661,7 @@ Stmts {stmt; stmts_tl}
                   :: Elm.{symbol=Symbol.Token (HOCC hocc_); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Hocc (
                   (*______________________________________________________________________________*)
-#562 "./Parse.hmh"
+#620 "./Parse.hmh"
 Hocc {hocc_; indent; stmts; dedent}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14199,7 +14671,7 @@ Hocc {hocc_; indent; stmts; dedent}
                   | Elm.{symbol=Symbol.Nonterm (Sep sep); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#567 "./Parse.hmh"
+#625 "./Parse.hmh"
 let token = match sep with
           | SepLineDelim {line_delim=LINE_DELIM {token}}
           | SepSemi {semi=SEMI {token}}
@@ -14215,7 +14687,7 @@ let token = match sep with
                   | Elm.{symbol=Symbol.Token (NONTERM (NONTERM {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14225,7 +14697,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (EPSILON_ (EPSILON {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14235,7 +14707,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (START (START {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14245,7 +14717,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (TOKEN (TOKEN {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14255,7 +14727,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (NEUTRAL (NEUTRAL {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14265,7 +14737,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (LEFT (LEFT {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14275,7 +14747,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (RIGHT (RIGHT {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14285,7 +14757,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (NONASSOC (NONASSOC {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14295,7 +14767,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (PREC (PREC {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14305,7 +14777,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (OTHER_TOKEN (OTHER_TOKEN {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14315,7 +14787,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (UIDENT (UIDENT {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14325,7 +14797,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (CIDENT (CIDENT {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14335,7 +14807,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (USCORE (USCORE {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14345,7 +14817,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (ISTRING (ISTRING {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14355,7 +14827,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (COLON_COLON_EQ (COLON_COLON_EQ {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14365,7 +14837,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (AS (AS {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14375,7 +14847,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (OF (OF {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14385,7 +14857,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (COLON (COLON {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14395,7 +14867,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (DOT (DOT {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14405,7 +14877,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (ARROW (ARROW {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14415,7 +14887,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (LT (LT {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14425,7 +14897,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (EQ (EQ {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14435,7 +14907,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (COMMA (COMMA {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14445,7 +14917,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (INDENT (INDENT {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14455,7 +14927,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (DEDENT (DEDENT {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14465,7 +14937,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (LPAREN (LPAREN {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14475,7 +14947,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (RPAREN (RPAREN {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14485,7 +14957,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (LCAPTURE (LCAPTURE {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14495,7 +14967,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (RCAPTURE (RCAPTURE {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14505,7 +14977,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (LBRACK (LBRACK {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14515,7 +14987,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (RBRACK (RBRACK {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14525,7 +14997,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (LARRAY (LARRAY {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14535,7 +15007,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (RARRAY (RARRAY {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14545,7 +15017,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (LCURLY (LCURLY {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14555,7 +15027,7 @@ MatterToken {token}
                   | Elm.{symbol=Symbol.Token (RCURLY (RCURLY {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (MatterToken (
                   (*______________________________________________________________________________*)
-#609 "./Parse.hmh"
+#667 "./Parse.hmh"
 MatterToken {token}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14566,7 +15038,7 @@ MatterToken {token}
                   :: Elm.{symbol=Symbol.Nonterm (MatterToken (MatterToken {token})); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Matter (
                   (*______________________________________________________________________________*)
-#612 "./Parse.hmh"
+#670 "./Parse.hmh"
 Matter {token; matter}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14575,7 +15047,7 @@ Matter {token; matter}
                 (* 153 *) (function
                   tl__hocc__ -> Symbol.Nonterm (Matter (
                   (*______________________________________________________________________________*)
-#613 "./Parse.hmh"
+#671 "./Parse.hmh"
 MatterEpsilon
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14587,7 +15059,7 @@ MatterEpsilon
                   :: Elm.{symbol=Symbol.Nonterm (Matter prelude); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Hmh (
                   (*______________________________________________________________________________*)
-#616 "./Parse.hmh"
+#674 "./Parse.hmh"
 Hmh {prelude; hocc_; postlude; eoi}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14601,7 +15073,7 @@ Hmh {prelude; hocc_; postlude; eoi}
                   :: Elm.{symbol=Symbol.Nonterm (Matter prelude); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Hmhi (
                   (*______________________________________________________________________________*)
-#619 "./Parse.hmh"
+#677 "./Parse.hmh"
 Hmhi {prelude; hocc_; postlude; eoi}
                   (*‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾*)
                   )), tl__hocc__
@@ -14810,11 +15282,29 @@ Hmhi {prelude; hocc_; postlude; eoi}
           | Reject _ -> t
 
     let next token ({status; _} as t) =
+        let open Status in
         match status with
-          | Status.Prefix -> t |> feed token |> walk
-          | _ -> not_reached ()
+          | Prefix -> begin
+            match t |> feed token |> walk with
+              | {status=Reject _ as status; _} -> {t with status}
+              | t' -> t'
+          end
+          | _ -> halt "`token` only supports `Prefix` status"
+
+    let expect ({status; _} as t) =
+        let open Status in
+        let t = match status with
+          | Prefix -> t
+          | Reject _ -> {t with status=Prefix}
+          | _ -> halt "`expect` only supports `Prefix`/`Reject` status"
+          in
+        Array.fold ~init:(Ordset.empty (module Token)) ~f:(fun expect token ->
+            match next token t with
+              | {status=Reject _; _} -> expect
+              | _ -> Ordset.insert token expect
+        ) Token.protos
   end
-#620 "./Parse.hmh"
+#678 "./Parse.hmh"
 
 let rec scan scanner =
     let scanner, scan_token = Scan.next scanner in
@@ -14874,6 +15364,21 @@ let rec scan scanner =
       end
       | mals -> scanner, scan_token, Token.OTHER_TOKEN (OTHER_TOKEN {token=scan_token}), mals
 
+let pp_expect expect formatter =
+    let names =
+      expect
+      |> Ordset.to_list
+      |> List.map ~f:(fun token ->
+        match Token.spec token with
+          | {alias=Some alias; _} -> alias
+          | {name; _} -> name
+      )
+      in
+    formatter
+      |> Fmt.fmt "{⸱"
+      |> Fmt.fmt (String.join ~sep:"⸱" names)
+      |> Fmt.fmt "⸱}"
+
 let hmhi scanner =
     let rec inner scanner errs parser = begin
         let scanner, scan_token, token, mals = scan scanner in
@@ -14887,7 +15392,13 @@ let hmhi scanner =
           | Accept (Hmhi hmhi), [] -> scanner, Ok hmhi
           | Accept (Hmhi _), _ -> scanner, Error errs
           | Reject _, _ ->
-            let errs = Error.init_token scan_token "Unexpected token" :: errs in
+            let msg =
+              String.Fmt.empty
+              |> Fmt.fmt "Unexpected token not in "
+              |> pp_expect (expect parser)
+              |> Fmt.to_string
+              in
+            let errs = Error.init_token scan_token msg :: errs in
             scanner, Error errs
           | _ -> not_reached ()
       end in
@@ -14907,7 +15418,13 @@ let hmh scanner =
           | Accept (Hmh hmh), [] -> scanner, Ok hmh
           | Accept (Hmh _), _ -> scanner, Error errs
           | Reject _, _ -> begin
-            let errs = Error.init_token scan_token "Unexpected token" :: errs in
+            let msg =
+              String.Fmt.empty
+              |> Fmt.fmt "Unexpected token not in "
+              |> pp_expect (expect parser)
+              |> Fmt.to_string
+              in
+            let errs = Error.init_token scan_token msg :: errs in
             scanner, Error errs
           end
           | _ -> not_reached ()
@@ -15286,20 +15803,6 @@ let rec pp_token_hocc (HOCC {token}) formatter =
   and pp_symbol_type symbol_type formatter =
     fmt_symbol_type symbol_type formatter
 
-  and fmt_symbol_type0 ?(alt=Fmt.alt_default) ?(width=Fmt.width_default) symbol_type0
-  formatter =
-    let width' = width + 4L in
-    match symbol_type0 with
-      | SymbolType0SymbolType {symbol_type} ->
-        formatter |> Fmt.fmt "SymbolType0SymbolType "
-          |> fmt_lcurly ~alt ~width
-          |> Fmt.fmt "symbol_type=" |> fmt_symbol_type ~alt ~width:width' symbol_type
-          |> fmt_rcurly ~alt ~width
-      | SymbolType0Epsilon ->
-        formatter |> Fmt.fmt "SymbolType0Epsilon"
-  and pp_symbol_type0 symbol_type0 formatter =
-    fmt_symbol_type0 symbol_type0 formatter
-
   and fmt_prec_ref ?(alt=Fmt.alt_default) ?(width=Fmt.width_default) prec_ref formatter =
     match prec_ref with
       | PrecRefUident {uident} ->
@@ -15312,29 +15815,44 @@ let rec pp_token_hocc (HOCC {token}) formatter =
   and pp_prec_ref prec_ref formatter =
     fmt_prec_ref prec_ref formatter
 
-  and fmt_token_alias ?(alt=Fmt.alt_default) ?(width=Fmt.width_default) token_alias formatter =
-    match token_alias with
-      | TokenAlias {alias} ->
-        formatter |> Fmt.fmt "Token "
+  and fmt_alias ?(alt=Fmt.alt_default) ?(width=Fmt.width_default) token formatter =
+    match token with
+      | Alias {alias} ->
+        formatter |> Fmt.fmt "Alias "
           |> fmt_lcurly ~alt ~width
           |> Fmt.fmt "alias=" |> pp_token_istring alias
           |> fmt_rcurly ~alt ~width
-      | TokenAliasEpsilon ->
-        formatter |> Fmt.fmt "TokenAliasEpsilon"
-  and pp_token_alias token_alias formatter =
-    fmt_token_alias token_alias formatter
+      | AliasEpsilon ->
+        formatter |> Fmt.fmt "AliasEpsilon"
+  and pp_alias alias formatter =
+    fmt_alias alias formatter
+
+  and fmt_token_type ?(alt=Fmt.alt_default) ?(width=Fmt.width_default) token formatter =
+    let width' = width + 4L in
+    match token with
+      | TokenType {symbol_type; proto} ->
+        formatter |> Fmt.fmt "TokenType "
+          |> fmt_lcurly ~alt ~width
+          |> Fmt.fmt "symbol_type=" |> pp_symbol_type symbol_type
+          |> fmt_semi ~alt ~width
+          |> Fmt.fmt "proto=" |> fmt_code ~alt ~width:width' proto
+          |> fmt_rcurly ~alt ~width
+      | TokenTypeEpsilon ->
+        formatter |> Fmt.fmt "TokenTypeEpsilon"
+  and pp_token_type token_type formatter =
+    fmt_token_type token_type formatter
 
   and fmt_token ?(alt=Fmt.alt_default) ?(width=Fmt.width_default) token formatter =
     let width' = width + 4L in
     match token with
-      | Token {cident; token_alias; symbol_type0; prec_ref} ->
+      | Token {cident; alias; token_type; prec_ref} ->
         formatter |> Fmt.fmt "Token "
           |> fmt_lcurly ~alt ~width
           |> Fmt.fmt "cident=" |> pp_token_cident cident
           |> fmt_semi ~alt ~width
-          |> Fmt.fmt "token_alias=" |> fmt_token_alias ~alt ~width:width' token_alias
+          |> Fmt.fmt "alias=" |> pp_alias alias
           |> fmt_semi ~alt ~width
-          |> Fmt.fmt "symbol_type0=" |> fmt_symbol_type0 ~alt ~width:width' symbol_type0
+          |> Fmt.fmt "token_type=" |> fmt_token_type ~alt ~width:width' token_type
           |> fmt_semi ~alt ~width
           |> Fmt.fmt "prec_ref=" |> fmt_prec_ref ~alt ~width:width' prec_ref
           |> fmt_rcurly ~alt ~width
@@ -16019,7 +16537,7 @@ let rec source_of_binding = function
 (**************************************************************************************************)
 (* Miscellaneous helper functions. *)
 
-let min_comment_indentation_of_hocc_block = function
+let indentation_of_hocc_block = function
   | Hocc {indent=INDENT {token=indent}; _} ->
     Scan.Token.source indent
       |> Hmc.Source.Slice.base
@@ -16099,7 +16617,7 @@ let source_of_code code =
     Hmc.Source.Slice.of_cursors ~base ~past
 
 let indentation_of_code hocc_block code =
-    let min_comment_indentation = min_comment_indentation_of_hocc_block hocc_block in
+    let min_comment_indentation = indentation_of_hocc_block hocc_block in
     match code with
       | CodeDelimited _ -> min_comment_indentation + 4L
       | CodeCodeToken _ -> min_comment_indentation
@@ -16122,17 +16640,51 @@ let postlude_base_of_hocc (Hocc {stmts=Stmts {stmt; stmts_tl}; _}) =
       and of_prec_rels = function
       | PrecRelsPrecs {precs} -> Some (of_precs precs)
       | PrecRelsEpsilon -> None
-      and of_symbol_type = function
-      | SymbolType {symbol_type; _} -> symbol_type
-      and of_symbol_type0 = function
-      | SymbolType0SymbolType {symbol_type} -> Some (of_symbol_type symbol_type)
-      | SymbolType0Epsilon -> None
       and of_prec_ref = function
       | PrecRefUident {uident} -> Some uident
       | PrecRefEpsilon -> None
-      and of_token_alias = function
-      | TokenAlias {alias=ISTRING {token=alias}} -> Some alias
-      | TokenAliasEpsilon -> None
+      and of_alias = function
+      | Alias {alias=ISTRING {token=alias}} -> Some alias
+      | AliasEpsilon -> None
+      and of_token_type = function
+      | TokenType {proto; _} -> Some (of_code proto)
+      | TokenTypeEpsilon-> None
+      and of_token = function
+      | Token {cident=CIDENT {token=cident}; alias; token_type; prec_ref} -> begin
+        of_prec_ref prec_ref
+          |> Option.some_or_thunk ~f:(fun () -> of_token_type token_type)
+          |> Option.some_or_thunk ~f:(fun () -> of_alias alias)
+          |> Option.value_or_thunk ~f:(fun () -> cident)
+      end
+      and of_delimited = function
+      | DelimitedBlock {dedent=DEDENT {token}; _}
+      | DelimitedParen {rparen=RPAREN {token}; _}
+      | DelimitedCapture {rcapture=RCAPTURE {token}; _}
+      | DelimitedList {rbrack=RBRACK {token}; _}
+      | DelimitedArray {rarray=RARRAY {token}; _}
+      | DelimitedModule {rcurly=RCURLY {token}; _} -> token
+      and of_code_token = function
+      | CodeToken {token} -> token
+      and of_code_tl = function
+      | CodeTlDelimited {delimited; code_tl} -> begin
+        of_code_tl code_tl
+          |> Option.some_or_thunk ~f:(fun () -> Some (of_delimited delimited))
+      end
+      | CodeTlCodeToken {code_token; code_tl} -> begin
+        of_code_tl code_tl
+          |> Option.some_or_thunk ~f:(fun () -> Some (of_code_token code_token))
+      end
+      | CodeTlEpsilon -> None
+      and of_code = function
+      | CodeDelimited {delimited; code_tl} -> begin
+        of_code_tl code_tl
+          |> Option.value_or_thunk ~f:(fun () -> of_delimited delimited)
+      end
+      | CodeCodeToken {code_token; code_tl} -> begin
+        of_code_tl code_tl
+          |> Option.value_or_thunk ~f:(fun () -> of_code_token code_token)
+      end
+
       and of_prod_param_symbol = function
       | ProdParamSymbolCident {cident=CIDENT {token=cident}} -> cident
       | ProdParamSymbolAlias {alias=ISTRING {token=alias}} -> alias
@@ -16191,13 +16743,7 @@ let postlude_base_of_hocc (Hocc {stmts=Stmts {stmt; stmts_tl}; _}) =
         of_prec_rels prec_rels
           |> Option.value_or_thunk ~f:(fun () -> of_precs prec_set)
       end
-      | StmtToken {token=Token {cident=CIDENT {token=cident}; token_alias; symbol_type0;
-      prec_ref; _}} -> begin
-        of_prec_ref prec_ref
-          |> Option.some_or_thunk ~f:(fun () -> of_symbol_type0 symbol_type0)
-          |> Option.some_or_thunk ~f:(fun () -> of_token_alias token_alias)
-          |> Option.value_or_thunk ~f:(fun () -> cident)
-      end
+      | StmtToken {token} -> of_token token
       | StmtNonterm {nonterm} -> of_nonterm nonterm
       and of_stmts_tl = function
       | StmtsTl {stmt; stmts_tl} -> begin

--- a/bootstrap/bin/hocc/code.ml
+++ b/bootstrap/bin/hocc/code.ml
@@ -249,6 +249,9 @@ let hmi_template = {|{
     Token = {
         «tokens»
 
+        protos: array t
+          [@@doc "Token prototypes, one per variant."]
+
         include IdentifiableIntf.S with type t := t
 
         spec: t -> Spec.Symbol.t
@@ -349,19 +352,19 @@ let hmi_template = {|{
     next: Token.t -> t -> t
       [@@doc "`next token t` calls `feed token t` and fast-forwards via `step` calls to return a
       result with status in {`Prefix`, `Accept`, `Reject`}. `t.status` must be `Prefix`."]
+
+    expect: t -> Ordset.t Token.t Token.cmper_witness
+      [@@doc "`expect t` returns the set of token (proto)types which `next token t` would not
+      reject, assuming status were `Prefix`. `t.status` must be in {`Prefix`, `Reject`}."]
   }|}
 
 let expand_hmi_tokens symbols ~indentation formatter =
   let indent = mk_indent indentation in
   let fmt_tokens formatter = begin
-    let formatter, _first = Symbols.tokens_fold ~init:(formatter, true)
-      ~f:(fun (formatter, first) {name; alias; stype; _}->
+    Symbols.tokens_fold ~init:formatter
+      ~f:(fun formatter {name; alias; stype; _}->
         formatter
-        |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
+        |> Fmt.fmt "\n"
         |> indent |> Fmt.fmt "  | " |> Fmt.fmt name
         |> (fun formatter ->
           match SymbolType.is_explicit stype with
@@ -372,40 +375,30 @@ let expand_hmi_tokens symbols ~indentation formatter =
           match alias with
           | None -> formatter
           | Some alias -> formatter |> Fmt.fmt " # " |> String.fmt ~pretty:true alias
-        ),
-        false
+        )
       ) symbols
-    in
-    formatter
   end in
   formatter
-  |> indent |> Fmt.fmt "type t: t =\n"
+  |> indent |> Fmt.fmt "type t: t ="
   |> fmt_tokens
 
 let expand_hmi_nonterms symbols ~indentation formatter =
   let indent = mk_indent indentation in
   let fmt_nonterms formatter = begin
-    let formatter, _first = Symbols.nonterms_fold ~init:(formatter, true)
-      ~f:(fun (formatter, first) {name; stype; _} ->
+    Symbols.nonterms_fold ~init:formatter
+      ~f:(fun formatter {name; stype; _} ->
         formatter
-        |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
+        |> Fmt.fmt "\n"
         |> indent |> Fmt.fmt "  | " |> Fmt.fmt name
         |> (fun formatter ->
           match SymbolType.is_explicit stype with
           | false -> formatter
           | true -> formatter |> Fmt.fmt " of " |> Fmt.fmt (SymbolType.to_string stype)
-        ),
-        false
+        )
       ) symbols
-    in
-    formatter
   end in
   formatter
-  |> indent |> Fmt.fmt "type t: t =\n"
+  |> indent |> Fmt.fmt "type t: t ="
   |> fmt_nonterms
 
 let expand_hmi_starts symbols ~indentation formatter =
@@ -1287,9 +1280,25 @@ let hm_template = {|{
           | Reject _ -> t
 
     next token ({status; _} as t) =
+        let open Status
         match status with
-          | Status.Prefix -> t |> feed token |> walk
-          | _ -> not_reached ()
+          | Status.Prefix ->
+            match t |> feed token |> walk with
+              | {status=Reject _ as status; _} -> {t with status}
+              | t' -> t'
+          | _ -> halt "`token` only supports `Prefix` status"
+
+    expect ({status; _} as t) =
+        let open Status
+        let t = match status with
+          | Prefix -> t
+          | Reject _ -> {t with status=Prefix}
+          | _ -> halt "`expect` only supports `Prefix`/`Reject` status"
+        Array.fold ~init:(Ordset.empty Token) ~f:(fn expect token ->
+            match next token t with
+              | {status=Reject _; _} -> expect
+              | _ -> Ordset.insert token expect
+        ) Token.protos
   }|}
 
 let state_of_synthetic_start_symbol symbols states synthetic_start_symbol =
@@ -1314,14 +1323,10 @@ let expand_hm_algorithm algorithm ~indentation formatter =
 let expand_hm_prec_sets precs ~indentation formatter =
   let fmt_prec_sets ~indentation formatter = begin
     let indent = mk_indent indentation in
-    let formatter, _first = Precs.fold_prec_sets ~init:(formatter, true)
-      ~f:(fun (formatter, first) PrecSet.{index; names; assoc; doms; _} ->
+    Precs.fold_prec_sets ~init:formatter
+      ~f:(fun formatter PrecSet.{index; names; assoc; doms; _} ->
         formatter
-        |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
+        |> Fmt.fmt "\n"
         |> (fun formatter ->
           formatter
           |> indent
@@ -1347,29 +1352,22 @@ let expand_hm_prec_sets precs ~indentation formatter =
               end
           )
           |> Fmt.fmt ")"
-        ),
-        false
+        )
       ) precs
-    in
-    formatter
   end in
   let indent = mk_indent indentation in
   formatter
-  |> indent |> Fmt.fmt "prec_sets = [|\n"
+  |> indent |> Fmt.fmt "prec_sets = [|"
   |> fmt_prec_sets ~indentation:(indentation+4L) |> Fmt.fmt "\n"
   |> indent |> Fmt.fmt "  |]"
 
 let expand_hm_prods prods ~indentation formatter =
   let fmt_prods ~indentation formatter = begin
     let indent = mk_indent indentation in
-    let formatter, _first = Prods.fold ~init:(formatter, true)
-      ~f:(fun (formatter, first) Prod.{index; lhs_index; rhs_indexes; prec; callback; _} ->
+    Prods.fold ~init:formatter
+      ~f:(fun formatter Prod.{index; lhs_index; rhs_indexes; prec; callback; _} ->
         formatter
-        |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
+        |> Fmt.fmt "\n"
         |> (fun formatter ->
           formatter
           |> indent
@@ -1388,30 +1386,22 @@ let expand_hm_prods prods ~indentation formatter =
               end
           )
           |> Fmt.fmt " ~callback:" |> Callback.Index.pp callback.index
-        ),
-        false
+        )
       ) prods
-    in
-    formatter
   end in
   let indent = mk_indent indentation in
   formatter
-  |> indent |> Fmt.fmt "prods = [|\n"
+  |> indent |> Fmt.fmt "prods = [|"
   |> fmt_prods ~indentation:(indentation+4L) |> Fmt.fmt "\n"
   |> indent |> Fmt.fmt "  |]"
 
 let expand_hm_symbols symbols ~indentation formatter =
   let fmt_symbols ~indentation formatter = begin
     let indent = mk_indent indentation in
-    let formatter, _first_line = Symbols.symbols_fold ~init:(formatter, true)
-      ~f:(fun (formatter, first_line)
-        Symbol.{index; name; prec; alias; start; prods; first; follow; _} ->
+    Symbols.symbols_fold ~init:formatter
+      ~f:(fun formatter Symbol.{index; name; prec; alias; start; prods; first; follow; _} ->
         formatter
-        |> (fun formatter ->
-          match first_line with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
+        |> Fmt.fmt "\n"
         |> (fun formatter ->
           formatter
           |> indent
@@ -1489,15 +1479,12 @@ let expand_hm_symbols symbols ~indentation formatter =
                 |> Fmt.fmt ")"
               end
           )
-        ),
-        false
+        )
       ) symbols
-    in
-    formatter
   end in
   let indent = mk_indent indentation in
   formatter
-  |> indent |> Fmt.fmt "symbols = [|\n"
+  |> indent |> Fmt.fmt "symbols = [|"
   |> fmt_symbols ~indentation:(indentation+4L) |> Fmt.fmt "\n"
   |> indent |> Fmt.fmt "  |]"
 
@@ -1555,15 +1542,11 @@ let expand_hm_lr1Itemset lr1itemset ~indentation formatter =
 let expand_hm_states states ~indentation formatter =
   let fmt_states ~indentation formatter = begin
     let indent = mk_indent indentation in
-    let formatter, _first = Array.fold ~init:(formatter, true)
-      ~f:(fun (formatter, first)
+    Array.fold ~init:formatter
+      ~f:(fun formatter
         State.{statenub={lr1itemsetclosure={index; kernel; _}; _}; actions; gotos; _} ->
         formatter
-        |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
+        |> Fmt.fmt "\n"
         |> (fun formatter ->
           formatter
           |> indent |> Fmt.fmt "(* " |> Lr1ItemsetClosure.Index.pp index
@@ -1625,29 +1608,22 @@ let expand_hm_states states ~indentation formatter =
               end
             | true -> formatter |> indent |> Fmt.fmt "Map.empty Uns"
           )
-        ),
-        false
+        )
       ) states
-    in
-    formatter
   end in
   let indent = mk_indent indentation in
   formatter
-  |> indent |> Fmt.fmt "states = [|\n"
+  |> indent |> Fmt.fmt "states = [|"
   |> fmt_states ~indentation:(indentation+4L) |> Fmt.fmt "\n"
   |> indent |> Fmt.fmt "  |]"
 
 let expand_hm_token_type symbols ~indentation formatter =
   let indent = mk_indent indentation in
   let fmt_tokens formatter = begin
-    let formatter, _first = Symbols.tokens_fold ~init:(formatter, true)
-      ~f:(fun (formatter, first) {name; alias; stype; _} ->
+    Symbols.tokens_fold ~init:formatter
+      ~f:(fun formatter {name; alias; stype; _} ->
         formatter
-        |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
+        |> Fmt.fmt "\n"
         |> indent |> Fmt.fmt "  | " |> Fmt.fmt name
         |> (fun formatter ->
           match SymbolType.is_explicit stype with
@@ -1658,105 +1634,114 @@ let expand_hm_token_type symbols ~indentation formatter =
           match alias with
           | None -> formatter
           | Some alias -> formatter |> Fmt.fmt " # " |> String.fmt ~pretty:true alias
-        ),
-        false
+        )
       ) symbols
-    in
-    formatter
   end in
   formatter
-  |> indent |> Fmt.fmt "type t: t =\n"
+  |> indent |> Fmt.fmt "type t: t ="
   |> fmt_tokens
 
 let expand_hm_token_index symbols ~indentation formatter =
   let indent = mk_indent indentation in
   let fmt_token_indexes formatter = begin
-    let formatter, _first = Symbols.tokens_fold ~init:(formatter, true)
-      ~f:(fun (formatter, first) {index; name; stype; _} ->
-        formatter
-        |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
-        |> indent |> Fmt.fmt "  | " |> Fmt.fmt name
-        |> (fun formatter ->
+    let formatter = Symbols.tokens_fold ~init:formatter
+        ~f:(fun formatter {index; name; stype; _} ->
           formatter
+          |> Fmt.fmt "\n"
+          |> indent |> Fmt.fmt "  | " |> Fmt.fmt name
           |> (fun formatter ->
-            match SymbolType.is_explicit stype with
-            | false -> formatter
-            | true -> formatter |> Fmt.fmt " _"
+            formatter
+            |> (fun formatter ->
+              match SymbolType.is_explicit stype with
+              | false -> formatter
+              | true -> formatter |> Fmt.fmt " _"
+            )
+            |> Fmt.fmt " -> "
+            |> Uns.pp index
           )
-          |> Fmt.fmt " -> "
-          |> Uns.pp index
-        ),
-        false
-      ) symbols
+        ) symbols
     in
     formatter
   end in
   formatter
-  |> indent |> Fmt.fmt "index t = match t with\n"
+  |> indent |> Fmt.fmt "index t = match t with"
   |> fmt_token_indexes
 
-let expand_hm_tokens symbols ~indentation formatter =
+let expand_hm_token_protos hocc_block symbols ~indentation formatter =
+  let indent = mk_indent indentation in
+  let fmt_token_protos formatter = begin
+    let indent = mk_indent (indentation + 4L) in
+    Symbols.tokens_fold ~init:formatter
+      ~f:(fun formatter {name; proto; _} ->
+        formatter
+        |> Fmt.fmt "\n"
+        |> indent |> Fmt.fmt name
+        |> (fun formatter ->
+          formatter
+          |> (fun formatter ->
+            match proto with
+            | None -> formatter
+            | Some code -> begin
+                let source = Parse.source_of_code code in
+                formatter
+                |> Fmt.fmt " "
+                |> fmt_source_directive (Parse.indentation_of_hocc_block hocc_block) source
+                |> Fmt.fmt (Hmc.Source.Slice.to_string source)
+                |> Fmt.fmt "[:]"
+              end
+          )
+        )
+      ) symbols
+  end in
+  formatter
+  |> indent |> Fmt.fmt "protos = [|"
+  |> fmt_token_protos |> Fmt.fmt "\n"
+  |> indent |> Fmt.fmt "  |]"
+
+let expand_hm_tokens hocc_block symbols ~indentation formatter =
   formatter
   |> expand_hm_token_type symbols ~indentation |> Fmt.fmt "\n"
   |> Fmt.fmt "\n"
-  |> expand_hm_token_index symbols ~indentation
+  |> expand_hm_token_index symbols ~indentation |> Fmt.fmt "\n"
+  |> Fmt.fmt "\n"
+  |> expand_hm_token_protos hocc_block symbols ~indentation
 
 let expand_hm_nonterm_type symbols ~indentation formatter =
   let indent = mk_indent indentation in
   let fmt_nonterms formatter = begin
-    let formatter, _first = Symbols.nonterms_fold ~init:(formatter, true)
-      ~f:(fun (formatter, first) {name; stype; _} ->
-        formatter
-        |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
-        |> indent |> Fmt.fmt "  | " |> Fmt.fmt name
-        |> (fun formatter ->
-          match SymbolType.is_explicit stype with
-          | false -> formatter
-          | true -> formatter |> Fmt.fmt " of " |> Fmt.fmt (SymbolType.to_string stype)
-        ),
-        false
-      ) symbols
-    in
-    formatter
+    Symbols.nonterms_fold ~init:formatter ~f:(fun formatter {name; stype; _} ->
+      formatter
+      |> Fmt.fmt "\n"
+      |> indent |> Fmt.fmt "  | " |> Fmt.fmt name
+      |> (fun formatter ->
+        match SymbolType.is_explicit stype with
+        | false -> formatter
+        | true -> formatter |> Fmt.fmt " of " |> Fmt.fmt (SymbolType.to_string stype)
+      )
+    ) symbols
   end in
   formatter
-  |> indent |> Fmt.fmt "type t: t =\n"
+  |> indent |> Fmt.fmt "type t: t ="
   |> fmt_nonterms
 
 let expand_hm_nonterm_index symbols ~indentation formatter =
   let indent = mk_indent indentation in
   let fmt_nonterm_indexes formatter = begin
-    let formatter, _first = Symbols.nonterms_fold ~init:(formatter, true)
-      ~f:(fun (formatter, first) {index; name; _} ->
+    Symbols.nonterms_fold ~init:formatter ~f:(fun formatter {index; name; _} ->
+      formatter
+      |> Fmt.fmt "\n"
+      |> (fun formatter ->
         formatter
-        |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
-        |> (fun formatter ->
-          formatter
-          |> indent
-          |> Fmt.fmt "  | "
-          |> Fmt.fmt name
-          |> Fmt.fmt " _ -> "
-          |> Uns.pp index
-        ),
-        false
-      ) symbols
-    in
-    formatter
+        |> indent
+        |> Fmt.fmt "  | "
+        |> Fmt.fmt name
+        |> Fmt.fmt " _ -> "
+        |> Uns.pp index
+      )
+    ) symbols
   end in
   formatter
-  |> indent |> Fmt.fmt "index t = match t with\n"
+  |> indent |> Fmt.fmt "index t = match t with"
   |> fmt_nonterm_indexes
 
 let expand_hm_nonterms symbols ~indentation formatter =
@@ -1768,14 +1753,10 @@ let expand_hm_nonterms symbols ~indentation formatter =
 let expand_hm_callbacks hocc_block symbols callbacks ~indentation formatter =
   let fmt_callbacks ~indentation formatter = begin
     let indent = mk_indent indentation in
-    let formatter, _first = Callbacks.fold ~init:(formatter, true)
-      ~f:(fun (formatter, first) (Callback.{index; lhs_name; rhs; code; _} as callback) ->
+    Callbacks.fold ~init:formatter
+      ~f:(fun formatter (Callback.{index; lhs_name; rhs; code; _} as callback) ->
         formatter
-        |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
+        |> Fmt.fmt "\n"
         |> (fun formatter ->
           formatter
           |> indent |> Fmt.fmt "(* " |> Callback.Index.pp index
@@ -1853,15 +1834,12 @@ let expand_hm_callbacks hocc_block symbols callbacks ~indentation formatter =
               end
             | true -> formatter |> Fmt.fmt "fn _stack -> not_reached ()"
           )
-        ),
-        false
+        )
       ) callbacks
-    in
-    formatter
   end in
   let indent = mk_indent indentation in
   formatter
-  |> indent |> Fmt.fmt "callbacks = [|\n"
+  |> indent |> Fmt.fmt "callbacks = [|"
   |> fmt_callbacks ~indentation:(indentation+4L) |> Fmt.fmt "\n"
   |> indent |> Fmt.fmt "  |]"
 
@@ -1925,7 +1903,7 @@ let expand_hm_template template_indentation template hocc_block
     ("«prods»", expand_hm_prods prods);
     ("«symbols»", expand_hm_symbols symbols);
     ("«states»", expand_hm_states states);
-    ("«tokens»", expand_hm_tokens symbols);
+    ("«tokens»", expand_hm_tokens hocc_block symbols);
     ("«nonterms»", expand_hm_nonterms symbols);
     ("«callbacks»", expand_hm_callbacks hocc_block symbols callbacks);
     ("«starts»", expand_hm_starts symbols states)
@@ -2162,6 +2140,9 @@ let mli_template = {|sig
     module Token : sig
         «tokens»
 
+        val protos: t array
+          (** Token prototypes, one per variant. *)
+
         include IdentifiableIntf.S with type t := t
 
         val spec: t -> Spec.Symbol.t
@@ -2262,64 +2243,52 @@ let mli_template = {|sig
     val next: Token.t -> t -> t
       (** `next token t` calls `feed token t` and fast-forwards via `step` calls to return a result
           with status in {`Prefix`, `Accept`, `Reject`}. `t.status` must be `Prefix`. *)
+
+    val expect: t -> (Token.t, Token.cmper_witness) Ordset.t
+      (** `expect t` returns the set of token (proto)types which `next token t` would not reject,
+          assuming status were `Prefix`. `t.status` must be in {`Prefix`, `Reject`}. *)
   end|}
 
 let expand_mli_tokens symbols ~indentation formatter =
   let indent = mk_indent indentation in
   let fmt_tokens formatter = begin
-    let formatter, _first = Symbols.tokens_fold ~init:(formatter, true)
-      ~f:(fun (formatter, first) {name; alias; stype; _}->
-        formatter
-        |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
-        |> indent |> Fmt.fmt "  | " |> Fmt.fmt name
-        |> (fun formatter ->
-          match SymbolType.is_explicit stype with
-          | false -> formatter
-          | true -> formatter |> Fmt.fmt " of " |> Fmt.fmt (SymbolType.to_string stype)
-        )
-        |> (fun formatter ->
-          match alias with
-          | None -> formatter
-          | Some alias ->
-            formatter |> Fmt.fmt " (* " |> String.fmt ~pretty:true alias |> Fmt.fmt " *)"
-        ),
-        false
-      ) symbols
-    in
-    formatter
+    Symbols.tokens_fold ~init:formatter ~f:(fun formatter {name; alias; stype; _}->
+      formatter
+      |> Fmt.fmt "\n"
+      |> indent |> Fmt.fmt "  | " |> Fmt.fmt name
+      |> (fun formatter ->
+        match SymbolType.is_explicit stype with
+        | false -> formatter
+        | true -> formatter |> Fmt.fmt " of " |> Fmt.fmt (SymbolType.to_string stype)
+      )
+      |> (fun formatter ->
+        match alias with
+        | None -> formatter
+        | Some alias ->
+          formatter |> Fmt.fmt " (* " |> String.fmt ~pretty:true alias |> Fmt.fmt " *)"
+      )
+    ) symbols
   end in
   formatter
-  |> indent |> Fmt.fmt "type t =\n"
+  |> indent |> Fmt.fmt "type t ="
   |> fmt_tokens
 
 let expand_mli_nonterms symbols ~indentation formatter =
   let indent = mk_indent indentation in
   let fmt_nonterms formatter = begin
-    let formatter, _first = Symbols.nonterms_fold ~init:(formatter, true)
-      ~f:(fun (formatter, first) {name; stype; _} ->
-        formatter
-        |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
-        |> indent |> Fmt.fmt "  | " |> Fmt.fmt name
-        |> (fun formatter ->
-          match SymbolType.is_explicit stype with
-          | false -> formatter
-          | true -> formatter |> Fmt.fmt " of " |> Fmt.fmt (SymbolType.to_string stype)
-        ),
-        false
-      ) symbols
-    in
-    formatter
+    Symbols.nonterms_fold ~init:formatter ~f:(fun formatter {name; stype; _} ->
+      formatter
+      |> Fmt.fmt "\n"
+      |> indent |> Fmt.fmt "  | " |> Fmt.fmt name
+      |> (fun formatter ->
+        match SymbolType.is_explicit stype with
+        | false -> formatter
+        | true -> formatter |> Fmt.fmt " of " |> Fmt.fmt (SymbolType.to_string stype)
+      )
+    ) symbols
   end in
   formatter
-  |> indent |> Fmt.fmt "type t =\n"
+  |> indent |> Fmt.fmt "type t ="
   |> fmt_nonterms
 
 let expand_mli_starts symbols ~indentation formatter =
@@ -3247,9 +3216,27 @@ let ml_template = {|struct
           | Reject _ -> t
 
     let next token ({status; _} as t) =
+        let open Status in
         match status with
-          | Status.Prefix -> t |> feed token |> walk
-          | _ -> not_reached ()
+          | Prefix -> begin
+            match t |> feed token |> walk with
+              | {status=Reject _ as status; _} -> {t with status}
+              | t' -> t'
+          end
+          | _ -> halt "`token` only supports `Prefix` status"
+
+    let expect ({status; _} as t) =
+        let open Status in
+        let t = match status with
+          | Prefix -> t
+          | Reject _ -> {t with status=Prefix}
+          | _ -> halt "`expect` only supports `Prefix`/`Reject` status"
+          in
+        Array.fold ~init:(Ordset.empty (module Token)) ~f:(fun expect token ->
+            match next token t with
+              | {status=Reject _; _} -> expect
+              | _ -> Ordset.insert token expect
+        ) Token.protos
   end|}
 
 let expand_ml_algorithm algorithm ~indentation formatter =
@@ -3509,218 +3496,221 @@ let expand_ml_lr1Itemset lr1itemset ~indentation formatter =
 let expand_ml_states states ~indentation formatter =
   let fmt_states ~indentation formatter = begin
     let indent = mk_indent indentation in
-    let formatter, _first = Array.fold ~init:(formatter, true)
-      ~f:(fun (formatter, first)
-        State.{statenub={lr1itemsetclosure={index; kernel; _}; _}; actions; gotos; _} ->
+    Array.fold ~init:formatter ~f:(fun formatter
+      State.{statenub={lr1itemsetclosure={index; kernel; _}; _}; actions; gotos; _} ->
+      formatter
+      |> Fmt.fmt "\n"
+      |> (fun formatter ->
         formatter
+        |> indent |> Fmt.fmt "(* " |> State.Index.pp index
+        |> Fmt.fmt " *) State.init\n"
+        |> indent |> Fmt.fmt "  ~lr1ItemsetClosure:(\n"
         |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
-        |> (fun formatter ->
+          let indentation = indentation + 4L in
+          let indent = mk_indent indentation in
           formatter
-          |> indent |> Fmt.fmt "(* " |> State.Index.pp index
-          |> Fmt.fmt " *) State.init\n"
-          |> indent |> Fmt.fmt "  ~lr1ItemsetClosure:(\n"
-          |> (fun formatter ->
-            let indentation = indentation + 4L in
-            let indent = mk_indent indentation in
-            formatter
-            |> indent |> Fmt.fmt "Lr1ItemsetClosure.init\n"
-            |> indent |> Fmt.fmt "  ~index:"
-            |> ml_uns_pp index |> Fmt.fmt "\n"
-            |> indent |> Fmt.fmt "  ~kernel:(\n"
-            |> expand_ml_lr1Itemset kernel ~indentation:(indentation+4L)
-            |> indent |> Fmt.fmt "  )\n"
-          )
+          |> indent |> Fmt.fmt "Lr1ItemsetClosure.init\n"
+          |> indent |> Fmt.fmt "  ~index:"
+          |> ml_uns_pp index |> Fmt.fmt "\n"
+          |> indent |> Fmt.fmt "  ~kernel:(\n"
+          |> expand_ml_lr1Itemset kernel ~indentation:(indentation+4L)
           |> indent |> Fmt.fmt "  )\n"
-          |> indent |> Fmt.fmt "  ~actions:(\n"
+        )
+        |> indent |> Fmt.fmt "  )\n"
+        |> indent |> Fmt.fmt "  ~actions:(\n"
+        |> (fun formatter ->
+          let indentation = indentation + 4L in
+          let indent = mk_indent indentation in
+          formatter
+          |> indent |> Fmt.fmt "Map.of_alist (module Uns) [\n"
           |> (fun formatter ->
             let indentation = indentation + 4L in
             let indent = mk_indent indentation in
-            formatter
-            |> indent |> Fmt.fmt "Map.of_alist (module Uns) [\n"
-            |> (fun formatter ->
-              let indentation = indentation + 4L in
-              let indent = mk_indent indentation in
-              Ordmap.fold ~init:formatter ~f:(fun formatter (symbol_index, action_set) ->
-                assert (State.ActionSet.length action_set = 1L);
-                let action = State.ActionSet.choose_hlt action_set in
-                formatter
-                |> indent
-                |> Fmt.fmt "("
-                |> ml_uns_pp symbol_index
-                |> Fmt.fmt ", Action."
-                |> State.Action.pp action
-                |> Fmt.fmt "L);\n"
-              ) actions
-            )
-            |> indent |> Fmt.fmt "  ]\n"
+            Ordmap.fold ~init:formatter ~f:(fun formatter (symbol_index, action_set) ->
+              assert (State.ActionSet.length action_set = 1L);
+              let action = State.ActionSet.choose_hlt action_set in
+              formatter
+              |> indent
+              |> Fmt.fmt "("
+              |> ml_uns_pp symbol_index
+              |> Fmt.fmt ", Action."
+              |> State.Action.pp action
+              |> Fmt.fmt "L);\n"
+            ) actions
           )
-          |> indent |> Fmt.fmt "  )\n"
-          |> indent |> Fmt.fmt "  ~gotos:(\n"
-          |> (fun formatter ->
-            let indentation = indentation + 4L in
-            let indent = mk_indent indentation in
-            match Ordmap.is_empty gotos with
-            | false -> begin
-                formatter
-                |> indent |> Fmt.fmt "Map.of_alist (module Uns) [\n"
-                |> (fun formatter ->
-                  let indentation = indentation + 4L in
-                  let indent = mk_indent indentation in
-                  Ordmap.fold ~init:formatter ~f:(fun formatter (symbol_index, state_index) ->
-                    formatter
-                    |> indent
-                    |> Fmt.fmt "("
-                    |> ml_uns_pp symbol_index
-                    |> Fmt.fmt ", "
-                    |> ml_uns_pp state_index
-                    |> Fmt.fmt ");\n"
-                  ) gotos
-                )
-                |> indent |> Fmt.fmt "  ]"
-              end
-            | true -> formatter |> indent |> Fmt.fmt "Map.empty (module Uns)"
-          )
-          |> Fmt.fmt "\n"
-          |> indent |> Fmt.fmt "  );"
-        ),
-        false
-      ) states
-    in
-    formatter
+          |> indent |> Fmt.fmt "  ]\n"
+        )
+        |> indent |> Fmt.fmt "  )\n"
+        |> indent |> Fmt.fmt "  ~gotos:(\n"
+        |> (fun formatter ->
+          let indentation = indentation + 4L in
+          let indent = mk_indent indentation in
+          match Ordmap.is_empty gotos with
+          | false -> begin
+              formatter
+              |> indent |> Fmt.fmt "Map.of_alist (module Uns) [\n"
+              |> (fun formatter ->
+                let indentation = indentation + 4L in
+                let indent = mk_indent indentation in
+                Ordmap.fold ~init:formatter ~f:(fun formatter (symbol_index, state_index) ->
+                  formatter
+                  |> indent
+                  |> Fmt.fmt "("
+                  |> ml_uns_pp symbol_index
+                  |> Fmt.fmt ", "
+                  |> ml_uns_pp state_index
+                  |> Fmt.fmt ");\n"
+                ) gotos
+              )
+              |> indent |> Fmt.fmt "  ]"
+            end
+          | true -> formatter |> indent |> Fmt.fmt "Map.empty (module Uns)"
+        )
+        |> Fmt.fmt "\n"
+        |> indent |> Fmt.fmt "  );"
+      )
+    ) states
   end in
   let indent = mk_indent indentation in
   formatter
-  |> indent |> Fmt.fmt "let states = [|\n"
+  |> indent |> Fmt.fmt "let states = [|"
   |> fmt_states ~indentation:(indentation+4L) |> Fmt.fmt "\n"
   |> indent |> Fmt.fmt "  |]"
 
 let expand_ml_token_type symbols ~indentation formatter =
   let indent = mk_indent indentation in
   let fmt_tokens formatter = begin
-    let formatter, _first = Symbols.tokens_fold ~init:(formatter, true)
-      ~f:(fun (formatter, first) {name; alias; stype; _} ->
-        formatter
-        |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
-        |> indent |> Fmt.fmt "  | " |> Fmt.fmt name
-        |> (fun formatter ->
-          match SymbolType.is_explicit stype with
-          | false -> formatter
-          | true -> formatter |> Fmt.fmt " of " |> Fmt.fmt (SymbolType.to_string stype)
-        )
-        |> (fun formatter ->
-          match alias with
-          | None -> formatter
-          | Some alias ->
-            formatter |> Fmt.fmt " (* " |> String.fmt ~pretty:true alias |> Fmt.fmt " *)"
-        ),
-        false
-      ) symbols
-    in
-    formatter
+    Symbols.tokens_fold ~init:formatter ~f:(fun formatter {name; alias; stype; _} ->
+      formatter
+      |> Fmt.fmt "\n"
+      |> indent |> Fmt.fmt "  | " |> Fmt.fmt name
+      |> (fun formatter ->
+        match SymbolType.is_explicit stype with
+        | false -> formatter
+        | true -> formatter |> Fmt.fmt " of " |> Fmt.fmt (SymbolType.to_string stype)
+      )
+      |> (fun formatter ->
+        match alias with
+        | None -> formatter
+        | Some alias ->
+          formatter |> Fmt.fmt " (* " |> String.fmt ~pretty:true alias |> Fmt.fmt " *)"
+      )
+    ) symbols
   end in
   formatter
-  |> indent |> Fmt.fmt "type t =\n"
+  |> indent |> Fmt.fmt "type t ="
   |> fmt_tokens
 
 let expand_ml_token_index symbols ~indentation formatter =
   let indent = mk_indent indentation in
   let fmt_token_indexes formatter = begin
+    Symbols.tokens_fold ~init:formatter ~f:(fun formatter {index; name; stype; _} ->
+      formatter
+      |> Fmt.fmt "\n"
+      |> (fun formatter ->
+        formatter
+        |> indent
+        |> Fmt.fmt "  | "
+        |> Fmt.fmt name
+        |> (fun formatter ->
+          match SymbolType.is_explicit stype with
+          | false -> formatter
+          | true -> formatter |> Fmt.fmt " _"
+        )
+        |> Fmt.fmt " -> "
+        |> ml_uns_pp index
+      )
+    ) symbols
+  end in
+  formatter
+  |> indent |> Fmt.fmt "let index = function"
+  |> fmt_token_indexes
+
+let expand_ml_token_protos symbols ~indentation formatter =
+  let indent = mk_indent indentation in
+  let fmt_token_indexes formatter = begin
+    let indent = mk_indent (indentation + 4L) in
     let formatter, _first = Symbols.tokens_fold ~init:(formatter, true)
-      ~f:(fun (formatter, first) {index; name; stype; _} ->
+      ~f:(fun (formatter, first) {name; proto; _} ->
         formatter
         |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
-        |> (fun formatter ->
-          formatter
-          |> indent
-          |> Fmt.fmt "  | "
-          |> Fmt.fmt name
-          |> (fun formatter ->
-            match SymbolType.is_explicit stype with
-            | false -> formatter
-            | true -> formatter |> Fmt.fmt " _"
-          )
-          |> Fmt.fmt " -> "
-          |> ml_uns_pp index
+          match proto with
+          | None -> begin
+              formatter
+              |> (fun formatter ->
+                match first with
+                | true -> formatter
+                | false -> formatter |> Fmt.fmt ";\n"
+              )
+              |> indent |> Fmt.fmt name
+            end
+          | Some code -> begin
+              let source = Parse.source_of_code code in
+              formatter
+              |> (fun formatter ->
+                match first with
+                | true -> formatter
+                | false -> formatter |> Fmt.fmt ";"
+              )
+              |> fmt_ml_source_directive source
+              |> indent |> Fmt.fmt name
+              |> Fmt.fmt " "
+              |> Fmt.fmt (Hmc.Source.Slice.to_string source)
+            end
         ),
         false
-      ) symbols
-    in
+      ) symbols in
     formatter
   end in
   formatter
-  |> indent |> Fmt.fmt "let index = function\n"
-  |> fmt_token_indexes
+  |> indent |> Fmt.fmt "let protos = [|\n"
+  |> fmt_token_indexes |> Fmt.fmt "\n"
+  |> indent |> Fmt.fmt "  |]"
 
 let expand_ml_tokens symbols ~indentation formatter =
   formatter
   |> expand_ml_token_type symbols ~indentation |> Fmt.fmt "\n"
   |> Fmt.fmt "\n"
-  |> expand_ml_token_index symbols ~indentation
+  |> expand_ml_token_index symbols ~indentation |> Fmt.fmt "\n"
+  |> Fmt.fmt "\n"
+  |> expand_ml_token_protos symbols ~indentation
 
 let expand_ml_nonterm_type symbols ~indentation formatter =
   let indent = mk_indent indentation in
   let fmt_nonterms formatter = begin
-    let formatter, _first = Symbols.nonterms_fold ~init:(formatter, true)
-      ~f:(fun (formatter, first) {name; stype; _} ->
-        formatter
-        |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
-        |> indent |> Fmt.fmt "  | " |> Fmt.fmt name
-        |> (fun formatter ->
-          match SymbolType.is_explicit stype with
-          | false -> formatter
-          | true -> formatter |> Fmt.fmt " of " |> Fmt.fmt (SymbolType.to_string stype)
-        ),
-        false
-      ) symbols
-    in
-    formatter
+    Symbols.nonterms_fold ~init:formatter ~f:(fun formatter {name; stype; _} ->
+      formatter
+      |> Fmt.fmt "\n"
+      |> indent |> Fmt.fmt "  | " |> Fmt.fmt name
+      |> (fun formatter ->
+        match SymbolType.is_explicit stype with
+        | false -> formatter
+        | true -> formatter |> Fmt.fmt " of " |> Fmt.fmt (SymbolType.to_string stype)
+      )
+    ) symbols
   end in
   formatter
-  |> indent |> Fmt.fmt "type t =\n"
+  |> indent |> Fmt.fmt "type t ="
   |> fmt_nonterms
 
 let expand_ml_nonterm_index symbols ~indentation formatter =
   let indent = mk_indent indentation in
   let fmt_nonterm_indexes formatter = begin
-    let formatter, _first = Symbols.nonterms_fold ~init:(formatter, true)
-      ~f:(fun (formatter, first) {index; name; _} ->
+    Symbols.nonterms_fold ~init:formatter ~f:(fun formatter {index; name; _} ->
+      formatter
+      |> Fmt.fmt "\n"
+      |> (fun formatter ->
         formatter
-        |> (fun formatter ->
-          match first with
-          | true -> formatter
-          | false -> formatter |> Fmt.fmt "\n"
-        )
-        |> (fun formatter ->
-          formatter
-          |> indent
-          |> Fmt.fmt "  | "
-          |> Fmt.fmt name
-          |> Fmt.fmt " _ -> "
-          |> ml_uns_pp index
-        ),
-        false
-      ) symbols
-    in
-    formatter
+        |> indent
+        |> Fmt.fmt "  | "
+        |> Fmt.fmt name
+        |> Fmt.fmt " _ -> "
+        |> ml_uns_pp index
+      )
+    ) symbols
   end in
   formatter
-  |> indent |> Fmt.fmt "let index = function\n"
+  |> indent |> Fmt.fmt "let index = function"
   |> fmt_nonterm_indexes
 
 let expand_ml_nonterms symbols ~indentation formatter =

--- a/bootstrap/bin/hocc/spec.ml
+++ b/bootstrap/bin/hocc/spec.ml
@@ -168,18 +168,9 @@ let rec qualify_symbol_type symbol_type_qualifier symbol_type =
 
 let tokens_init io precs hmh =
   let fold_token io precs symbols_builder token = begin
-    match token with
-    | Parse.Token {cident=CIDENT {token=cident}; token_alias; symbol_type0; prec_ref; _}
-      -> begin
+    let name, prec = match token with
+      | Parse.Token {cident=CIDENT {token=cident}; prec_ref; _} -> begin
           let name = string_of_token cident in
-          let stype = match symbol_type0 with
-            | SymbolType0SymbolType {symbol_type=SymbolType {
-              symbol_type_qualifier; symbol_type; _}} -> begin
-                SymbolType.explicit (string_of_token symbol_type)
-                |> qualify_symbol_type symbol_type_qualifier
-              end
-            | SymbolType0Epsilon -> SymbolType.implicit
-          in
           let prec = match prec_ref with
             | PrecRefUident {uident} -> begin
                 let prec_name = string_of_token uident in
@@ -209,30 +200,42 @@ let tokens_init io precs hmh =
                 Io.fatal io
               end
           in
-          let alias = match token_alias with
-            | TokenAlias {alias=ISTRING {token=a}} -> begin
-                let alias_name = string_of_alias_token a in
-                let () = match Symbols.Builder.symbol_index_of_alias alias_name symbols_builder with
-                  | None -> ()
-                  | Some _ -> begin
-                      let io =
-                        io.err
-                        |> Fmt.fmt "hocc: At " |> Hmc.Source.Slice.pp (Scan.Token.source a)
-                        |> Fmt.fmt ": Redefined token alias: " |> Fmt.fmt alias_name |> Fmt.fmt "\n"
-                        |> Io.with_err io
-                      in
-                      Io.fatal io
-                    end
-                in
-                Some alias_name
-              end
-            | TokenAliasEpsilon -> None
-          in
-          let symbols_builder =
-            Symbols.Builder.insert_token ~name ~stype ~prec ~stmt:(Some token) ~alias
-              symbols_builder in
-          io, symbols_builder
+          name, prec
         end
+    in
+    let alias = match token with
+      | Token {alias=Alias {alias=ISTRING {token=a}}; _} -> begin
+          let alias_name = string_of_alias_token a in
+          let () = match Symbols.Builder.symbol_index_of_alias alias_name symbols_builder with
+            | None -> ()
+            | Some _ -> begin
+                let io =
+                  io.err
+                  |> Fmt.fmt "hocc: At " |> Hmc.Source.Slice.pp (Scan.Token.source a)
+                  |> Fmt.fmt ": Redefined token alias: " |> Fmt.fmt alias_name |> Fmt.fmt "\n"
+                  |> Io.with_err io
+                in
+                Io.fatal io
+              end
+          in
+          Some alias_name
+        end
+      | Token {alias=AliasEpsilon; _} -> None
+    in
+    let stype, proto = match token with
+      | Token {token_type=TokenType {symbol_type=SymbolType {symbol_type_qualifier; symbol_type};
+        proto}; _} -> begin
+          let stype = SymbolType.explicit (string_of_token symbol_type)
+            |> qualify_symbol_type symbol_type_qualifier in
+          let proto = Some proto in
+          stype, proto
+        end
+      | Token {token_type=TokenTypeEpsilon; _} -> SymbolType.implicit, None
+    in
+    let symbols_builder =
+      Symbols.Builder.insert_token ~name ~stype ~prec ~stmt:(Some token) ~alias ~proto
+        symbols_builder in
+    io, symbols_builder
   end in
   let fold_stmt io precs symbols_builder stmt = begin
     match stmt with
@@ -649,6 +652,7 @@ let symbols_init io precs symbols_builder hmh =
             index=index';
             name=name';
             alias=None;
+            proto=None;
             stype=SymbolType.synthetic_wrapper stype;
           } in
           let Symbol.{index=pe_index; name=pe_name; stype=pe_stype; _} = Symbol.pseudo_end in

--- a/bootstrap/bin/hocc/symbol.ml
+++ b/bootstrap/bin/hocc/symbol.ml
@@ -19,6 +19,7 @@ module T = struct
     prec: Prec.t option;
     stmt: stmt option;
     alias: string option;
+    proto: Parse.nonterm_code option;
     start: bool;
     prods: Prod.t array;
     first: Bitset.t;
@@ -31,7 +32,7 @@ module T = struct
   let cmp {index=index0; _} {index=index1; _} =
     Index.cmp index0 index1
 
-  let pp {index; name; stype; prec; stmt; alias; start; prods; first; follow} formatter =
+  let pp {index; name; stype; prec; stmt; alias; proto; start; prods; first; follow} formatter =
     formatter
     |> Fmt.fmt "{index=" |> Index.pp index
     |> Fmt.fmt "; name=" |> String.pp name
@@ -39,6 +40,7 @@ module T = struct
     |> Fmt.fmt "; prec=" |> (Option.pp Prec.pp) prec
     |> Fmt.fmt "; stmt=" |> (Option.pp pp_stmt) stmt
     |> Fmt.fmt "; alias=" |> (Option.pp String.pp) alias
+    |> Fmt.fmt "; proto=" |> (Option.pp Parse.pp_code) proto
     |> Fmt.fmt "; start=" |> Bool.pp start
     |> Fmt.fmt "; prods=" |> (Array.pp Prod.pp) prods
     |> Fmt.fmt "; first=" |> Bitset.pp first
@@ -57,7 +59,7 @@ end
 include T
 include Identifiable.Make(T)
 
-let init_token ~index ~name ~stype ~prec ~stmt ~alias =
+let init_token ~index ~name ~stype ~prec ~stmt ~alias ~proto =
   let stmt = match stmt with
     | None -> None
     | Some stmt -> Some (Token stmt)
@@ -67,11 +69,11 @@ let init_token ~index ~name ~stype ~prec ~stmt ~alias =
   (* Tokens are in their own `first` sets. *)
   let first = Bitset.singleton index in
   let follow = Bitset.empty in
-  {index; name; stype; prec; stmt; alias; start; prods; first; follow}
+  {index; name; stype; prec; stmt; alias; proto; start; prods; first; follow}
 
 let init_synthetic_token ~index ~name ~alias =
   init_token ~index ~name ~stype:SymbolType.synthetic_implicit ~prec:None ~stmt:None
-    ~alias:(Some alias)
+    ~alias:(Some alias) ~proto:None
 
 let epsilon = init_synthetic_token ~index:0L ~name:"EPSILON" ~alias:"ε"
 
@@ -84,6 +86,7 @@ let init_nonterm ~index ~name ~stype ~prec ~stmt ~start ~prods =
   in
   let prods = Ordset.to_array prods in
   let alias = None in
+  let proto = None in
   (* Insert "ε" into the `first` set if there is an epsilon production. *)
   let has_epsilon_prod = Array.fold_until ~init:false ~f:(fun _has_epsilon_prod prod ->
     let is_epsilon = Prod.is_epsilon prod in
@@ -98,7 +101,7 @@ let init_nonterm ~index ~name ~stype ~prec ~stmt ~start ~prods =
     | Some _ -> Bitset.empty
     | None -> Bitset.singleton epsilon.index
   in
-  {index; name; stype; prec; stmt; alias; start; prods; first; follow}
+  {index; name; stype; prec; stmt; alias; proto; start; prods; first; follow}
 
 let is_token {prods; _} =
   Array.is_empty prods

--- a/bootstrap/bin/hocc/symbol.mli
+++ b/bootstrap/bin/hocc/symbol.mli
@@ -29,6 +29,9 @@ type t = {
   alias: string option;
   (** Optional alias, e.g. [Some "+"] for [token PLUS "+"]. *)
 
+  proto: Parse.nonterm_code option;
+  (** Optional variant constructor prototype value, used to generate `Token.protos`. *)
+
   start: bool;
   (** True if start symbol. Always false for tokens. *)
 
@@ -50,7 +53,7 @@ val pseudo_end: t
 (** [pseudo_end] returns a pseudo-end (⊥) symbol. *)
 
 val init_token: index:Index.t -> name:string -> stype:SymbolType.t -> prec:Prec.t option
-  -> stmt:Parse.nonterm_token option -> alias:string option -> t
+  -> stmt:Parse.nonterm_token option -> alias:string option -> proto:Parse.nonterm_code option -> t
 (** Used only by [Symbols.insert_token]. *)
 
 val init_nonterm: index:Index.t -> name:string -> stype:SymbolType.t -> prec:Prec.t option

--- a/bootstrap/bin/hocc/symbolType.mli
+++ b/bootstrap/bin/hocc/symbolType.mli
@@ -8,7 +8,7 @@ type t
 include IdentifiableIntf.S with type t := t
 
 val is_synthetic: t -> bool
-(** [is_synthetic t] returns true if [t] is an synthetic symbol type, false otherwise. *)
+(** [is_synthetic t] returns true if [t] is a synthetic symbol type, false otherwise. *)
 
 val is_explicit: t -> bool
 (** [is_explicit t] returns true if [t] is an explicit symbol type, false otherwise. *)

--- a/bootstrap/bin/hocc/symbols.ml
+++ b/bootstrap/bin/hocc/symbols.ml
@@ -14,6 +14,7 @@ module Builder = struct
     index: Symbol.Index.t;
     name: string;
     alias: string option;
+    proto: Parse.nonterm_code option;
     stype: SymbolType.t;
   }
 
@@ -30,8 +31,9 @@ module Builder = struct
     let infos, names, aliases, symbols = List.fold
         ~init:(Map.empty (module String), Map.empty (module String), Map.empty (module String),
           Ordmap.empty (module Symbol.Index))
-        ~f:(fun (infos, names, aliases, symbols) (Symbol.{index; name; stype; alias; _} as token) ->
-          let info = {index; name; alias; stype} in
+        ~f:(fun (infos, names, aliases, symbols)
+          (Symbol.{index; name; stype; alias; proto; _} as token) ->
+          let info = {index; name; alias; proto; stype} in
           let infos' = Map.insert_hlt ~k:name ~v:info infos in
           let names' = Map.insert_hlt ~k:name ~v:index names in
           let aliases' = Map.insert_hlt ~k:(Option.value_hlt alias) ~v:index aliases in
@@ -52,12 +54,12 @@ module Builder = struct
     | None -> None
     | Some symbol_index -> info_of_name Symbol.((Ordmap.get_hlt symbol_index tokens).name) t
 
-  let insert_token ~name ~stype ~prec ~stmt ~alias
+  let insert_token ~name ~stype ~prec ~stmt ~alias ~proto
       ({infos; names; aliases; symbols; tokens; nonterms} as t) =
     assert (Ordmap.is_empty nonterms);
     let index = Map.length infos in
-    let info = {index; name; alias; stype} in
-    let token = Symbol.init_token ~index ~name ~stype ~prec ~stmt ~alias in
+    let info = {index; name; alias; proto; stype} in
+    let token = Symbol.init_token ~index ~name ~stype ~prec ~stmt ~alias ~proto in
     let infos' = Map.insert_hlt ~k:name ~v:info infos in
     let names' = Map.insert_hlt ~k:name ~v:index names in
     let aliases' = match alias with
@@ -70,7 +72,7 @@ module Builder = struct
 
   let insert_nonterm_info ~name ~stype ({infos; _} as t) =
     let index = Map.length infos in
-    let info = {index; name; alias=None; stype} in
+    let info = {index; name; alias=None; proto=None; stype} in
     let infos' = Map.insert_hlt ~k:name ~v:info infos in
     {t with infos=infos'}
 

--- a/bootstrap/bin/hocc/symbols.mli
+++ b/bootstrap/bin/hocc/symbols.mli
@@ -21,6 +21,9 @@ module Builder : sig
     alias: string option;
     (** Optional token alias. *)
 
+    proto: Parse.nonterm_code option;
+    (** Optional variant constructor prototype value, used to generate `Token.protos`. *)
+
     stype: SymbolType.t;
     (** Symbol type, e.g. implicit for [token SOME_TOKEN], or explicit "Zint.t" for [token INT of
         Zint.t]. *)
@@ -30,9 +33,10 @@ module Builder : sig
   (** [empty] returns an empty symbols builder. *)
 
   val insert_token: name:string -> stype:SymbolType.t -> prec:Prec.t option
-    -> stmt:Parse.nonterm_token option -> alias:string option -> t -> t
-  (** [insert_token ~name ~stype ~prec ~stmt ~alias t] creates a token [Symbol.t] with unique index
-      and returns a new [t] with the symbol inserted. Must not be called after any
+    -> stmt:Parse.nonterm_token option -> alias:string option -> proto:Parse.nonterm_code option
+    -> t -> t
+  (** [insert_token ~name ~stype ~prec ~stmt ~alias ~proto t] creates a token [Symbol.t] with unique
+      index and returns a new [t] with the symbol inserted. Must not be called after any
       [insert_nonterm_info] call. *)
 
   val insert_nonterm_info: name:string -> stype:SymbolType.t -> t -> t

--- a/bootstrap/test/hocc/Binding_error.hmh
+++ b/bootstrap/test/hocc/Binding_error.hmh
@@ -1,6 +1,6 @@
 hocc
     token T
-    token U of Unit.t
+    token U of Unit.t ()
     token EOI
     start S of Token.t ::=
       | T EOI -> T

--- a/bootstrap/test/hocc/Binding_error_b.hmh
+++ b/bootstrap/test/hocc/Binding_error_b.hmh
@@ -4,7 +4,7 @@ type t: t = {
   }
 
 hocc
-    token T of t
+    token T of t {x=0; y=0}
     token EOI
     start S of uns ::=
       | {x; y}:T EOI -> x + y

--- a/bootstrap/test/hocc/Binding_error_c.hmh
+++ b/bootstrap/test/hocc/Binding_error_c.hmh
@@ -4,7 +4,7 @@ type t: t = {
   }
 
 hocc
-    token T of t
+    token T of t {x=0; y=0}
     token EOI
     start S of uns ::=
       | {x; _}:T EOI

--- a/bootstrap/test/hocc/Example.expected.hm
+++ b/bootstrap/test/hocc/Example.expected.hm
@@ -944,6 +944,17 @@ include [:]{
               | INT _ -> 6
               | EOI -> 7
 
+            protos = [|
+                EPSILON
+                PSEUDO_END
+                STAR
+                SLASH
+                PLUS
+                MINUS
+                INT [:"./Example.hmh":19:4+20]0z[:]
+                EOI
+              |]
+
             hash_fold t state =
                 state |> Uns.hash_fold (index t)
 
@@ -1352,9 +1363,25 @@ include [:]{
           | Reject _ -> t
 
     next token ({status; _} as t) =
+        let open Status
         match status with
-          | Status.Prefix -> t |> feed token |> walk
-          | _ -> not_reached ()
+          | Status.Prefix ->
+            match t |> feed token |> walk with
+              | {status=Reject _ as status; _} -> {t with status}
+              | t' -> t'
+          | _ -> halt "`token` only supports `Prefix` status"
+
+    expect ({status; _} as t) =
+        let open Status
+        let t = match status with
+          | Prefix -> t
+          | Reject _ -> {t with status=Prefix}
+          | _ -> halt "`expect` only supports `Prefix`/`Reject` status"
+        Array.fold ~init:(Ordset.empty Token) ~f:(fn expect token ->
+            match next token t with
+              | {status=Reject _; _} -> expect
+              | _ -> Ordset.insert token expect
+        ) Token.protos
   }[:"./Example.hmh":35:0+23]
 
 # Tokenize `s`, e.g. "2 + 3 * 4", and append an `EOI` token.

--- a/bootstrap/test/hocc/Example.expected.hmi
+++ b/bootstrap/test/hocc/Example.expected.hmi
@@ -159,6 +159,9 @@ include [:]{
           | INT of Zint.t
           | EOI
 
+        protos: array t
+          [@@doc "Token prototypes, one per variant."]
+
         include IdentifiableIntf.S with type t := t
 
         spec: t -> Spec.Symbol.t
@@ -266,6 +269,10 @@ include [:]{
     next: Token.t -> t -> t
       [@@doc "`next token t` calls `feed token t` and fast-forwards via `step` calls to return a
       result with status in {`Prefix`, `Accept`, `Reject`}. `t.status` must be `Prefix`."]
+
+    expect: t -> Ordset.t Token.t Token.cmper_witness
+      [@@doc "`expect t` returns the set of token (proto)types which `next token t` would not
+      reject, assuming status were `Prefix`. `t.status` must be in {`Prefix`, `Reject`}."]
   }[:"./Example.hmhi":5:0+12]
 
 calculate: string -> zint

--- a/bootstrap/test/hocc/Example.hmh
+++ b/bootstrap/test/hocc/Example.hmh
@@ -16,7 +16,7 @@ include hocc
       | "+" -> PLUS
       | "-" -> MINUS
 
-    token INT of Zint.t
+    token INT of Zint.t 0z
     nonterm Expr of Zint.t ::=
       | e0:Expr op:MulOp e1:Expr prec mul ->
         match op with

--- a/bootstrap/test/hocc/Example_b.expected.hm
+++ b/bootstrap/test/hocc/Example_b.expected.hm
@@ -945,6 +945,19 @@ include
               | INT _ -> 6
               | EOI -> 7
 
+            protos = [|
+                EPSILON
+                PSEUDO_END
+                STAR
+                SLASH
+                PLUS
+                MINUS
+                INT [:"./Example_b.hmh":20:4+20](
+        0z
+      )[:]
+                EOI
+              |]
+
             hash_fold t state =
                 state |> Uns.hash_fold (index t)
 
@@ -1141,7 +1154,7 @@ include
                   :: {symbol=Symbol.Nonterm (Expr e0); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Expr (
                   # ________________________________________________________________________________
-                  [:"./Example_b.hmh":23:8+0]match op with
+                  [:"./Example_b.hmh":25:8+0]match op with
           | STAR -> Zint.(e0 * e1)
           | SLASH -> Zint.(e0 / e1)
           | _ -> not_reached ()[:]
@@ -1154,7 +1167,7 @@ include
                   :: {symbol=Symbol.Nonterm (Expr e0); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Expr (
                   # ________________________________________________________________________________
-                  [:"./Example_b.hmh":28:8+0]match op with
+                  [:"./Example_b.hmh":30:8+0]match op with
           | PLUS -> Zint.(e0 + e1)
           | MINUS -> Zint.(e0 - e1)
           | _ -> not_reached ()[:]
@@ -1165,7 +1178,7 @@ include
                   | {symbol=Symbol.Token (INT x); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Expr (
                   # ________________________________________________________________________________
-                  [:"./Example_b.hmh":32:4+13]x[:]
+                  [:"./Example_b.hmh":34:4+13]x[:]
                   # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
                   )), tl__hocc__
                   | _ -> not_reached ()
@@ -1174,7 +1187,7 @@ include
                   :: {symbol=Symbol.Nonterm (Expr e); _}
                   :: tl__hocc__ -> Symbol.Nonterm (Answer (
                   # ________________________________________________________________________________
-                  [:"./Example_b.hmh":36:4+18]e[:]
+                  [:"./Example_b.hmh":38:4+18]e[:]
                   # ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
                   )), tl__hocc__
                   | _ -> not_reached ()
@@ -1353,10 +1366,26 @@ include
           | Reject _ -> t
 
     next token ({status; _} as t) =
+        let open Status
         match status with
-          | Status.Prefix -> t |> feed token |> walk
-          | _ -> not_reached ()
-  }[:"./Example_b.hmh":36:0+23]
+          | Status.Prefix ->
+            match t |> feed token |> walk with
+              | {status=Reject _ as status; _} -> {t with status}
+              | t' -> t'
+          | _ -> halt "`token` only supports `Prefix` status"
+
+    expect ({status; _} as t) =
+        let open Status
+        let t = match status with
+          | Prefix -> t
+          | Reject _ -> {t with status=Prefix}
+          | _ -> halt "`expect` only supports `Prefix`/`Reject` status"
+        Array.fold ~init:(Ordset.empty Token) ~f:(fn expect token ->
+            match next token t with
+              | {status=Reject _; _} -> expect
+              | _ -> Ordset.insert token expect
+        ) Token.protos
+  }[:"./Example_b.hmh":38:0+23]
 
 # Tokenize `s`, e.g. "2 + 3 * 4", and append an `EOI` token.
 tokenize s =

--- a/bootstrap/test/hocc/Example_b.expected.hmi
+++ b/bootstrap/test/hocc/Example_b.expected.hmi
@@ -159,6 +159,9 @@ include
           | INT of Zint.t
           | EOI
 
+        protos: array t
+          [@@doc "Token prototypes, one per variant."]
+
         include IdentifiableIntf.S with type t := t
 
         spec: t -> Spec.Symbol.t
@@ -266,6 +269,10 @@ include
     next: Token.t -> t -> t
       [@@doc "`next token t` calls `feed token t` and fast-forwards via `step` calls to return a
       result with status in {`Prefix`, `Accept`, `Reject`}. `t.status` must be `Prefix`."]
+
+    expect: t -> Ordset.t Token.t Token.cmper_witness
+      [@@doc "`expect t` returns the set of token (proto)types which `next token t` would not
+      reject, assuming status were `Prefix`. `t.status` must be in {`Prefix`, `Reject`}."]
   }[:"./Example_b.hmhi":5:0+6]
 
 calculate: string -> zint

--- a/bootstrap/test/hocc/Example_b.hmh
+++ b/bootstrap/test/hocc/Example_b.hmh
@@ -17,7 +17,9 @@ include
       | "+" -> PLUS
       | "-" -> MINUS
 
-    token INT of Zint.t
+    token INT of Zint.t (
+        0z
+      )
     nonterm Expr of Zint.t ::=
       | e0:Expr op:MulOp e1:Expr prec mul ->
         match op with

--- a/bootstrap/test/hocc/Example_c.expected.hm
+++ b/bootstrap/test/hocc/Example_c.expected.hm
@@ -945,6 +945,17 @@ Parser = {
                   | INT _ -> 6
                   | EOI -> 7
 
+                protos = [|
+                    EPSILON
+                    PSEUDO_END
+                    STAR
+                    SLASH
+                    PLUS
+                    MINUS
+                    INT [:"./Example_c.hmh":20:8+20]0z[:]
+                    EOI
+                  |]
+
                 hash_fold t state =
                     state |> Uns.hash_fold (index t)
 
@@ -1353,9 +1364,25 @@ Parser = {
               | Reject _ -> t
 
         next token ({status; _} as t) =
+            let open Status
             match status with
-              | Status.Prefix -> t |> feed token |> walk
-              | _ -> not_reached ()
+              | Status.Prefix ->
+                match t |> feed token |> walk with
+                  | {status=Reject _ as status; _} -> {t with status}
+                  | t' -> t'
+              | _ -> halt "`token` only supports `Prefix` status"
+
+        expect ({status; _} as t) =
+            let open Status
+            let t = match status with
+              | Prefix -> t
+              | Reject _ -> {t with status=Prefix}
+              | _ -> halt "`expect` only supports `Prefix`/`Reject` status"
+            Array.fold ~init:(Ordset.empty Token) ~f:(fn expect token ->
+                match next token t with
+                  | {status=Reject _; _} -> expect
+                  | _ -> Ordset.insert token expect
+            ) Token.protos
       }[:"./Example_c.hmh":36:4+23]
   }
 

--- a/bootstrap/test/hocc/Example_c.expected.hmi
+++ b/bootstrap/test/hocc/Example_c.expected.hmi
@@ -159,6 +159,9 @@ Parser = {
               | INT of Zint.t
               | EOI
 
+            protos: array t
+              [@@doc "Token prototypes, one per variant."]
+
             include IdentifiableIntf.S with type t := t
 
             spec: t -> Spec.Symbol.t
@@ -266,6 +269,10 @@ Parser = {
         next: Token.t -> t -> t
           [@@doc "`next token t` calls `feed token t` and fast-forwards via `step` calls to return a
           result with status in {`Prefix`, `Accept`, `Reject`}. `t.status` must be `Prefix`."]
+
+        expect: t -> Ordset.t Token.t Token.cmper_witness
+          [@@doc "`expect t` returns the set of token (proto)types which `next token t` would not
+          reject, assuming status were `Prefix`. `t.status` must be in {`Prefix`, `Reject`}."]
       }[:"./Example_c.hmhi":5:4+12]
   }
 

--- a/bootstrap/test/hocc/Example_c.hmh
+++ b/bootstrap/test/hocc/Example_c.hmh
@@ -17,7 +17,7 @@ Parser = {
           | "+" -> PLUS
           | "-" -> MINUS
 
-        token INT of Zint.t
+        token INT of Zint.t 0z
         nonterm Expr of Zint.t ::=
           | e0:Expr op:MulOp e1:Expr prec mul ->
             match op with

--- a/bootstrap/test/hocc/Example_introspect.expected.ml
+++ b/bootstrap/test/hocc/Example_introspect.expected.ml
@@ -1048,6 +1048,18 @@ include struct
               | INT _ -> 6L
               | EOI -> 7L
 
+            let protos = [|
+                EPSILON;
+                PSEUDO_END;
+                STAR;
+                SLASH;
+                PLUS;
+                MINUS;
+#19 "./Example_introspect.hmh"
+                INT Zint.zero;
+                EOI
+              |]
+
             let hash_fold t state =
                 state |> Uns.hash_fold (index t)
 
@@ -1494,9 +1506,27 @@ e
           | Reject _ -> t
 
     let next token ({status; _} as t) =
+        let open Status in
         match status with
-          | Status.Prefix -> t |> feed token |> walk
-          | _ -> not_reached ()
+          | Prefix -> begin
+            match t |> feed token |> walk with
+              | {status=Reject _ as status; _} -> {t with status}
+              | t' -> t'
+          end
+          | _ -> halt "`token` only supports `Prefix` status"
+
+    let expect ({status; _} as t) =
+        let open Status in
+        let t = match status with
+          | Prefix -> t
+          | Reject _ -> {t with status=Prefix}
+          | _ -> halt "`expect` only supports `Prefix`/`Reject` status"
+          in
+        Array.fold ~init:(Ordset.empty (module Token)) ~f:(fun expect token ->
+            match next token t with
+              | {status=Reject _; _} -> expect
+              | _ -> Ordset.insert token expect
+        ) Token.protos
   end
 #36 "./Example_introspect.hmh"
 

--- a/bootstrap/test/hocc/Example_introspect.expected.mli
+++ b/bootstrap/test/hocc/Example_introspect.expected.mli
@@ -158,6 +158,9 @@ include sig
           | INT of Zint.t
           | EOI
 
+        val protos: t array
+          (** Token prototypes, one per variant. *)
+
         include IdentifiableIntf.S with type t := t
 
         val spec: t -> Spec.Symbol.t
@@ -265,4 +268,8 @@ include sig
     val next: Token.t -> t -> t
       (** `next token t` calls `feed token t` and fast-forwards via `step` calls to return a result
           with status in {`Prefix`, `Accept`, `Reject`}. `t.status` must be `Prefix`. *)
+
+    val expect: t -> (Token.t, Token.cmper_witness) Ordset.t
+      (** `expect t` returns the set of token (proto)types which `next token t` would not reject,
+          assuming status were `Prefix`. `t.status` must be in {`Prefix`, `Reject`}. *)
   end

--- a/bootstrap/test/hocc/Example_introspect.hmh
+++ b/bootstrap/test/hocc/Example_introspect.hmh
@@ -16,7 +16,7 @@ include hocc
       | "+" -> PLUS
       | "-" -> MINUS
 
-    token INT of Zint.t
+    token INT of Zint.t Zint.zero
     nonterm Expr of Zint.t ::=
       | e0:Expr op:MulOp e1:Expr prec mul ->
         match op with

--- a/bootstrap/test/hocc/Example_ml.expected.ml
+++ b/bootstrap/test/hocc/Example_ml.expected.ml
@@ -1049,6 +1049,18 @@ include struct
               | INT _ -> 6L
               | EOI -> 7L
 
+            let protos = [|
+                EPSILON;
+                PSEUDO_END;
+                STAR;
+                SLASH;
+                PLUS;
+                MINUS;
+#20 "./Example_ml.hmh"
+                INT Zint.zero;
+                EOI
+              |]
+
             let hash_fold t state =
                 state |> Uns.hash_fold (index t)
 
@@ -1495,9 +1507,27 @@ e
           | Reject _ -> t
 
     let next token ({status; _} as t) =
+        let open Status in
         match status with
-          | Status.Prefix -> t |> feed token |> walk
-          | _ -> not_reached ()
+          | Prefix -> begin
+            match t |> feed token |> walk with
+              | {status=Reject _ as status; _} -> {t with status}
+              | t' -> t'
+          end
+          | _ -> halt "`token` only supports `Prefix` status"
+
+    let expect ({status; _} as t) =
+        let open Status in
+        let t = match status with
+          | Prefix -> t
+          | Reject _ -> {t with status=Prefix}
+          | _ -> halt "`expect` only supports `Prefix`/`Reject` status"
+          in
+        Array.fold ~init:(Ordset.empty (module Token)) ~f:(fun expect token ->
+            match next token t with
+              | {status=Reject _; _} -> expect
+              | _ -> Ordset.insert token expect
+        ) Token.protos
   end
 #37 "./Example_ml.hmh"
 

--- a/bootstrap/test/hocc/Example_ml.expected.mli
+++ b/bootstrap/test/hocc/Example_ml.expected.mli
@@ -160,6 +160,9 @@ include sig
           | INT of Zint.t
           | EOI
 
+        val protos: t array
+          (** Token prototypes, one per variant. *)
+
         include IdentifiableIntf.S with type t := t
 
         val spec: t -> Spec.Symbol.t
@@ -267,6 +270,10 @@ include sig
     val next: Token.t -> t -> t
       (** `next token t` calls `feed token t` and fast-forwards via `step` calls to return a result
           with status in {`Prefix`, `Accept`, `Reject`}. `t.status` must be `Prefix`. *)
+
+    val expect: t -> (Token.t, Token.cmper_witness) Ordset.t
+      (** `expect t` returns the set of token (proto)types which `next token t` would not reject,
+          assuming status were `Prefix`. `t.status` must be in {`Prefix`, `Reject`}. *)
   end
 #7 "./Example_ml.hmhi"
 

--- a/bootstrap/test/hocc/Example_ml.hmh
+++ b/bootstrap/test/hocc/Example_ml.hmh
@@ -17,7 +17,7 @@ include hocc
       | "+" -> PLUS
       | "-" -> MINUS
 
-    token INT of Zint.t
+    token INT of Zint.t Zint.zero
     nonterm Expr of Zint.t ::=
       | e0:Expr op:MulOp e1:Expr prec mul ->
         match op with

--- a/bootstrap/test/hocc/Parse_error_cident.expected
+++ b/bootstrap/test/hocc/Parse_error_cident.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_cident.hmh"
-hocc: At ["./Parse_error_cident.hmh":2:10.."./Parse_error_cident.hmh":2:16): Unexpected token
+hocc: At ["./Parse_error_cident.hmh":2:10.."./Parse_error_cident.hmh":2:16): Unexpected token not in {⸱CIDENT⸱}

--- a/bootstrap/test/hocc/Parse_error_code.expected
+++ b/bootstrap/test/hocc/Parse_error_code.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_code.hmh"
-hocc: At ["./Parse_error_code.hmh":3:0.."./Parse_error_code.hmh":3:0): Unexpected token
+hocc: At ["./Parse_error_code.hmh":3:0.."./Parse_error_code.hmh":3:0): Unexpected token not in {⸱hocc⸱nonterm⸱epsilon⸱start⸱token⸱neutral⸱left⸱right⸱nonassoc⸱prec⸱UIDENT⸱CIDENT⸱_⸱ISTRING⸱::=⸱of⸱:⸱.⸱->⸱<⸱=⸱,⸱as⸱INDENT⸱(⸱(|⸱[⸱[|⸱{⸱OTHER_TOKEN⸱}

--- a/bootstrap/test/hocc/Parse_error_delimited_rarray.expected
+++ b/bootstrap/test/hocc/Parse_error_delimited_rarray.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_delimited_rarray.hmh"
-hocc: At ["./Parse_error_delimited_rarray.hmh":4:0.."./Parse_error_delimited_rarray.hmh":4:0): Unexpected token
+hocc: At ["./Parse_error_delimited_rarray.hmh":4:0.."./Parse_error_delimited_rarray.hmh":4:0): Unexpected token not in {⸱hocc⸱nonterm⸱epsilon⸱start⸱token⸱neutral⸱left⸱right⸱nonassoc⸱prec⸱UIDENT⸱CIDENT⸱_⸱ISTRING⸱::=⸱of⸱:⸱.⸱->⸱<⸱=⸱,⸱as⸱INDENT⸱(⸱(|⸱[⸱[|⸱|]⸱{⸱OTHER_TOKEN⸱}

--- a/bootstrap/test/hocc/Parse_error_delimited_rbrack.expected
+++ b/bootstrap/test/hocc/Parse_error_delimited_rbrack.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_delimited_rbrack.hmh"
-hocc: At ["./Parse_error_delimited_rbrack.hmh":4:0.."./Parse_error_delimited_rbrack.hmh":4:0): Unexpected token
+hocc: At ["./Parse_error_delimited_rbrack.hmh":4:0.."./Parse_error_delimited_rbrack.hmh":4:0): Unexpected token not in {⸱hocc⸱nonterm⸱epsilon⸱start⸱token⸱neutral⸱left⸱right⸱nonassoc⸱prec⸱UIDENT⸱CIDENT⸱_⸱ISTRING⸱::=⸱of⸱:⸱.⸱->⸱<⸱=⸱,⸱as⸱INDENT⸱(⸱(|⸱[⸱]⸱[|⸱{⸱OTHER_TOKEN⸱}

--- a/bootstrap/test/hocc/Parse_error_delimited_rcapture.expected
+++ b/bootstrap/test/hocc/Parse_error_delimited_rcapture.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_delimited_rcapture.hmh"
-hocc: At ["./Parse_error_delimited_rcapture.hmh":4:0.."./Parse_error_delimited_rcapture.hmh":4:0): Unexpected token
+hocc: At ["./Parse_error_delimited_rcapture.hmh":4:0.."./Parse_error_delimited_rcapture.hmh":4:0): Unexpected token not in {⸱hocc⸱nonterm⸱epsilon⸱start⸱token⸱neutral⸱left⸱right⸱nonassoc⸱prec⸱UIDENT⸱CIDENT⸱_⸱ISTRING⸱::=⸱of⸱:⸱.⸱->⸱<⸱=⸱,⸱as⸱INDENT⸱(⸱(|⸱|)⸱[⸱[|⸱{⸱OTHER_TOKEN⸱}

--- a/bootstrap/test/hocc/Parse_error_delimited_rcurly.expected
+++ b/bootstrap/test/hocc/Parse_error_delimited_rcurly.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_delimited_rcurly.hmh"
-hocc: At ["./Parse_error_delimited_rcurly.hmh":4:0.."./Parse_error_delimited_rcurly.hmh":4:0): Unexpected token
+hocc: At ["./Parse_error_delimited_rcurly.hmh":4:0.."./Parse_error_delimited_rcurly.hmh":4:0): Unexpected token not in {⸱hocc⸱nonterm⸱epsilon⸱start⸱token⸱neutral⸱left⸱right⸱nonassoc⸱prec⸱UIDENT⸱CIDENT⸱_⸱ISTRING⸱::=⸱of⸱:⸱.⸱->⸱<⸱=⸱,⸱as⸱INDENT⸱(⸱(|⸱[⸱[|⸱{⸱}⸱OTHER_TOKEN⸱}

--- a/bootstrap/test/hocc/Parse_error_delimited_rparen.expected
+++ b/bootstrap/test/hocc/Parse_error_delimited_rparen.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_delimited_rparen.hmh"
-hocc: At ["./Parse_error_delimited_rparen.hmh":4:0.."./Parse_error_delimited_rparen.hmh":4:0): Unexpected token
+hocc: At ["./Parse_error_delimited_rparen.hmh":4:0.."./Parse_error_delimited_rparen.hmh":4:0): Unexpected token not in {⸱hocc⸱nonterm⸱epsilon⸱start⸱token⸱neutral⸱left⸱right⸱nonassoc⸱prec⸱UIDENT⸱CIDENT⸱_⸱ISTRING⸱::=⸱of⸱:⸱.⸱->⸱<⸱=⸱,⸱as⸱INDENT⸱(⸱)⸱(|⸱[⸱[|⸱{⸱OTHER_TOKEN⸱}

--- a/bootstrap/test/hocc/Parse_error_hmhi.expected
+++ b/bootstrap/test/hocc/Parse_error_hmhi.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_hmhi.hmhi"
-hocc: At ["./Parse_error_hmhi.hmhi":2:0.."./Parse_error_hmhi.hmhi":2:0): Unexpected token
+hocc: At ["./Parse_error_hmhi.hmhi":2:0.."./Parse_error_hmhi.hmhi":2:0): Unexpected token not in {⸱hocc⸱nonterm⸱epsilon⸱start⸱token⸱neutral⸱left⸱right⸱nonassoc⸱prec⸱UIDENT⸱CIDENT⸱_⸱ISTRING⸱::=⸱of⸱:⸱.⸱->⸱|⸱<⸱=⸱,⸱;⸱as⸱LINE_DELIM⸱INDENT⸱DEDENT⸱(⸱)⸱(|⸱|)⸱[⸱]⸱[|⸱|]⸱{⸱}⸱OTHER_TOKEN⸱}

--- a/bootstrap/test/hocc/Parse_error_hocc.expected
+++ b/bootstrap/test/hocc/Parse_error_hocc.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_hocc.hmh"
-hocc: At ["./Parse_error_hocc.hmh":2:0.."./Parse_error_hocc.hmh":2:0): Unexpected token
+hocc: At ["./Parse_error_hocc.hmh":2:0.."./Parse_error_hocc.hmh":2:0): Unexpected token not in {⸱hocc⸱nonterm⸱epsilon⸱start⸱token⸱neutral⸱left⸱right⸱nonassoc⸱prec⸱UIDENT⸱CIDENT⸱_⸱ISTRING⸱::=⸱of⸱:⸱.⸱->⸱|⸱<⸱=⸱,⸱;⸱as⸱LINE_DELIM⸱INDENT⸱DEDENT⸱(⸱)⸱(|⸱|)⸱[⸱]⸱[|⸱|]⸱{⸱}⸱OTHER_TOKEN⸱}

--- a/bootstrap/test/hocc/Parse_error_malformed.expected
+++ b/bootstrap/test/hocc/Parse_error_malformed.expected
@@ -1,3 +1,3 @@
 hocc: Parsing "./Parse_error_malformed.hmh"
-hocc: At ["./Parse_error_malformed.hmh":2:16.."./Parse_error_malformed.hmh":2:28): Unexpected token
+hocc: At ["./Parse_error_malformed.hmh":2:16.."./Parse_error_malformed.hmh":2:28): Unexpected token not in {⸱prec⸱ISTRING⸱of⸱LINE_DELIM⸱DEDENT⸱}
 hocc: At ["./Parse_error_malformed.hmh":2:19.."./Parse_error_malformed.hmh":2:24): Invalid codepoint

--- a/bootstrap/test/hocc/Parse_error_nonterm_cce.expected
+++ b/bootstrap/test/hocc/Parse_error_nonterm_cce.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_nonterm_cce.hmh"
-hocc: At ["./Parse_error_nonterm_cce.hmh":3:0.."./Parse_error_nonterm_cce.hmh":3:0): Unexpected token
+hocc: At ["./Parse_error_nonterm_cce.hmh":3:0.."./Parse_error_nonterm_cce.hmh":3:0): Unexpected token not in {⸱prec⸱::=⸱}

--- a/bootstrap/test/hocc/Parse_error_of_type_dot.expected
+++ b/bootstrap/test/hocc/Parse_error_of_type_dot.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_of_type_dot.hmh"
-hocc: At ["./Parse_error_of_type_dot.hmh":3:0.."./Parse_error_of_type_dot.hmh":3:0): Unexpected token
+hocc: At ["./Parse_error_of_type_dot.hmh":2:17.."./Parse_error_of_type_dot.hmh":2:18): Unexpected token not in {⸱.⸱}

--- a/bootstrap/test/hocc/Parse_error_of_type_dot.hmh
+++ b/bootstrap/test/hocc/Parse_error_of_type_dot.hmh
@@ -1,2 +1,2 @@
 hocc
-    token A of T
+    token A of T t

--- a/bootstrap/test/hocc/Parse_error_precs.expected
+++ b/bootstrap/test/hocc/Parse_error_precs.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_precs.hmh"
-hocc: At ["./Parse_error_precs.hmh":3:0.."./Parse_error_precs.hmh":3:0): Unexpected token
+hocc: At ["./Parse_error_precs.hmh":3:0.."./Parse_error_precs.hmh":3:0): Unexpected token not in {⸱hocc⸱nonterm⸱epsilon⸱start⸱token⸱neutral⸱left⸱right⸱nonassoc⸱prec⸱UIDENT⸱}

--- a/bootstrap/test/hocc/Parse_error_precs_lt.expected
+++ b/bootstrap/test/hocc/Parse_error_precs_lt.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_precs_lt.hmh"
-hocc: At ["./Parse_error_precs_lt.hmh":3:0.."./Parse_error_precs_lt.hmh":3:0): Unexpected token
+hocc: At ["./Parse_error_precs_lt.hmh":3:0.."./Parse_error_precs_lt.hmh":3:0): Unexpected token not in {⸱hocc⸱nonterm⸱epsilon⸱start⸱token⸱neutral⸱left⸱right⸱nonassoc⸱prec⸱UIDENT⸱}

--- a/bootstrap/test/hocc/Parse_error_prod_param_type.expected
+++ b/bootstrap/test/hocc/Parse_error_prod_param_type.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_prod_param_type.hmh"
-hocc: At ["./Parse_error_prod_param_type.hmh":3:10.."./Parse_error_prod_param_type.hmh":3:12): Unexpected token
+hocc: At ["./Parse_error_prod_param_type.hmh":3:10.."./Parse_error_prod_param_type.hmh":3:12): Unexpected token not in {⸱CIDENT⸱ISTRING⸱}

--- a/bootstrap/test/hocc/Parse_error_reduction_arrow.expected
+++ b/bootstrap/test/hocc/Parse_error_reduction_arrow.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_reduction_arrow.hmh"
-hocc: At ["./Parse_error_reduction_arrow.hmh":4:0.."./Parse_error_reduction_arrow.hmh":4:0): Unexpected token
+hocc: At ["./Parse_error_reduction_arrow.hmh":4:0.."./Parse_error_reduction_arrow.hmh":4:0): Unexpected token not in {⸱prec⸱:⸱->⸱|⸱}

--- a/bootstrap/test/hocc/Parse_error_uident.expected
+++ b/bootstrap/test/hocc/Parse_error_uident.expected
@@ -1,2 +1,2 @@
 hocc: Parsing "./Parse_error_uident.hmh"
-hocc: At ["./Parse_error_uident.hmh":2:12.."./Parse_error_uident.hmh":2:18): Unexpected token
+hocc: At ["./Parse_error_uident.hmh":2:12.."./Parse_error_uident.hmh":2:18): Unexpected token not in {⸱hocc⸱nonterm⸱epsilon⸱start⸱token⸱neutral⸱left⸱right⸱nonassoc⸱prec⸱UIDENT⸱}

--- a/bootstrap/test/hocc/TokenCoverage.hmh
+++ b/bootstrap/test/hocc/TokenCoverage.hmh
@@ -16,10 +16,10 @@ include hocc
     neutral add < mul
     token OP
     token PLUS "+"
-    token UNS of Uns.t
+    token UNS of Uns.t 0
     token MINUS prec add
     token STAR "*" prec mul
-    token SLASH "/" of Unit.t prec mul
+    token SLASH "/" of String.t "/" prec mul
 
     nonterm N1 of Unit.t ::= epsilon ->
         (a b)

--- a/doc/tools/hocc.md
+++ b/doc/tools/hocc.md
@@ -127,13 +127,18 @@ hocc
     token LPAREN "("
 ```
 
-Tokens with variant contents must have an optionally qualified declared data type.
+Tokens with variant contents must have an optionally qualified declared data type and a prototype
+constructor parameter value. Hocc constructs one token of each variant and makes the tokens
+available via `Token.protos`, which facilitates automaton exploration such as that of the `expect`
+function. Note that any use of `prec` as a token in the prototype constructor code must be delimited
+in order to avoid being interpreted as introducing the token precedence.
 
 ```hocc
 hocc
-    token T of t
-    token U of M.t
-    token V of M.N.t
+    token U of uns 0
+    token V of Zint.t Zint.zero
+    token W of String.C.Slice.t (String.Slice.of_string "")
+    token X of X.t (prec)
 ```
 
 Tokens may be assigned [precedence](#precedence) to aid in conflict resolution.
@@ -141,7 +146,8 @@ Tokens may be assigned [precedence](#precedence) to aid in conflict resolution.
 ```hocc
 hocc
     left p
-    token X prec p
+    token Y prec p
+    token Z of t (prec arg_to_prec_fn) prec p
 ```
 
 ### Non-terminals
@@ -756,6 +762,9 @@ parser states can be used as persistent reusable snapshots.
 
         include IdentifiableIntf.S with type t := t
 
+        protos: array t
+          [@@doc "Token prototypes, one per variant. "]
+
         spec: t -> Spec.Symbol.t
       }
 
@@ -859,9 +868,15 @@ parser states can be used as persistent reusable snapshots.
       [@@doc "`step t` returns the result of applying one state transition to `t`. `t.status` must
       be in {`ShiftPrefix`, `ShiftAccept`, `Reduce`}."]
 
-    next: -> Token.t -> t -> t
+    next: Token.t -> t -> t
       [@@doc "`next token t` calls `feed token t` and fast-forwards via `step` calls to return a
-      result with status in {`Prefix`, `Accept`, `Reject`}. `t.status` must be `Prefix`."]
+      result with status in {`Prefix`, `Accept`, `Reject`}. `t.status` must be `Prefix`. If the
+      resulting status is `Reject`, the stack remains in its initial state even if one or more
+      reduction steps lead to the syntax error."]
+
+    expect: t -> Ordset.t Token.t Token.cmper_witness
+      [@@doc "`expect t` returns the set of token (proto)types which `next token t` would not
+      reject, assuming status were `Prefix`. `t.status` must be in {`Prefix`, `Reject`}."]
   }
 ```
 
@@ -996,6 +1011,8 @@ The `hocc` specification language grammar is equivalent to the following specifi
 
 ```hocc
 hocc
+    neutral pCodeTlEpsilon
+    neutral pPrec < pCodeTlEpsilon
     neutral pCIDENT
     left pDOT
     left pCOMMA < pCIDENT
@@ -1010,7 +1027,7 @@ hocc
     token LEFT "left"
     token RIGHT "right"
     token NONASSOC "nonassoc"
-    token PREC "prec"
+    token PREC "prec" prec pPrec
     token UIDENT
     token CIDENT
     token USCORE "_"
@@ -1070,16 +1087,16 @@ hocc
       | CIDENT "." SymbolTypeQualifier
       | epsilon
     nonterm SymbolType ::= "of" SymbolTypeQualifier Uident
-    nonterm SymbolType0 ::=
-      | SymbolType
-      | epsilon
     nonterm PrecRef ::=
       | "prec" Uident
       | epsilon
-    nonterm TokenAlias ::=
+    nonterm Alias ::=
       | ISTRING
       | epsilon
-    nonterm Token ::= "token" CIDENT TokenAlias SymbolType0 PrecRef
+    nonterm TokenType ::=
+      | SymbolType Code
+      | epsilon
+    nonterm Token ::= "token" CIDENT Alias TokenType PrecRef
     nonterm Sep ::=
       | LINE_DELIM
       | ";"
@@ -1116,7 +1133,7 @@ hocc
     nonterm CodeTl ::=
       | Delimited CodeTl
       | CodeToken CodeTl
-      | epsilon
+      | epsilon prec pCodeTlEpsilon
     nonterm Code ::=
       | Delimited CodeTl
       | CodeToken CodeTl


### PR DESCRIPTION
It is possible for automata to encode sequences of state transitions via reduce actions that lead to input rejection (syntax error), the causes being state remerging and/or `nonassoc`. Enhance the `next` function to restore the stack to its initial state upon transitively encountering a `Reject` status.

Enhance the Hocc grammar to require prototype token payloads for token variants that have constructor parameters, and use the payloads to generate `Token.protos`, which contains one prototype token for each token type.

Implement the `expect` function, which given a parser with `Prefix` or `Reject` status returns the set of prototype tokens that `next` would not reject given the parser's stack configuration, i.e. the set of valid next tokens. The above-described stack restoration enhancement to `next` enables this to work in the `Reject` case.

Enhance Hocc scanner to report expected tokens on unexpected token.